### PR TITLE
WIP: exclusive reader interface

### DIFF
--- a/Locking Design Doc.md
+++ b/Locking Design Doc.md
@@ -1,0 +1,108 @@
+# Locking a Stream for Exclusive Reading
+
+In [#241](https://github.com/whatwg/streams/issues/241) we had a great conversation about the need for being able to "lock" a stream for exclusive use. This would be done implicitly while piping, but could also be useful for building user-facing abstractions, as we'll see below.
+
+What emerged was the idea of a "stream reader," which has most of the readable stream interface, but while it exists you cannot read from the stream except through that reader.
+
+This document represents some formative rationales for the design of the reader concept, approached from the perspective of a developer that uses increasingly complex features of the streams ecosystem.
+
+## Developer usage
+
+### Level 0: no reader usage
+
+If the developer knows nothing about readers, they can continue using the stream just fine.
+
+- `read()`, `state`, and `ready` all behave as they do now if used without `pipeTo`.
+- `pipeTo` will cause the following side effects:
+    - `read()` will throw an informative error
+    - `state` will return `"waiting"` until the pipe completes (successfully or otherwise)
+    - `ready` will return a promise that remains pending until the pipe completes
+
+### Level 1: using readers directly
+
+The developer might want to create their own abstractions that require exclusive access to the stream. For example, a read-to-end function would probably want to avoid others being able to call `.read()` in the middle.
+
+Example code:
+
+```js
+function readAsJson(rs) {
+    var string = "";
+    var reader = rs.getReader();
+
+    pump();
+
+    // These lines would be simpler with `Promise.prototype.finally` (or async functions).
+    return reader.closed.then(
+        () => {
+            reader.releaseLock();
+            return JSON.parse(string);
+        },
+        e => {
+            reader.releaseLock();
+            throw e;
+        }
+    );
+
+    function pump() {
+        while (reader.state === "readable") {
+            string += reader.read();
+        }
+        if (reader.state === "waiting") {
+            reader.ready.then(pump);
+        }
+    }
+}
+```
+
+The stream would have the same behaviors after being passed to `readAsJson` that it would have after calling its `pipeTo` method.
+
+The reader should have all of the non-piping-related public interface of the stream. This includes:
+
+- `closed` getter, which is a pass-through
+- `state` and `ready` getters, which reveal the "true" state and state transitions of the stream which the stream itself no longer reveals
+- `read()` method, which has the same behavior as that of the stream's except that it works while the stream is locked
+- `cancel()` method, which first calls `this.releaseLock()` before the pass-through
+
+While a stream is locked, it is indistinguishable from a stream that has been drained of all chunks and is not getting any more enqueued. We could consider adding some kind of test, like `stream.isLocked`, to distinguish. However, it's not clear there's a compelling reason for doing so (let us know if so?), and the indistinguishability is kind of a nice property from the perspective of the principle of least authority.
+
+For readers, you should be able to tell if they're still active (i.e. have not been released) via `reader.isActive`.
+
+### Level 2: subclassers of `ReadableStream`
+
+Subclasses of `ReadableStream` should get locking support "for free." The same mechanisms for acquiring and using a lock should work flawlessly. More interestingly, if they wanted to support modifying the behavior of e.g. `read()` (or `state` or `ready` or `closed`), they should only have to override it in one location.
+
+Which location is more friendly? Probably in `ReadableStream`, so that `ExclusiveStreamReader` still works for `ReadableStream` subclasses. Less work.
+
+This means `ExclusiveStreamReader` should delegate to `ReadableStream`, and not the other way around.
+
+### Level 3: custom readable stream implementations?
+
+It is unclear whether this is necessary, but up until now we have a high level of support for anyone who wants to re-implement the entire `ReadableStream` interface with their own specific code. For example, if you implement `state`, `ready`, `closed`, `read()`, and `cancel()`, you can do `myCustomStream.pipeTo = ReadableStream.prototype.pipeTo` and it will continue to work.
+
+If we encourage this kind of thing, we should make it easy for custom readable streams to be lockable as well. That basically means `ExclusiveStreamReader` should not require knowledge of `ReadableStream`'s internal slots.
+
+We can work around this if necessary by passing `ExclusiveStreamReader` any capabilities it needs to manipulate `ReadableStream`'s internal state; then people reimplementing the readable stream interface can do e.g. `new ExclusiveStreamReader(this, { getLock, setLock })` or similar.
+
+## Optimizability
+
+The need to support subclassing, via `ExclusiveStreamReader` delegating to the `ReadableStream` implementation, conflicts a bit with the desire for readers to be fast. However, this can be fixed with some cleverness.
+
+The spec semantics for e.g. `reader.read()` are essentially:
+
+- Check that `reader@[[stream]]` is locked to `reader`.
+- Unlock `reader@[[stream]]`.
+- Try `return reader@[[stream]].read()`; finally re-lock `reader@[[stream]]`.
+
+This will ensure that if `reader@[[stream]]` is a subclass of `ReadableStream`, it will polymorphically dispatch to the subclass's `read` method. However, this kind of try/finally pattern is not very optimizable in V8.
+
+Here is an optimization that can be performed instead, with slight tweaks to both `ReadableStream.prototype.read` and `ExclusiveStreamReader.prototype.read`:
+
+- Define `ReadableStream.prototype.read` as:
+    - Check that `this` is not locked.
+    - Return `ReadFromReadableStream(this)`. (That is, extract the main functionality, without the check, into its own function.)
+- Define `ExclusiveStreamReader.prototype.read` like so:
+    - Check that `this@[[stream]]` is locked to `this`.
+    - If `this@[[stream]].read` is equal to the original `ReadableStream.prototype.read`: return `ReadFromReadableStream(this@[[stream]])`.
+    - Otherwise, proceed via the per-spec semantics above.
+
+This essentially ensures that all undisturbed readable streams, or readable stream subclasses that do not override `read`, go down the "fast path" by ignoring all the try/finally and lock/unlock business. It is unobservable, since we have checked that `read` has not been modified in any way.

--- a/index.bs
+++ b/index.bs
@@ -148,6 +148,24 @@ based the total size of all chunks in the stream's internal queue.
   backpressure signal.
 </div>
 
+<h3 id="locking">Locking</h3>
+
+<!-- TODO: writable streams too, probably -->
+
+An <dfn>exclusive stream reader</dfn> or simply reader is an object that encapsulates a <a>readable stream</a>,
+preventing access to the stream except through the reader's interface. We say in this case the stream is
+<dfn title="locked to a reader">locked to the reader</dfn>, and that the reader is
+<dfn title="active reader">active</dfn>. A readable stream can have at most one reader at a time.
+
+The reader presents most of the stream's interface, but while it is active, only the reader's methods and properties
+can be used to successfully manipulate and interrogate the state of the stream; when the stream is used directly, it
+appears as if it is empty.
+
+A reader also has the capability to <dfn title="release a read lock">release its read lock</dfn>, which makes it no
+longer active. At this point the original stream can be used as before, and the reader becomes inert. If the
+encapsulated stream becomes closed or errored as a result of the behavior of its <a>underlying source</a>, any
+associated reader will automatically release its lock.
+
 <h2 id="rs">Readable Streams</h2>
 
 <h3 id="rs-intro">Introduction to Readable Streams</h3>
@@ -376,6 +394,7 @@ would look like
     get state()
 
     cancel(reason)
+    getReader()
     pipeThrough({ writable, readable }, options)
     pipeTo(dest, { preventClose, preventAbort, preventCancel } = {})
     read()
@@ -433,6 +452,10 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
     <td>\[[queue]]
     <td>A List representing the stream's internal queue of <a>chunks</a>
   </tr>
+  <tr>
+    <td>\[[reader]]
+    <td>A <code>ExclusiveStreamReader</code> instance, if the stream is locked to an exclusive reader, or
+      <b>undefined</b> if it is not
   <tr>
     <td>\[[started]]
     <td>A boolean flag indicating whether the <a>underlying source</a> has finished starting
@@ -493,6 +516,7 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   <li> Set <b>this</b>@\[[queue]] to a new empty List.
   <li> Set <b>this</b>@\[[state]] to <code>"waiting"</code>.
   <li> Set <b>this</b>@\[[started]], <b>this</b>@\[[draining]], and <b>this</b>@\[[pulling]] to <b>false</b>.
+  <li> Set <b>this</b>@\[[reader]] to <b>undefined</b>.
   <li> Set <b>this</b>@\[[enqueue]] to CreateReadableStreamEnqueueFunction(<b>this</b>).
   <li> Set <b>this</b>@\[[close]] to CreateReadableStreamCloseFunction(<b>this</b>).
   <li> Set <b>this</b>@\[[error]] to CreateReadableStreamErrorFunction(<b>this</b>).
@@ -532,6 +556,7 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
 </div>
 
 <ol>
+  <li> If <b>this</b>@\[[reader]] is not <b>undefined</b>, return <b>this</b>@\[[reader]]@\[[lockReleased]].
   <li> Return <b>this</b>@\[[readyPromise]].
 </ol>
 
@@ -553,9 +578,12 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
     <dt><code>"errored"</code>
     <dd>An error occurred interacting with the <a>underlying source</a>, and so the stream is now dead.
   </dl>
+
+  If the stream is <a>locked to a reader</a>, the stream will appear to be <code>"waiting"</code>.
 </div>
 
 <ol>
+  <li> If <b>this</b>@\[[reader]] is not <b>undefined</b>, return <code>"waiting"</code>.
   <li> Return <b>this</b>@\[[state]].
 </ol>
 
@@ -565,17 +593,42 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   The <code>cancel</code> method signals a loss of interest in the stream by a consumer. Calling it will immediately
   move the stream to a <code>"closed"</code> state, throwing away any queued data, as well as executing any
   cancellation mechanism of the <a>underlying source</a>.
+
+  Readable streams cannot be cancelled while <a>locked to a reader</a>; this method will return a rejected promise.
 </div>
 
 <ol>
+  <li> If <b>this</b>@\[[reader]] is not <b>undefined</b>, return a new promise rejected with a <b>TypeError</b>.
   <li> If <b>this</b>@\[[state]] is <code>"closed"</code>, return a new promise resolved with <b>undefined</b>.
   <li> If <b>this</b>@\[[state]] is <code>"errored"</code>, return a new promise rejected with <b>this</b>@\[[storedError]].
   <li> If <b>this</b>@\[[state]] is <code>"waiting"</code>, resolve <b>this</b>@\[[readyPromise]] with <b>undefined</b>.
   <li> Let <b>this</b>@\[[queue]] be a new empty List.
-  <li> Set <b>this</b>@\[[state]] to <code>"closed"</code>.
-  <li> Resolve <b>this</b>@\[[closedPromise]] with <b>undefined</b>.
+  <li> Call-with-rethrow CloseReadableStream(<b>this</b>).
   <li> Let <var>sourceCancelPromise</var> be the result of promise-calling <b>this</b>@\[[onCancel]](<var>reason</var>).
   <li> Return the result of transforming <var>sourceCancelPromise</var> by a fulfillment handler that returns <b>undefined</b>.
+</ol>
+
+<h5 id="rs-get-reader">getReader()</h5>
+
+<div class="note">
+  The <code>getReader</code> method creates an <a>exclusive stream reader</a> and
+  <a title="locked to a reader">locks</a> the stream to the the new reader. While the stream is locked, it cannot be
+  manipulated directly, and will appear to be an inert, empty stream waiting for new <a>chunks</a> to be enqueued.
+  Instead, the returned reader object can be used to read from or cancel the stream, or to discern its state and state
+  transitions. If or when the lock is <a title="release a read lock">released</a>, the stream can be used again as
+  normal.
+
+  This functionality is especially useful for creating abstractions that desire the ability to consume a stream in its
+  entirety. By getting a reader for the stream, you can ensure nobody else can interleave reads with yours, interfering
+  with your abstraction or observing its side-effects.
+
+  Note that when a stream is closed or errors, any reader it is locked to is automatically released.
+</div>
+
+<ol>
+  <li> If <b>this</b>@\[[state]] is <code>"closed"</code>, throw a <b>TypeError</b> exception.
+  <li> If <b>this</b>@\[[state]] is <code>"errored"</code>, throw <b>this</b>@\[[storedError]].
+  <li> Return Construct(<code>ExclusiveStreamReader</code>, (<b>this</b>)).
 </ol>
 
 <h5 id="rs-pipe-through">pipeThrough({ writable, readable }, options)</h5>
@@ -621,6 +674,7 @@ look for the <code>pipeTo</code> method.
 </div>
 
 <ol>
+  <li> If <b>this</b>@\[[reader]] is not <b>undefined</b>, throw a <b>TypeError</b> exception.
   <li> If <b>this</b>@\[[state]] is <code>"waiting"</code> or <code>"closed"</code>, throw a <b>TypeError</b> exception.
   <li> If <b>this</b>@\[[state]] is <code>"errored"</code>, throw <b>this</b>@\[[storedError]].
   <li> Assert: <b>this</b>@\[[state]] is <code>"readable"</code>.
@@ -628,11 +682,7 @@ look for the <code>pipeTo</code> method.
   <li> Let <var>chunk</var> be DequeueValue(<b>this</b>@\[[queue]]).
   <li> If <b>this</b>@\[[queue]] is now empty,
     <ol>
-      <li> If <b>this</b>@\[[draining]] is <b>true</b>,
-        <ol>
-          <li> Set <b>this</b>@\[[state]] to <code>"closed"</code>.
-          <li> Resolve <b>this</b>@\[[closedPromise]] with <b>undefined</b>.
-        </ol>
+      <li> If <b>this</b>@\[[draining]] is <b>true</b>, call-with-rethrow CloseReadableStream(<b>this</b>).
       <li> If <b>this</b>@\[[draining]] is <b>false</b>,
         <ol>
           <li> Set <b>this</b>@\[[state]] to <code>"waiting"</code>.
@@ -641,6 +691,172 @@ look for the <code>pipeTo</code> method.
     </ol>
   <li> Call-with-rethrow CallReadableStreamPull(<b>this</b>).
   <li> Return <var>chunk</var>.
+</ol>
+
+<h3 id="reader-class">Class <code>ExclusiveStreamReader</code></h3>
+
+<h4 id="reader-class-definition">Class Definition</h4>
+
+<em>This section is non-normative.</em>
+
+If one were to write the <code>ExclusiveStreamReader</code> class in something close to the syntax of [[!ECMASCRIPT]],
+it would look like
+
+<pre><code class="lang-javascript">
+  class ExclusiveStreamReader {
+    constructor(stream)
+
+    get closed()
+    get isActive()
+    get ready()
+    get state()
+
+    cancel(reason, ...args)
+    read(...args)
+    releaseLock()
+  }
+</code></pre>
+
+<h4 id="reader-internal-slots">Internal Slots</h4>
+
+Instances of <code>ExclusiveStreamReader</code> are created with the internal slots described in the following table:
+
+<table>
+  <thead>
+    <tr>
+      <th>Internal Slot</th>
+      <th>Description (<em>non-normative</em>)</th>
+    </tr>
+  </thead>
+  <tr>
+    <td>\[[stream]]
+    <td>A <code>ReadableStream</code> instance that this reader encapsulates
+  </tr>
+  <tr>
+    <td>\[[lockReleased]]
+    <td>A promise that becomes fulfilled when the reader releases its lock on the stream
+  </tr>
+</table>
+
+<h4 id="reader-constructor">new ExclusiveStreamReader(stream)</h4>
+
+<ol>
+  <li> If <var>stream</var> does not have a \[[reader]] internal slot, throw a <b>TypeError</b> exception.
+  <li> If <var>stream</var>@\[[reader]] is not <b>undefined</b>, throw a <b>TypeError</b> exception.
+  <li> Set <var>stream</var>@\[[reader]] to <b>this</b>.
+  <li> Set <b>this</b>@\[[stream]] to <var>stream</var>.
+  <li> Set <b>this</b>@\[[lockReleased]] to a new promise.
+</ol>
+
+<h4 id="reader-prototype">Properties of the <code>ExclusiveStreamReader</code> Prototype</h4>
+
+<h5 id="reader-closed">get closed</h5>
+
+<div class="note">
+  The <code>closed</code> getter for a stream reader simply delegates to the encapsulated stream, to allow consumers to
+  use the reader interface as they would the readable stream interface.
+</div>
+
+<ol>
+  <li> Return Get(<b>this</b>@\[[stream]], <code>"closed"</code>).
+</ol>
+
+<h5 id="reader-is-active">get isActive</h5>
+
+<div class="note">
+  The <code>isActive</code> getter returns whether or not the stream reader is currently
+  <a title="active reader">active</a>.
+</div>
+
+<ol>
+ <li> Return SameValue(<b>this</b>@\[[stream]]@\[[reader]], <b>this</b>).
+</ol>
+
+<h5 id="reader-ready">get ready</h5>
+
+<div class="note">
+  The <code>ready</code> getter behaves the same as that for the readable stream encapsulated by this reader, except
+  that while the reader has exclusive access to the stream, the promise returned will reveal the stream's true state
+  transitions. (In contrast, the stream itself does not signal any state transitions while
+  <a title="locked to a reader">locked</a>, giving off the appearance of being <code>"waiting"</code> for the
+  duration.)
+</div>
+
+<ol>
+  <li> If SameValue(<b>this</b>@\[[stream]]@\[[reader]], <b>this</b>) is <b>false</b>, return
+    Get(<b>this</b>@\[[stream]], <code>"ready"</code>).
+  <li> Set <b>this</b>@\[[stream]]@\[[reader]] to <b>undefined</b>.
+  <li> Let <var>readyResult</var> be Get(<b>this</b>@\[[stream]], <code>"ready"</code>).
+  <li> Set <b>this</b>@\[[stream]]@\[[reader]] to <b>this</b>.
+  <li> Return <var>readyResult</var>.
+</ol>
+
+<h5 id="reader-state">get state</h5>
+
+<div class="note">
+  The <code>state</code> getter behaves the same as that for the readable stream encapsulated by this reader, except
+  that while the reader has exclusive access to the stream, it will reveal the stream's true state. (In contrast, the
+  stream itself gives off the appearance of being <code>"waiting"</code> while it is
+  <a title="locked to a reader">locked</a>.)
+</div>
+
+<ol>
+  <li> If SameValue(<b>this</b>@\[[stream]]@\[[reader]], <b>this</b>) is <b>false</b>, return
+    Get(<b>this</b>@\[[stream]], <code>"state"</code>).
+  <li> Set <b>this</b>@\[[stream]]@\[[reader]] to <b>undefined</b>.
+  <li> Let <var>stateResult</var> be Get(<b>this</b>@\[[stream]], <code>"state"</code>).
+  <li> Set <b>this</b>@\[[stream]]@\[[reader]] to <b>this</b>.
+  <li> Return <var>stateResult</var>.
+</ol>
+
+<h5 id="reader-cancel">cancel(...args)</h5>
+
+<div class="note">
+  If the reader is <a title="active reader">active</a>, the <code>cancel</code> method will
+  <a title="release a read lock">release the lock</a> and then call through to the stream's own <code>cancel</code>
+  method.
+</div>
+
+<ol>
+  <li> If SameValue(<b>this</b>@\[[stream]]@\[[reader]], <b>this</b>) is <b>false</b>, return a new promise rejected with a
+    <b>TypeError</b>.
+  <li> Call-with-rethrow Invoke(<b>this</b>, <code>"releaseLock"</code>).
+  <li> Return Invoke(<b>this</b>@\[[stream]], <code>"cancel"</code>, <var>args</var>).
+</ol>
+
+The <code>length</code> property of the <code>cancel</code> method is <b>1</b>.
+
+<h5 id="reader-read">read(...args)</h5>
+
+<div class="note">
+  If the reader is <a title="active reader">active</a>, the <code>read</code> method behaves the same as that for the
+  encapsulated stream, except that the reader will be able to use its exclusive access to the stream to retrieve
+  <a>chunks</a>. (In contrast, the stream itself will not allow any chunks to be read from it while it is
+  <a title="locked to a reader">locked</a>.)
+</div>
+
+<ol>
+  <li> If SameValue(<b>this</b>@\[[stream]]@\[[reader]], <b>this</b>) is <b>false</b>, throw a <b>TypeError</b>
+    exception.
+  <li> Set <b>this</b>@\[[stream]]@\[[reader]] to <b>undefined</b>.
+  <li> Let <var>readResult</var> be Invoke(<b>this</b>@\[[stream]], <code>"read"</code>, <var>args</var>).
+  <li> Set <b>this</b>@\[[stream]]@\[[reader]] to <b>this</b>.
+  <li> Return <var>readResult</var>.
+</ol>
+
+<h5 id="reader-release-lock">releaseLock()</h5>
+
+<div class="note">
+  The <code>releaseLock</code> method <a title="release a read lock">releases the reader's lock</a> on the encapsulated
+  stream. After the lock is released, the reader is no longer <a title="active reader">active</a>, and its
+  <code>cancel</code> and <code>read</code> methods will fail, while its <code>closed</code>, <code>ready</code>, and
+  <code>state</code> getters will simply delegate to the encapsulated stream.
+</div>
+
+<ol>
+  <li> If SameValue(<b>this</b>@\[[stream]]@\[[reader]], <b>this</b>) is <b>false</b>, return <b>undefined</b>.
+  <li> Set <b>this</b>@\[[stream]]@\[[reader]] to <b>undefined</b>.
+  <li> Resolve <b>this</b>@\[[lockReleased]] with <b>undefined</b>.
 </ol>
 
 <h3 id="rs-abstract-ops">Readable Stream Abstract Operations</h3>
