### PR TITLE
Remove unnecessary step from BWS.[[doClose]]

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,7 +904,7 @@ In reaction to calls to the stream's `.write()` method, the `write` constructor 
 
 1. Reject `this.[[writablePromise]]` with a `TypeError` exception.
 1. Call `this.[[onClose]]()`.
-1. If the call throws an exception `e`, call `this.[[error]](e)` and return a promise rejected with `e`.
+1. If the call throws an exception `e`, call `this.[[error]](e)`.
 1. Otherwise, let `closeResult` be the result of casting the return value to a promise.
 1. When/if `closeResult` is fulfilled,
     1. Set `this.[[state]]` to `"closed"`.


### PR DESCRIPTION
When [[onClose]]() throws, we just call [[error]] and it rejects [[closedPromise]].
