### PR TITLE
Use ws.foobar() style for comments about non static methods

### DIFF
--- a/reference-implementation/test/writable-stream-abort.js
+++ b/reference-implementation/test/writable-stream-abort.js
@@ -43,7 +43,7 @@ test('Aborting a WritableStream prevents further writes after any that are in pr
   }, 0);
 });
 
-test(`Fulfillment value of WritableStream.abort() call must be undefined even if the underlying sink returns a
+test(`Fulfillment value of ws.abort() call must be undefined even if the underlying sink returns a
  non-undefined value`, t => {
   var ws = new WritableStream({
     abort() {

--- a/reference-implementation/test/writable-stream.js
+++ b/reference-implementation/test/writable-stream.js
@@ -90,7 +90,7 @@ test('Underlying sink\'s close won\'t be called until start finishes', t => {
   }, 100);
 });
 
-test(`Fulfillment value of WritableStream.close() call must be undefined even if the underlying sink returns a
+test(`Fulfillment value of ws.close() call must be undefined even if the underlying sink returns a
  non-undefined value`, t => {
   var ws = new WritableStream({
     close() {
@@ -238,7 +238,7 @@ test('WritableStream wait() fulfills immediately if the stream is writable', t =
   });
 });
 
-test(`Fulfillment value of WritableStream.write() call must be undefined even if the underlying sink returns a
+test(`Fulfillment value of ws.write() call must be undefined even if the underlying sink returns a
  non-undefined value`, t => {
   var ws = new WritableStream({
     write() {


### PR DESCRIPTION
See https://github.com/whatwg/streams/pull/197#issuecomment-54631762
