### PR TITLE
Fix ReadableStream constructor if not getting a promise as startResult

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -555,6 +555,7 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   <li> Let <var>startResult</var> be the result of calling <var>start</var>(<b>this</b>@\[[enqueue]],
     <b>this</b>@\[[close]], <b>this</b>@\[[error]]).
   <li> ReturnIfAbrupt(<var>startResult</var>).
+  <li> If <var>startResult</var> is <b>undefined</b>, return CallReadableStreamPull(<b>this</b>).
   <li> Resolve <var>startResult</var> as a promise:
     <ol>
       <li> Upon fulfillment,


### PR DESCRIPTION
In the examples we have cases where the result of invoking the start
is undefined and we treat it as something acceptable, therefore the
constructor should be prepared to operate in that case.

I guess this should also apply to other cases, like the WritableStream constructor, cancel functions, etc.
