### PR TITLE
BWS.write: Create promise only when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,13 +398,14 @@ In reaction to calls to the stream's `.write()` method, the `write` constructor 
 
 ##### write(data)
 
-1. Let `promise` be a newly-created pending promise.
 1. If `this.[[state]]` is `"writable"`,
     1. Set `this.[[state]]` to `"waiting"`.
     1. Set `this.[[writablePromise]]` to be a newly-created pending promise.
+    1. Let `promise` be a newly-created pending promise.
     1. Call `this.[[doNextWrite]]({ type: "data", promise, data })`.
     1. Return `promise`.
 1. If `this.[[state]]` is `"waiting"`,
+    1. Let `promise` be a newly-created pending promise.
     1. Push `{ type: "data", promise, data }` onto `this.[[buffer]]`.
     1. Return `promise`.
 1. If `this.[[state]]` is `"closing"` or `"closed"`,


### PR DESCRIPTION
promise created in the step 1 is used only when [[state]] is writable or waiting.
Move it into each case block.

Reference implementation is untouched since we're extracting handlers and making
it consistent with the spec algorithm just seems to make the code dirty.
