### PR TITLE
Add tests and a note about close + abort

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1014,6 +1014,14 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   </ul>
 </div>
 
+<div class="note">
+  Due to the way writable streams asynchronously close, it is possible for both <var>close</var> and <var>abort</var>
+  to be called, in cases where the <a>producer</a> aborts the stream while it is in the <code>"closing"</code> state.
+  Notably, since a stream always spends at least one turn in the <code>"closing"</code> state, code like
+  <code>ws.close(); ws.abort(...);</code> will cause both to be called, even if the <var>close</var> function itself
+  has no asynchronous behavior. A well-designed <a>underlying source</a> should be able to deal with this.
+</div>
+
 <ol>
   <li> If <var>start</var> is <b>undefined</b>, set <var>start</var> to a no-op function.
   <li> If IsCallable(<var>start</var>) is <b>false</b>, throw a <b>TypeError</b> exception.


### PR DESCRIPTION
Closes #130; closes #192.

Preview the note at https://streams.spec.whatwg.org/branch-snapshots/allow-abort-after-close/#new-writablestream-start-write-close-abort-strategy-
