### PR TITLE
Clearing the buffer is not optimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,6 @@ The `[[error]]` internal method:
 1. Sets `[[error]]` to `e`.
 1. Rejects `[[finishedPromise]]` with `e`.
 1. Rejects `[[readablePromise]]` with `e`.
-1. Clears `[[buffer]]`.
 
 #### `[[abort]]` and `[[pull]]`
 


### PR DESCRIPTION
If an error occurs in a stream, I may want to figure out what data was read from the source up until the point the error occurred in case the error is some kind of `MalformedInputError`

However we should probably clear the buffer at some point to avoid leaks.

Maybe set the `buffer` on the error object ?

Currently people cannot recover the information that was in the unread buffer when an error occurs. This may be acceptable.
