### PR TITLE
WritableStream: [[error]] must replace writablePromise when in readable ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,10 +392,11 @@ In reaction to calls to the stream's `.write()` method, the `write` constructor 
     1. Let `writeRecord` be DequeueValue(`this.[[queue]]`).
     1. Reject `writeRecord.[[promise]]` with `e`.
 1. Set `this.[[currentWritePromise]]` to **undefined**.
-1. Set `this.[[state]]` to `"errored"`.
 1. Set `this.[[storedError]]` to `e`.
-1. Reject `this.[[writablePromise]]` with `e`.
+1. If `this.[[state]]`` is `"writable"`, set `this.[[writablePromise]]` to a new promise rejected with `e`.
+1. If `this.[[state]]`` is `"waiting"`, reject `this.[[writablePromise]]` with `e`.
 1. Reject `this.[[closedPromise]]` with `e`.
+1. Set `this.[[state]]` to `"errored"`.
 
 ##### `[[advanceQueue]]()`
 

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -150,10 +150,16 @@ export default class WritableStream {
     this._currentWritePromise = undefined;
     this._currentWritePromise_resolve = null;
     this._currentWritePromise_reject = null;
-    this._state = 'errored';
     this._storedError = error;
-    this._writablePromise_reject(error);
+    if (this._state === 'writable') {
+      this._writablePromise = Promise.reject(error);
+      this._writablePromise_resolve = null;
+      this._writablePromise_reject = null;
+    } else if (this._state === 'waiting') {
+      this._writablePromise_reject(error);
+    }
     this._closedPromise_reject(error);
+    this._state = 'errored';
   }
 
   _advanceQueue() {

--- a/reference-implementation/test/writable-stream-abort.js
+++ b/reference-implementation/test/writable-stream-abort.js
@@ -98,14 +98,12 @@ test('Aborting a WritableStream puts it in an errored state, with stored error e
 });
 
 test('Aborting a WritableStream causes any outstanding wait() promises to be rejected with the abort reason', t => {
-  t.plan(1);
+  t.plan(2);
 
   var recordedReason;
-  var ws = new WritableStream({
-    write(chunk, done) {
-      done();
-    }
-  });
+  var ws = new WritableStream({});
+  ws.write('a');
+  t.equal(ws.state, 'waiting', 'state should be waiting');
 
   ws.wait().then(
     () => t.fail('waiting should not succeed'),

--- a/reference-implementation/test/writable-stream.js
+++ b/reference-implementation/test/writable-stream.js
@@ -153,6 +153,26 @@ test('WritableStream if sink calls error, queued write and close are cleared', t
   );
 });
 
+test('WritableStream if sink calls error, wait will return a rejected promise', t => {
+  var error;
+  var ws = new WritableStream({
+    write(chunk, done, error_) {
+      done();
+      error = error_;
+    }
+  });
+  ws.write('a');
+  t.strictEqual(ws.state, 'writable', 'state is writable as signalDone is called');
+
+  error();
+  t.strictEqual(ws.state, 'errored', 'state is errored as error is called');
+
+  ws.wait().then(
+    () => t.fail('wait on ws returned a fulfilled promise unexpectedly'),
+    r => t.end()
+  );
+});
+
 test('WritableStream if sink throws an error after done, the stream becomes errored but the promise fulfills', t => {
   t.plan(3);
 


### PR DESCRIPTION
...state

When a WritableStream is in readable state, writablePromise is set to a
fulfilled promise. We need to replace it with a new rejected promise.

In writable-stream-abort.js, 'Aborting a WritableStream causes ...' test is
testing a WritableStream in writable state which now returns a pending
promise which gets rejected but this should be a fulfilled promise to be
consistent with the initial value of [[state]] that is 'writable'. We need
to fix this behavior later but for now just put the WritableStream in
'waiting' state and test what stated in the test description.
