### PR TITLE
[pipeTo] Remove unnecessary catch() chained to write() call

### DIFF
--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -141,7 +141,7 @@ export default class ReadableStream {
         var ds = dest.state;
         if (ds === 'writable') {
           if (source.state === 'readable') {
-            dest.write(source.read()).catch(cancelSource);
+            dest.write(source.read());
             continue;
           } else if (source.state === 'waiting') {
             Promise.race([source.wait(), dest.closed]).then(doPipe, doPipe);


### PR DESCRIPTION
This call can be removed since:
- pipeTo() should pipe data without waiting for completion of each write but
  based on dest.state.
- pipeTo() watches for error by closed or wait() call. So, it doesn't have to
  watch the promises that write() call returns.

Fixes #184