@@ -664,6 +880,15 @@ look for the <code>pipeTo</code> method.
   <li> Otherwise, return <b>undefined</b>.
 </ol>
 
+<h4 id="close-readable-stream">CloseReadableStream ( stream )</h4>
+
+<ol>
+  <li> Set <var>stream</stream>@\[[state]] to <code>"closed"</code>.
+  <li> Resolve <var>stream</stream>@\[[closedPromise]] with <b>undefined</b>.
+  <li> If <var>stream</var>@\[[reader]] is not <b>undefined</b>, call-with-rethrow Invoke(<var>stream</var>@\[[reader]], <code>"releaseLock"</code>).
+  <li> Return <b>undefined</b>.
+</ol>
+
 <h4 id="create-readable-stream-close-function">CreateReadableStreamCloseFunction ( stream )</h4>
 
 <ol>
@@ -677,8 +902,7 @@ A <dfn>Readable Stream Close Function</dfn> is a built-in anonymous function of 
   <li> If <var>stream</var>@\[[state]] is <code>"waiting"</code>,
     <ol>
       <li> Resolve <var>stream</var>@\[[readyPromise]] with <b>undefined</b>.
-      <li> Resolve <var>stream</var>@\[[closedPromise]] with <b>undefined</b>.
-      <li> Set <var>stream</var>@\[[state]] to <code>"closed"</code>.
+      <li> Return CloseReadableStream(<b>this</b>).
     </ol>
   <li> If <var>stream</var>@\[[state]] is <code>"readable"</code>,
     <ol>
