### PR TITLE
Fixing a bug in WritableStream `[[error]]` algorithm and some bugs in the reference impl for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ In reaction to calls to the stream's `.write()` method, the `write` constructor 
 1. Repeat while `this.[[queue]]` is not empty:
     1. Let `writeRecord` be DequeueValue(`this.[[queue]]`).
     1. Reject `writeRecord.[[promise]]` with `e`.
-1. Set `this.[[currentWritePromise]]` to `undefined`.
+1. Set `this.[[currentWritePromise]]` to **undefined**.
 1. Set `this.[[state]]` to `"errored"`.
 1. Set `this.[[storedError]]` to `e`.
 1. Reject `this.[[writablePromise]]` with `e`.

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -100,7 +100,11 @@ export default class WritableStream {
 
       case 'waiting':
         this._state = 'closing';
-        helpers.enqueueValueWithSize(this._queue, { type: 'close', promise: this._closedPromise, chunk: undefined }, 0);
+        helpers.enqueueValueWithSize(
+          this._queue,
+          { type: 'close', promise: this._closedPromise, chunk: undefined, _resolve: this._closedPromise_resolve, _reject: this._closedPromise_reject },
+          0
+        );
         return this._closedPromise;
 
       case 'closing':


### PR DESCRIPTION
Spec
- currentWritePromise must be cleared in `[[error]]`

Reference implementation
- resolver and rejecter for closedPromise must be included in the record
- need to get value to touch the record
