### PR TITLE
Document default strategies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1580,11 +1580,49 @@ Instances of <code>CountQueuingStrategy</code> are created with the internal slo
 
 <h3 id="default-rs-strategy">%DefaultReadableStreamStrategy%</h3>
 
-Basically, <code>new CountQueuingStrategy({ highWaterMark: 1 })</code>, but a singleton and tamper-proof, etc.
+%DefaultReadableStreamStrategy% is a well-known intrinsic object representing the default <a>queuing strategy</a> for
+<a>readable streams</a>. It has two methods.
+
+<div class="note">
+  The existence of an independent object for the default readable stream queuing strategy is not actually observable.
+  Thus, implementations could implement this default strategy by other means, e.g. by incorporating the default logic
+  into the readable stream algorithms themselves.
+</div>
+
+<h4 id="default-rs-strategy-should-apply-backpressure">shouldApplyBackpressure(queueSize)</h4>
+
+<ol>
+  <li> Assert: <var>queueSize</var> is a non-<b>NaN</b> number.</li>
+  <li> Return <var>queueSize</var> > 1.
+</ol>
+
+<h4 id="default-rs-strategy-size">size()</h4>
+
+<ol>
+  <li> Return 1.
+</ol>
 
 <h3 id="default-ws-strategy">%DefaultWritableStreamStrategy%</h3>
 
-Basically, <code>new CountQueuingStrategy({ highWaterMark: 0 })</code>, but a singleton and tamper-proof, etc.
+%DefaultWritableStreamStrategy% is a well-known intrinsic object representing the default <a>queuing strategy</a> for
+<a>writable streams</a>. It has two methods.
+
+<div class="note">
+  As with %DefaultReadableStreamStrategy%, this object is simply a spec device, and its existence is not observable.
+</div>
+
+<h4 id="default-ws-strategy-should-apply-backpressure">shouldApplyBackpressure(queueSize)</h4>
+
+<ol>
+  <li> Assert: <var>queueSize</var> is a non-<b>NaN</b> number.</li>
+  <li> Return <var>queueSize</var> > 0.
+</ol>
+
+<h4 id="default-ws-strategy-size">size()</h4>
+
+<ol>
+  <li> Return 1.
+</ol>
 
 <h3 id="queue-with-sizes">Queue-with-Sizes Operations</h3>
 


### PR DESCRIPTION
Would like feedback on this. See it at https://streams.spec.whatwg.org/branch-snapshots/default-strategies/#default-rs-strategy

In writing this, the approach ended up feeling kind of silly. To quote myself,

> The existence of an independent object for the default readable stream queuing strategy is not actually observable. Thus, implementations could implement this default strategy by other means, e.g. by incorporating the default logic into the readable stream algorithms themselves.

Maybe we should just do this in the spec? That is, instead of saying in the constructor "if no strategy is provided, set `this@[[strategy]]` to %DefaultReadableStreamStrategy%" and later just dispatching polymorphically to `this@[[strategy]]`, we should instead branch at each point `this@[[strategy]]` is used, and do the default behavior if `this@[[strategy]]` is `undefined`? There are only two places that `this@[[strategy]]` is used so it wouldn't be hard.

Would be curious what approach people think is clearer/easier to read/etc. Other relevant links to see how the current approach works:
- [The constructor where it is assigned](https://streams.spec.whatwg.org/branch-snapshots/default-strategies/#rs-constructor)
- [The place where both methods are used](https://streams.spec.whatwg.org/branch-snapshots/default-strategies/#readable-stream-enqueue-function): the alternate approach involves branching in these locations and inlining the default behavior, instead of having it polymorphically dispatch to the default strategy.
