### PR TITLE
Use RegExp for test.throws()

### DIFF
--- a/reference-implementation/test/count-queuing-strategy.js
+++ b/reference-implementation/test/count-queuing-strategy.js
@@ -23,11 +23,11 @@ test('Number-ish high water marks get converted to numbers', t => {
 
 test('Gives a RangeError when the number is negative', t => {
   t.throws(() => new CountQueuingStrategy({ highWaterMark: -4 }),
-           RangeError,
+           /RangeError/,
            'throws for { highWaterMark: -4 }');
 
   t.throws(() => new CountQueuingStrategy({ highWaterMark: '-4' }),
-           RangeError,
+           /RangeError/,
            'throws for { highWaterMark: \'-4\' }');
 
   t.end();

--- a/reference-implementation/test/readable-stream.js
+++ b/reference-implementation/test/readable-stream.js
@@ -60,7 +60,7 @@ test('ReadableStream reading a closed stream throws a TypeError', t => {
     }
   });
 
-  t.throws(() => rs.read(), TypeError);
+  t.throws(() => rs.read(), /TypeError/);
 });
 
 test(`ReadableStream reading a stream makes wait() and closed return a promise resolved with undefined when the stream
@@ -78,7 +78,7 @@ test(`ReadableStream reading a stream makes wait() and closed return a promise r
   t.equal(rs.read(), 'test', 'A test string should be read');
   t.equal(rs.state, 'closed', 'The stream should be in closed state');
 
-  t.throws(() => rs.read(), TypeError);
+  t.throws(() => rs.read(), /TypeError/);
 
   rs.wait().then(
     v => t.equal(v, undefined, 'wait() should return a promise resolved with undefined'),
@@ -119,10 +119,12 @@ test('ReadableStream start throws an error', t => {
 
   var error = new Error('aaaugh!!');
 
-  t.throws(
-    () => new ReadableStream({ start() { throw error; } }),
-    caught => t.equal(caught, error, 'error was allowed to propagate')
-  );
+  try {
+    new ReadableStream({ start() { throw error; } });
+    t.fail('Constructor didn\'t throw');
+  } catch (caughtError) {
+    t.strictEqual(caughtError, error, 'error was allowed to propagate');
+  }
 });
 
 test('ReadableStream pull throws an error', t => {
@@ -368,7 +370,7 @@ test('ReadableStream enqueue fails when the stream is in closing state', t => {
 
       t.throws(
         () => t.equal(enqueue('b'), false),
-        TypeError,
+        /TypeError/,
         'enqueue after close must throw a TypeError'
       );
     },

--- a/reference-implementation/test/transform-stream-errors.js
+++ b/reference-implementation/test/transform-stream-errors.js
@@ -24,7 +24,12 @@ test('TransformStream errors thrown in transform put the input and output in an 
     t.equal(ts.output.state, 'errored', 'output becomes errored after writing to the throwing transform');
     t.equal(ts.input.state, 'errored', 'input becomes errored after writing to the throwing transform');
 
-    t.throws(() => ts.output.read(), thrownError, 'output\'s read should throw the thrown error');
+    try {
+      ts.output.read();
+      t.fail('read() didn\'nt throw');
+    } catch (error) {
+      t.strictEqual(error, thrownError, 'output\'s read should throw the thrown error');
+    }
   }, 0);
 
   ts.output.wait().then(
@@ -73,7 +78,12 @@ test('TransformStream errors thrown in flush put the input and output in an erro
     t.equal(ts.output.state, 'errored', 'output becomes errored after closing with the throwing flush');
     t.equal(ts.input.state, 'errored', 'input becomes errored after closing with the throwing flush');
 
-    t.throws(() => ts.output.read(), thrownError, 'output\'s read should throw the thrown error');
+    try {
+      ts.output.read();
+      t.fail('read() didn\'nt throw');
+    } catch (error) {
+      t.strictEqual(error, thrownError, 'output\'s read should throw the thrown error');
+    }
   }, 0);
 
   ts.output.wait().then(

--- a/reference-implementation/test/transform-stream.js
+++ b/reference-implementation/test/transform-stream.js
@@ -11,8 +11,8 @@ test('TransformStream can be constructed with a transform function', t => {
 
 test('TransformStream cannot be constructed with no transform function', t => {
   t.plan(2);
-  t.throws(() => new TransformStream(), TypeError, 'TransformStream cannot be constructed with no arguments');
-  t.throws(() => new TransformStream({ }), TypeError, 'TransformStream cannot be constructed with an empty object');
+  t.throws(() => new TransformStream(), /TypeError/, 'TransformStream cannot be constructed with no arguments');
+  t.throws(() => new TransformStream({ }), /TypeError/, 'TransformStream cannot be constructed with an empty object');
 });
 
 test('TransformStream instances must have input and output properties of the correct types', t => {


### PR DESCRIPTION
throws() expects the "expect" argument to be a RegExp.
