### PR TITLE
Use more distinguishable name for BWS.[[doAbort]] arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,10 +911,10 @@ In reaction to calls to the stream's `.write()` method, the `write` constructor 
     1. Resolve `this.[[closedPromise]]` with `undefined`.
 1. When/if `closeResult` is rejected with reason `r`, call `this.[[error]](r)`.
 
-###### `[[doAbort]](r)`
+###### `[[doAbort]](abortReason)`
 
-1. Reject `this.[[writablePromise]]` with `r`.
-1. Call `this.[[onAbort]](r)`.
+1. Reject `this.[[writablePromise]]` with `abortReason`.
+1. Call `this.[[onAbort]](abortReason)`.
 1. If the call throws an exception `e`, call `this.[[error]](e)` and return a promise rejected with `e`.
 1. Otherwise, let `abortResult` be the result of casting the return value to a promise.
 1. When/if `abortResult` is fulfilled,

--- a/reference-implementation/lib/base-writable.js
+++ b/reference-implementation/lib/base-writable.js
@@ -127,14 +127,14 @@ BaseWritableStream.prototype._doClose = function _doClose() {
   );
 };
 
-BaseWritableStream.prototype._doAbort = function _doAbort(r) {
+BaseWritableStream.prototype._doAbort = function _doAbort(abortReason) {
   var stream = this;
 
-  this[WRITABLE_REJECT](r);
+  this[WRITABLE_REJECT](abortReason);
 
   var abortResult;
   try {
-    abortResult = Promise.cast(this._onAbort(r));
+    abortResult = Promise.cast(this._onAbort(abortReason));
   }
   catch (error) {
     this._error(error);


### PR DESCRIPTION
"r" is bound to the reason with which abortResult is rejected later in the step 6. Let's use some other name for the argument of [[doAbort]] function not to confuse readers.