@@ -728,19 +952,14 @@ A <dfn>Readable Stream Error Function</dfn> is a built-in anonymous function of 
 a variable <var>stream</var>, that performs the following steps:
 
 <ol>
-  <li> If <var>stream</var>@\[[state]] is <code>"waiting"</code>,
+  <li> If <var>stream</var>@\[[state]] is <code>"waiting"</code>, resolve <var>stream</var>@\[[readyPromise]] with <b>undefined</b>.
+  <li> If <var>stream</var>@\[[state]] is <code>"readable"</code>, let <var>stream</var>@\[[queue]] be a new empty List.
+  <li> If <var>stream</var>@\[[state]] is either <code>"waiting"</code> or <code>"readable"</code>,
     <ol>
       <li> Set <var>stream</var>@\[[state]] to <code>"errored"</code>.
       <li> Set <var>stream</var>@\[[storedError]] to <var>e</var>.
-      <li> Resolve <var>stream</var>@\[[readyPromise]] with <b>undefined</b>.
       <li> Reject <var>stream</var>@\[[closedPromise]] with <var>e</var>.
-    </ol>
-  <li> If <var>stream</var>@\[[state]] is <code>"readable"</code>,
-    <ol>
-      <li> Let <var>stream</var>@\[[queue]] be a new empty List.
-      <li> Set <var>stream</var>@\[[state]] to <code>"errored"</code>.
-      <li> Set <var>stream</var>@\[[storedError]] to <var>e</var>.
-      <li> Reject <var>stream</var>@\[[closedPromise]] with <var>e</var>.
+      <li> If <var>stream</var>@\[[reader]] is not <b>undefined</b>, call-with-rethrow Invoke(<var>stream</var>@\[[reader]], <code>"releaseLock"</code>).
     </ol>
 </ol>
 

