### PR TITLE
Update how strategies work per #189.

### DIFF
--- a/reference-implementation/lib/byte-length-queuing-strategy.js
+++ b/reference-implementation/lib/byte-length-queuing-strategy.js
@@ -16,7 +16,7 @@ export default class ByteLengthQueuingStrategy {
     return chunk.byteLength;
   }
 
-  needsMore(queueSize) {
-    return queueSize < this.highWaterMark;
+  shouldApplyBackpressure(queueSize) {
+    return queueSize > this.highWaterMark;
   }
 }

--- a/reference-implementation/lib/count-queuing-strategy.js
+++ b/reference-implementation/lib/count-queuing-strategy.js
@@ -16,7 +16,7 @@ export default class CountQueuingStrategy {
     return 1;
   }
 
-  needsMore(queueSize) {
-    return queueSize < this.highWaterMark;
+  shouldApplyBackpressure(queueSize) {
+    return queueSize > this.highWaterMark;
   }
 }

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -7,7 +7,7 @@ export default class ReadableStream {
     start = () => {},
     pull = () => {},
     cancel = () => {},
-    strategy = new CountQueuingStrategy({ highWaterMark: 0 })
+    strategy = new CountQueuingStrategy({ highWaterMark: 1 })
   } = {}) {
     if (typeof start !== 'function') {
       throw new TypeError('start must be a function or undefined');
@@ -222,9 +222,9 @@ export default class ReadableStream {
     this._pulling = false;
 
     var queueSize = helpers.getTotalQueueSize(this._queue);
-    var needsMore;
+    var shouldApplyBackpressure;
     try {
-      needsMore = Boolean(this._strategy.needsMore(queueSize));
+      shouldApplyBackpressure = Boolean(this._strategy.shouldApplyBackpressure(queueSize));
     } catch (error) {
       this._error(error);
       return false;
@@ -235,7 +235,10 @@ export default class ReadableStream {
       this._waitPromise_resolve(undefined);
     }
 
-    return needsMore;
+    if (shouldApplyBackpressure === true) {
+      return false;
+    }
+    return true;
  }
 
   _close() {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -248,19 +248,19 @@ export default class WritableStream {
     }
 
     var queueSize = helpers.getTotalQueueSize(this._queue);
-    var needsMore = Boolean(this._strategy.needsMore(queueSize));
+    var shouldApplyBackpressure = Boolean(this._strategy.shouldApplyBackpressure(queueSize));
 
-    if (needsMore === true && this._state === 'waiting') {
-      this._state = 'writable';
-      this._writablePromise_resolve(undefined);
-    }
-
-    if (needsMore === false && this._state === 'writable') {
+    if (shouldApplyBackpressure === true && this._state === 'writable') {
       this._state = 'waiting';
       this._writablePromise = new Promise((resolve, reject) => {
         this._writablePromise_resolve = resolve;
         this._writablePromise_reject = reject;
       });
+    }
+
+    if (shouldApplyBackpressure === false && this._state === 'waiting') {
+      this._state = 'writable';
+      this._writablePromise_resolve(undefined);
     }
   }
 

--- a/reference-implementation/test/pipe-through.js
+++ b/reference-implementation/test/pipe-through.js
@@ -42,9 +42,13 @@ test('Piping through an identity transform stream will close the destination whe
   });
 });
 
-test('Piping through a zero-HWM transform stream immediately causes backpressure to be exerted', t => {
+test('Piping through a default transform stream causes backpressure to be exerted after some delay', t => {
   t.plan(2);
 
+  // FIXME: expected results here will probably change as we fix https://github.com/whatwg/streams/issues/190
+  // As they are now they don't make very much sense
+
+  // Producer: every 20 ms
   var enqueueReturnValues = [];
   var rs = new ReadableStream({
     start(enqueue, close) {
@@ -67,6 +71,7 @@ test('Piping through a zero-HWM transform stream immediately causes backpressure
     }
   });
 
+  // Consumer: every 90 ms
   var writtenValues = [];
   var ws = new WritableStream({
     write(chunk) {
@@ -83,7 +88,7 @@ test('Piping through a zero-HWM transform stream immediately causes backpressure
     rs.pipeThrough(ts).pipeTo(ws).closed.then(() => {
       t.deepEqual(
         enqueueReturnValues,
-        [false, false, false, false, false, false, false, false],
+        [true, true, true, true, false, false, false, false],
         'backpressure was correctly exerted at the source');
       t.deepEqual(writtenValues, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'], 'all chunks were written');
     });

--- a/reference-implementation/test/pipe-to.js
+++ b/reference-implementation/test/pipe-to.js
@@ -115,7 +115,7 @@ test('Piping from a ReadableStream in readable state to a WritableStream in erro
     ws.wait().then(
       () => t.fail('wait promise unexpectedly fulfilled'),
       () => {
-        t.equal(ws.state, 'errored', 'as a result of error call, ws must be in errored state');
+        t.equal(ws.state, 'errored', 'as a result of rejected promise, ws must be in errored state');
 
         rs.pipeTo(ws);
 
@@ -1134,7 +1134,7 @@ test('Piping to a writable stream that does not consume the writes fast enough e
 
   setTimeout(() => {
     rs.pipeTo(ws).closed.then(() => {
-      t.deepEqual(enqueueReturnValues, [false, false, false, false], 'backpressure was correctly exerted at the source');
+      t.deepEqual(enqueueReturnValues, [true, true, false, false], 'backpressure was correctly exerted at the source');
       t.deepEqual(writtenValues, ['a', 'b', 'c', 'd'], 'all chunks were written');
     });
   }, 0);

--- a/reference-implementation/test/readable-stream.js
+++ b/reference-implementation/test/readable-stream.js
@@ -306,32 +306,17 @@ test('ReadableStream should be able to get data sequentially from an asynchronou
   }
 });
 
-test('Default ReadableStream returns `false` for any `enqueue` call', t => {
+test('Default ReadableStream returns `false` for all but the first `enqueue` call', t => {
   t.plan(5);
 
   new ReadableStream({
     start(enqueue) {
-      t.equal(enqueue('hi'), false);
+      t.equal(enqueue('hi'), true);
       t.equal(enqueue('hey'), false);
       t.equal(enqueue('whee'), false);
       t.equal(enqueue('yo'), false);
       t.equal(enqueue('sup'), false);
     }
-  });
-});
-
-test('ReadableStream returns `true` unless we are at or above the highWaterMark', t => {
-  t.plan(5);
-
-  new ReadableStream({
-    start(enqueue) {
-      t.equal(enqueue('a'), true);
-      t.equal(enqueue('b'), false);
-      t.equal(enqueue('c'), false);
-      t.equal(enqueue('d'), false);
-      t.equal(enqueue('e'), false);
-    },
-    strategy: new CountQueuingStrategy({ highWaterMark: 2 })
   });
 });
 
@@ -383,7 +368,7 @@ test('ReadableStream enqueue fails when the stream is in closing state', t => {
   t.end();
 });
 
-test('ReadableStream if needsMore throws, the stream is errored', t => {
+test('ReadableStream if shouldApplyBackpressure throws, the stream is errored', t => {
   var error = new Error('aaaugh!!');
 
   var rs = new ReadableStream({
@@ -395,7 +380,7 @@ test('ReadableStream if needsMore throws, the stream is errored', t => {
         return 1;
       },
 
-      needsMore() {
+      shouldApplyBackpressure() {
         throw error;
       }
     }
@@ -419,7 +404,7 @@ test('ReadableStream if size throws, the stream is errored', t => {
         throw error;
       },
 
-      needsMore() {
+      shouldApplyBackpressure() {
         return true;
       }
     }
@@ -447,7 +432,7 @@ test('ReadableStream if size is NaN, the stream is errored', t => {
         return NaN;
       },
 
-      needsMore() {
+      shouldApplyBackpressure() {
         return true;
       }
     }


### PR DESCRIPTION
- Replaces `needsMore()` with `shouldApplyBackpressure()`. There is no change for underlying source authors, however: false still means "apply backpressure."
- Changes `ReadableStream`'s default strategy to have a HWM of 1, not 0. `WritableStream` is unchanged.

Some of the stuff around transform streams is currently a bit sketchy. We will re-examine after fixing #190.

This does not address the other half of #189, regarding pull() behavior. I will do that in a follow-up commit.

This caused some changes for writable stream, but they seem reasonable.
