### PR TITLE
`open` should complete before `read` is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,10 @@ function pullSourceToReadableStream(source) {
                 if (err) {
                     error(err);
                 }
+                
+                // let BaseReadableStream know we are open
+                // and can start pulling
+                push()
             });
         },
 


### PR DESCRIPTION
Most pull sources that have an `open` logic which fails if you read from them before open is finished.

This means the `start` and `pull` functions need to co-ordinate the `[[pulling]]` state somehow. And `start` needs to set `[[pulling]]` to false somehow.

An empty call to `push()` might be used to set `[[pulling]]` to false.