--- a/reference-implementation/lib/exclusive-stream-reader.js
+++ b/reference-implementation/lib/exclusive-stream-reader.js
@@ -1,0 +1,87 @@
+var assert = require('assert');
+
+export default class ExclusiveStreamReader {
+  constructor(stream) {
+    if (!('_reader' in stream)) {
+      throw new TypeError('ExclusiveStreamReader can only be used with ReadableStream objects or subclasses');
+    }
+
+    if (stream._reader !== undefined) {
+      throw new TypeError('This stream has already been locked for exclusive reading by another reader');
+    }
+
+    stream._reader = this;
+
+    this._stream = stream;
+
+    this._lockReleased = new Promise(resolve => {
+      this._lockReleased_resolve = resolve;
+    });
+  }
+
+  get ready() {
+    if (this._stream._reader !== this) {
+      return this._stream.ready;
+    }
+
+    this._stream._reader = undefined;
+    try {
+      return this._stream.ready;
+    } finally {
+      this._stream._reader = this;
+    }
+  }
+
+  get state() {
+    if (this._stream._reader !== this) {
+      return this._stream.state;
+    }
+
+    this._stream._reader = undefined;
+    try {
+      return this._stream.state;
+    } finally {
+      this._stream._reader = this;
+    }
+  }
+
+  get closed() {
+    return this._stream.closed;
+  }
+
+  get isActive() {
+    return this._stream._reader === this;
+  }
+
+  read(...args) {
+    if (this._stream._reader !== this) {
+      throw new TypeError('This stream reader has released its lock on the stream and can no longer be used');
+    }
+
+    this._stream._reader = undefined;
+    try {
+      return this._stream.read(...args);
+    } finally {
+      this._stream._reader = this;
+    }
+  }
+
+  cancel(reason, ...args) {
+    if (this._stream._reader !== this) {
+      return Promise.reject(
+        new TypeError('This stream reader has released its lock on the stream and can no longer be used'));
+    }
+
+    this.releaseLock();
+    return this._stream.cancel(reason, ...args);
+  }
+
+  releaseLock() {
+    if (this._stream._reader !== this) {
+      return undefined;
+    }
+
+    this._stream._reader = undefined;
+    this._lockReleased_resolve(undefined);
+  }
+}

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 import * as helpers from './helpers';
 import { DequeueValue, EnqueueValueWithSize, GetTotalQueueSize } from './queue-with-sizes';
 import CountQueuingStrategy from './count-queuing-strategy';
+import ExclusiveStreamReader from './exclusive-stream-reader';
 
 export default class ReadableStream {
   constructor({
@@ -30,6 +31,7 @@ export default class ReadableStream {
     this._started = false;
     this._draining = false;
     this._pulling = false;
+    this._reader = undefined;
 
     this._enqueue = CreateReadableStreamEnqueueFunction(this);
     this._close = CreateReadableStreamCloseFunction(this);
@@ -50,10 +52,19 @@ export default class ReadableStream {
   }
 
   get state() {
+    if (this._reader !== undefined) {
+      return 'waiting';
+    }
+
     return this._state;
   }
 
   cancel(reason) {
+    if (this._reader !== undefined) {
+      return Promise.reject(
+        new TypeError('This stream is locked to a single exclusive reader and cannot be cancelled directly'));
+    }
+
     if (this._state === 'closed') {
       return Promise.resolve(undefined);
     }
@@ -65,11 +76,21 @@ export default class ReadableStream {
     }
 
     this._queue = [];
-    this._state = 'closed';
-    this._resolveClosedPromise(undefined);
+    CloseReadableStream(this);
 
     var sourceCancelPromise = helpers.promiseCall(this._onCancel, reason);
     return sourceCancelPromise.then(() => undefined);
+  }
+
+  getReader() {
+    if (this._state === 'closed') {
+      throw new TypeError('The stream has already been closed, so a reader cannot be acquired.');
+    }
+    if (this._state === 'errored') {
+      throw this._storedError;
+    }
+
+    return new ExclusiveStreamReader(this);
   }
 
   pipeThrough({ writable, readable }, options) {
@@ -86,11 +107,11 @@ export default class ReadableStream {
   }
 
   pipeTo(dest, { preventClose, preventAbort, preventCancel } = {}) {
-    var source = this;
     preventClose = Boolean(preventClose);
     preventAbort = Boolean(preventAbort);
     preventCancel = Boolean(preventCancel);
 
+    var source;
     var resolvePipeToPromise;
     var rejectPipeToPromise;
 
@@ -98,6 +119,7 @@ export default class ReadableStream {
       resolvePipeToPromise = resolve;
       rejectPipeToPromise = reject;
 
+      source = this.getReader();
       doPipe();
     });
 
@@ -137,12 +159,16 @@ export default class ReadableStream {
 
     function cancelSource(reason) {
       if (preventCancel === false) {
+        // implicitly releases the lock
         source.cancel(reason);
+      } else {
+        source.releaseLock();
       }
       rejectPipeToPromise(reason);
     }
 
     function closeDest() {
+      source.releaseLock();
       if (preventClose === false) {
         dest.close().then(resolvePipeToPromise, rejectPipeToPromise);
       } else {
@@ -151,6 +177,7 @@ export default class ReadableStream {
     }
 
     function abortDest(reason) {
+      source.releaseLock();
       if (preventAbort === false) {
         dest.abort(reason);
       }
@@ -159,6 +186,10 @@ export default class ReadableStream {
   }
 
   read() {
+    if (this._reader !== undefined) {
+      throw new TypeError('This stream is locked to a single exclusive reader and cannot be read from directly');
+    }
+
     if (this._state === 'waiting') {
       throw new TypeError('no chunks available (yet)');
     }
@@ -176,8 +207,7 @@ export default class ReadableStream {
 
     if (this._queue.length === 0) {
       if (this._draining === true) {
-        this._state = 'closed';
-        this._resolveClosedPromise(undefined);
+        CloseReadableStream(this);
       } else {
         this._state = 'waiting';
         this._initReadyPromise();
@@ -190,6 +220,10 @@ export default class ReadableStream {
   }
 
   get ready() {
+    if (this._reader !== undefined) {
+      return this._reader._lockReleased;
+    }
+
     return this._readyPromise;
   }
 
@@ -261,8 +295,7 @@ function CreateReadableStreamCloseFunction(stream) {
   return () => {
     if (stream._state === 'waiting') {
       stream._resolveReadyPromise(undefined);
-      stream._resolveClosedPromise(undefined);
-      stream._state = 'closed';
+      return CloseReadableStream(stream);
     }
     if (stream._state === 'readable') {
       stream._draining = true;
@@ -312,16 +345,18 @@ function CreateReadableStreamEnqueueFunction(stream) {
 function CreateReadableStreamErrorFunction(stream) {
   return e => {
     if (stream._state === 'waiting') {
-      stream._state = 'errored';
-      stream._storedError = e;
       stream._resolveReadyPromise(undefined);
-      stream._rejectClosedPromise(e);
     }
-    else if (stream._state === 'readable') {
+    if (stream._state === 'readable') {
       stream._queue = [];
+    }
+    if (stream._state === 'waiting' || stream._state === 'readable') {
       stream._state = 'errored';
       stream._storedError = e;
       stream._rejectClosedPromise(e);
+      if (stream._reader !== undefined) {
+        stream._reader.releaseLock();
+      }
     }
   };
 }
@@ -337,6 +372,17 @@ function ShouldReadableStreamApplyBackpressure(stream) {
   }
 
   return shouldApplyBackpressure;
+}
+
+function CloseReadableStream(stream) {
+  stream._state = 'closed';
+  stream._resolveClosedPromise(undefined);
+
+  if (stream._reader !== undefined) {
+    stream._reader.releaseLock();
+  }
+
+  return undefined;
 }
 
 var defaultReadableStreamStrategy = {

--- a/reference-implementation/test/exclusive-stream-reader.js
+++ b/reference-implementation/test/exclusive-stream-reader.js
@@ -1,0 +1,376 @@
+var test = require('tape');
+
+import ReadableStream from '../lib/readable-stream';
+
+test('Using the reader directly on a mundane stream', t => {
+  t.plan(22);
+
+  var rs = new ReadableStream({
+    start(enqueue, close) {
+      enqueue('a');
+      setTimeout(() => enqueue('b'), 30);
+      setTimeout(close, 60);
+    }
+  });
+
+  t.equal(rs.state, 'readable', 'stream starts out readable');
+
+  var reader = rs.getReader();
+
+  t.equal(reader.isActive, true, 'reader isActive is true');
+
+  t.equal(rs.state, 'waiting', 'after getting a reader, the stream state is waiting');
+  t.equal(reader.state, 'readable', 'the reader state is readable');
+
+  t.throws(() => rs.read(), /TypeError/, 'trying to read from the stream directly throws a TypeError');
+  t.equal(reader.read(), 'a', 'trying to read from the reader works and gives back the first enqueued value');
+  t.equal(reader.state, 'waiting', 'the reader state is now waiting since the queue has been drained');
+  rs.cancel().then(
+    () => t.fail('cancel() should not be fulfilled'),
+    e => t.equal(e.constructor, TypeError, 'cancel() should be rejected with a TypeError')
+  );
+
+  reader.ready.then(() => {
+    t.equal(reader.state, 'readable', 'ready for reader is fulfilled when second chunk is enqueued');
+    t.equal(rs.state, 'waiting', 'the stream state is still waiting');
+    t.equal(reader.read(), 'b', 'you can read the second chunk from the reader');
+  });
+
+  reader.closed.then(() => {
+    t.pass('closed for the reader is fulfilled');
+    t.equal(reader.state, 'closed', 'the reader state is closed');
+    t.equal(rs.state, 'closed', 'the stream state is closed');
+    t.equal(reader.isActive, false, 'the reader is no longer active');
+
+    t.doesNotThrow(() => reader.releaseLock(), 'trying to release the lock twice does nothing');
+  });
+
+  rs.ready.then(() => {
+    t.equal(rs.state, 'closed', 'ready for stream is not fulfilled until the stream closes');
+    t.equal(reader.isActive, false, 'the reader is no longer active after the stream has closed');
+  });
+
+  rs.closed.then(() => {
+    t.pass('closed for the stream is fulfilled');
+    t.equal(rs.state, 'closed', 'the stream state is closed');
+    t.equal(reader.state, 'closed', 'the reader state is closed');
+    t.equal(reader.isActive, false, 'the reader is no longer active');
+  });
+});
+
+test('Readers delegate to underlying stream implementations', t => {
+  t.plan(3 * 3 + 2 * 4);
+
+  var rs = new ReadableStream();
+  var reader = rs.getReader();
+
+  testGetter('ready');
+  testGetter('state');
+  testGetter('closed');
+  testMethod('read');
+  testMethod('cancel');
+
+  // Generates 4 assertions
+  function testGetter(propertyName) {
+    Object.defineProperty(rs, propertyName, {
+      get() {
+        t.pass('overriden ' + propertyName + ' called');
+        t.equal(this, rs, propertyName + ' called with the correct this value');
+        return propertyName + ' return value';
+      }
+    });
+    t.equal(reader[propertyName], propertyName + ' return value',
+      `reader's ${propertyName} returns the return value of the stream's ${propertyName}`);
+  }
+
+  // Generates 5 assertions
+  function testMethod(methodName) {
+    var testArgs = ['arg1', 'arg2', 'arg3'];
+    rs[methodName] = function (...args) {
+      t.pass('overridden ' + methodName + ' called');
+      t.deepEqual(args, testArgs, methodName + ' called with the correct arguments');
+      t.equal(this, rs, methodName + ' called with the correct this value');
+      return methodName + ' return value';
+    }
+    t.equal(reader[methodName](...testArgs), methodName + ' return value',
+      `reader's ${methodName} returns the return value of the stream's ${methodName}`);
+  }
+});
+
+test('Reading from a reader for an empty stream throws but doesn\'t break anything', t => {
+  var enqueue;
+  var rs = new ReadableStream({
+    start(e) {
+      enqueue = e;
+    }
+  });
+  var reader = rs.getReader();
+
+  t.equal(reader.isActive, true, 'reader is active to start with');
+  t.equal(reader.state, 'waiting', 'reader state is waiting to start with');
+  t.throws(() => reader.read(), /TypeError/, 'calling reader.read() throws a TypeError');
+  t.equal(reader.isActive, true, 'reader is still active');
+  t.equal(reader.state, 'waiting', 'reader state is still waiting');
+
+  enqueue('a');
+
+  reader.ready.then(() => {
+    t.equal(reader.state, 'readable', 'after enqueuing the reader state is readable');
+    t.equal(reader.read(), 'a', 'the enqueued chunk can be read back through the reader');
+    t.end();
+  });
+});
+
+test('Trying to use a released reader should work for ready/state/closed but fail for read/cancel', t => {
+  t.plan(9);
+
+  var rs = new ReadableStream({
+    start(enqueue, close) {
+      enqueue('a');
+      enqueue('b');
+      setTimeout(close, 40);
+    }
+  });
+  var reader = rs.getReader();
+  reader.releaseLock();
+
+  t.equal(reader.isActive, false, 'isActive returns false');
+  t.equal(reader.state, 'readable', 'reader.state returns readable');
+  t.equal(rs.state, 'readable', 'rs.state returns readable');
+
+  t.throws(() => reader.read(), /TypeError/, 'trying to read gives a TypeError');
+  reader.cancel().then(
+    () => t.fail('reader.cancel() should not be fulfilled'),
+    e => t.equal(e.constructor, TypeError, 'reader.cancel() should be rejected with a TypeError')
+  );
+
+  reader.ready.then(() => {
+    t.pass('reader.ready should be fulfilled');
+    t.equal(rs.read(), 'a', 'reading from the stream should give back the first enqueued chunk');
+    t.equal(rs.read(), 'b', 'reading from the stream should give back the second enqueued chunk');
+  });
+  reader.closed.then(() => t.pass('reader.closed should be fulfilled'));
+});
+
+test('cancel() on a reader implicitly releases the reader before calling through', t => {
+  t.plan(3);
+
+  var passedReason = new Error('it wasn\'t the right time, sorry');
+  var rs = new ReadableStream({
+    cancel(reason) {
+      t.equal(reason, passedReason, 'the cancellation reason is passed through to the underlying source');
+    }
+  });
+
+  var reader = rs.getReader();
+  reader.cancel(passedReason).then(
+    () => t.pass('reader.cancel() should fulfill'),
+    e => t.fail('reader.cancel() should not reject')
+  );
+
+  t.equal(reader.isActive, false, 'canceling via the reader should release the reader\'s lock');
+});
+
+test('cancel() on a reader calls this.releaseLock directly instead of cheating', t => {
+  t.plan(3);
+
+  var rs = new ReadableStream();
+
+  var reader = rs.getReader();
+  reader.releaseLock = function (...args) {
+    t.pass('releaseLock was called directly');
+    t.equal(args.length, 0, 'no arguments were passed');
+    t.equal(this, reader, 'the correct this value was passed');
+  };
+
+  reader.cancel();
+});
+
+test('getReader() on a closed stream should fail', t => {
+  var rs = new ReadableStream({
+    start(enqueue, close) {
+      close();
+    }
+  });
+
+  t.equal(rs.state, 'closed', 'the stream should be closed');
+  t.throws(() => rs.getReader(), /TypeError/, 'getReader() threw a TypeError');
+  t.end();
+});
+
+test('getReader() on a cancelled stream should fail (since cancelling closes)', t => {
+  var rs = new ReadableStream();
+  rs.cancel(new Error('fun time is over'));
+
+  t.equal(rs.state, 'closed', 'the stream should be closed');
+  t.throws(() => rs.getReader(), /TypeError/, 'getReader() threw a TypeError');
+  t.end();
+});
+
+test('getReader() on an errored stream should rethrow the error', t => {
+  var theError = new Error('don\'t say i didn\'t warn ya');
+  var rs = new ReadableStream({
+    start(enqueue, close, error) {
+      error(theError);
+    }
+  });
+
+  t.equal(rs.state, 'errored', 'the stream should be errored');
+  t.throws(() => rs.getReader(), /don't say i didn't warn ya/, 'getReader() threw the error');
+  t.end();
+});
+
+test('closed should be fulfilled after reader releases its lock (both .closed accesses after acquiring)', t => {
+  t.plan(2);
+
+  var doClose;
+  var rs = new ReadableStream({
+    start(enqueue, close) {
+      doClose = close;
+    }
+  });
+
+  var reader = rs.getReader();
+  doClose();
+
+  reader.closed.then(() => {
+    t.equal(reader.isActive, false, 'reader is no longer active when reader closed is fulfilled');
+  });
+
+  rs.closed.then(() => {
+    t.equal(reader.isActive, false, 'reader is no longer active when stream closed is fulfilled');
+  });
+});
+
+test('closed should be fulfilled after reader releases its lock (stream .closed access before acquiring)', t => {
+  t.plan(2);
+
+  var doClose;
+  var rs = new ReadableStream({
+    start(enqueue, close) {
+      doClose = close;
+    }
+  });
+
+  rs.closed.then(() => {
+    t.equal(reader.isActive, false, 'reader is no longer active when stream closed is fulfilled');
+  });
+
+  var reader = rs.getReader();
+  doClose();
+
+  reader.closed.then(() => {
+    t.equal(reader.isActive, false, 'reader is no longer active when reader closed is fulfilled');
+  });
+});
+
+test('closed should be fulfilled after reader releases its lock (multiple stream locks)', t => {
+  t.plan(6);
+
+  var doClose;
+  var rs = new ReadableStream({
+    start(enqueue, close) {
+      doClose = close;
+    }
+  });
+
+  var reader1 = rs.getReader();
+
+  rs.closed.then(() => {
+    t.equal(reader1.isActive, false, 'reader1 is no longer active when stream closed is fulfilled');
+    t.equal(reader2.isActive, false, 'reader2 is no longer active when stream closed is fulfilled');
+  });
+
+  reader1.releaseLock();
+
+  var reader2 = rs.getReader();
+  doClose();
+
+  reader1.closed.then(() => {
+    t.equal(reader1.isActive, false, 'reader1 is no longer active when reader1 closed is fulfilled');
+    t.equal(reader2.isActive, false, 'reader2 is no longer active when reader1 closed is fulfilled');
+  });
+
+  reader2.closed.then(() => {
+    t.equal(reader1.isActive, false, 'reader1 is no longer active when reader2 closed is fulfilled');
+    t.equal(reader2.isActive, false, 'reader2 is no longer active when reader2 closed is fulfilled');
+  });
+});
+
+test('Multiple readers can access the stream in sequence', t => {
+  var rs = new ReadableStream({
+    start(enqueue, close) {
+      enqueue('a');
+      enqueue('b');
+      enqueue('c');
+      enqueue('d');
+      enqueue('e');
+      close();
+    }
+  });
+
+  t.equal(rs.read(), 'a', 'reading the first chunk directly from the stream works');
+
+  var reader1 = rs.getReader();
+  t.equal(reader1.read(), 'b', 'reading the second chunk from reader1 works');
+  reader1.releaseLock();
+
+  t.equal(rs.read(), 'c', 'reading the third chunk from the stream after releasing reader1 works');
+
+  var reader2 = rs.getReader();
+  t.equal(reader2.read(), 'd', 'reading the fourth chunk from reader2 works');
+  reader2.releaseLock();
+
+  t.equal(rs.read(), 'e', 'reading the fifth chunk from the stream after releasing reader2 works');
+
+  t.end();
+});
+
+test('A stream that errors has that reflected in the reader and the stream', t => {
+  t.plan(9);
+
+  var error;
+  var rs = new ReadableStream({
+    start(enqueue, close, error_) {
+      error = error_;
+    }
+  });
+
+  var reader = rs.getReader();
+
+  var passedError = new Error('too exclusive');
+  error(passedError);
+
+  t.equal(reader.isActive, false, 'the reader should have lost its lock');
+  t.throws(() => reader.read(), /TypeError/,
+    'reader.read() should throw a TypeError since the reader no longer has a lock');
+  t.equal(reader.state, 'errored', 'the reader\'s state should be errored');
+  reader.ready.then(() => t.pass('reader.ready should fulfill'));
+  reader.closed.then(
+    () => t.fail('reader.closed should not be fulfilled'),
+    e => t.equal(e, passedError, 'reader.closed should be rejected with the stream error')
+  );
+
+  t.throws(() => rs.read(), /too exclusive/, 'rs.read() should throw the stream error');
+  t.equal(rs.state, 'errored', 'the stream\'s state should be errored');
+  rs.ready.then(() => t.pass('rs.ready should fulfill'));
+  rs.closed.then(
+    () => t.fail('rs.closed should not be fulfilled'),
+    e => t.equal(e, passedError, 'rs.closed should be rejected with the stream error')
+  );
+});
+
+test('Cannot use an already-released reader to unlock a stream again', t => {
+  t.plan(2);
+
+  var rs = new ReadableStream();
+
+  var reader1 = rs.getReader();
+  reader1.releaseLock();
+
+  var reader2 = rs.getReader();
+  t.equal(reader2.isActive, true, 'reader2 state is active before releasing reader1');
+
+  reader1.releaseLock();
+  t.equal(reader2.isActive, true, 'reader2 state is still active after releasing reader1 again');
+});


### PR DESCRIPTION
A start at solving #241. /cc @yutakahirano.

Didn't quite get as far as I hoped in terms of spec changes, but got a design doc and reference implementation up. The reference implementation passes all tests except for one, which I will talk about next. There are a lot of tests that need to be written, although the modifications I had to make to existing ones show that this is basically working as desired. The design doc also includes notes on how to optimize.

The test that is failing is the test of using `pipeTo` on ReadableByteStream. This is failing because we only allow `new ExclusiveStreamReader(s)` to work if `s` is a ReadableStream. We do that by checking the existence of the [[reader]] internal slot, which ReadableStreams have but ReadableByteStreams do not.

There are three ways I see of addressing this:
1. Add a slot named [[reader]] to ReadableByteStream, and assume everything "just works." This matches V8 (and possibly other engines), which has "private symbols" it uses and can be shared between classes. However I cannot find any instances of internal slots behaving this way in the ES spec; there is never a case when different classes share the same-named internal slot and algorithms are then meant to apply to both objects the same way. So this is kind of shaky, which leads to:
2. Have two distinct slot names, e.g. [[reader]] and [[byteReader]] or something, and everywhere in the spec that references [[reader]] do some branching logic. Since every single method uses [[reader]] multiple times right now, this would be pretty painful. I think it would basically end up doubling the size of each method. Or we could try to set up some framework ahead of time that allows us to "metaprogram" the slots, e.g. this@[[stream]]@[[_readerSlot_]] or something. This mostly seems to be spec-level pain though, not implementation or developer-facing pain.
3. Allow arbitrary objects to join into the reader party. This is discussed as "Level 3: custom readable stream implementations?" in the design doc. It would mean switching from `new ExclusiveStreamReader(stream)` to `stream.getReader()`, which would be specced as essentially `return new ExclusiveStreamReader(this, { getReader: () => this@[[reader]], setReader: v => this@[[reader]] = v })`. People creating custom readable stream implementations would then implement their own `getReader()` method that does e.g. `return new ExclusiveStreamReader(stream, { getReader: () => this._reader, setReader: v => this._reader = v })` or uses a weak set or some other mechanism of their choosing. This seems a bit more complicated for implementers, although it's presumably possible to optimize and simplify. E.g. maybe the built-in `getReader()` doesn't actually have to call `new ExclusiveStreamReader(...)`; it can just set up a version of the class that is implemented with explicit ties to its progenitor. Referencing the design doc, it gives level 1 developers a slightly different interface, and allows level 3 developers to get locking without reimplementing the entire thing themselves.

I will sleep on this a bit. In the meantime thoughts on choosing an approach, as well as code review on the existing stuff, much appreciated.
