### PR TITLE
First class source sink objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -20,7 +20,7 @@ Logo: https://resources.whatwg.org/logo-streams.svg
 
 <style>
   ol > li { margin: 0; }
-  .note + .example { margin-top: 1em; }
+  .note + .example, .note + .note { margin-top: 1em; }
 </style>
 <script src="https://resources.whatwg.org/file-issue.js" async></script>
 
@@ -1201,13 +1201,7 @@ would look like
 
 <pre><code class="lang-javascript">
   class WritableStream {
-    constructor({
-      start = (error) => {},
-      write = (chunk) => {},
-      close = () => {},
-      abort = (reason) => close(),
-      strategy = %DefaultWritableStreamStrategy%
-    } = {})
+    constructor(underlyingSink = {})
 
     get closed()
     get ready()
@@ -1234,19 +1228,6 @@ Instances of <code>WritableStream</code> are created with the internal slots des
     <td>\[[closedPromise]]
     <td>A promise that becomes fulfilled when the stream becomes <code>"closed"</code>; returned by the
       <code>closed</code> getter
-  </tr>
-  <tr>
-    <td>\[[onAbort]]
-    <td>A function passed to the constructor, meant to abruptly clean up and release access to the <a>underlying
-      sink</a>
-  </tr>
-  <tr>
-    <td>\[[onClose]]
-    <td>A function passed to the constructor, meant to close the the <a>underlying sink</a>
-  </tr>
-  <tr>
-    <td>\[[onWrite]]
-    <td>A function passed to the constructor, meant to write to the <a>underlying sink</a>
   </tr>
   <tr>
     <td>\[[error]]
@@ -1276,12 +1257,12 @@ Instances of <code>WritableStream</code> are created with the internal slots des
       on the stream while in the <code>"errored"</code> state
   </tr>
   <tr>
-    <td>\[[strategy]]
-    <td>An object containing the stream's <a>queuing strategy</a>
-  </tr>
-  <tr>
     <td>\[[readyPromise]]
     <td>A promise returned by the <code>ready</code> getter
+  </tr>
+  <tr>
+    <td>\[[underlyingSink]]
+    <td>An object representation of the stream's <a>underlying sink</a>, including its <a>queuing strategy</a>
   </tr>
   <tr>
     <td>\[[writing]]
@@ -1290,55 +1271,50 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   </tr>
 </table>
 
-<h4 id="ws-constructor">new WritableStream({ start, write, close, abort, strategy } = {})</h4>
+<h4 id="ws-constructor">new WritableStream(underlyingSink = {})</h4>
 
 <div class="note">
-  The constructor is passed several functions, all optional, which govern how the constructed stream instance behaves:
+  The <var>underlyingSink</var> object passed to the constructor can implement any of the following methods to govern
+  how the constructed stream instance behaves:
 
   <ul>
-    <li> <var>start</var>(<var>error</var>) is called immediately, and should perform any actions necessary to acquire
+    <li> <code>start(error)</code> is called immediately, and should perform any actions necessary to acquire
       access to the <a>underlying sink</a>. If this process is asynchronous, it can return a promise to signal success
       or failure.
-    <li> <var>write</var>(<var>chunk</var>) is called when a new <a>chunk</a> of data is ready to be written to the
+    <li> <code>write(chunk)</code> is called when a new <a>chunk</a> of data is ready to be written to the
       <a>underlying sink</a>. It can return a promise to signal success or failure of the write operation. The stream
-      implementation guarantees that this function will be called only after previous writes have succeeded, and never
-      after <var>close</var> or <var>abort</var> is called.
-    <li> <var>close</var>() is called after the producer signals that they are done writing chunks to the stream, and
+      implementation guarantees that this method will be called only after previous writes have succeeded, and never
+      after <code>close</code> or <code>abort</code> is called.
+    <li> <code>close()</code> is called after the producer signals that they are done writing chunks to the stream, and
       all queued-up writes successfully complete. It should perform any actions necessary to finalize writes to the
       <a>underlying sink</a>, and release access to it. If this process is asynchronous, it can return a promise to
-      signal success or failure. The stream implementation guarantees that this function will be called only after all
+      signal success or failure. The stream implementation guarantees that this method will be called only after all
       queued-up writes have succeeded.
-    <li> <var>abort</var>(<var>reason</var>) is called when the producer signals they wish to abruptly close the stream
-      and put it in an <code>"errored"</code> state. It should clean up any held resources, much like <var>close</var>,
-      but perhaps with some custom handling. Unlike <var>close</var>, <var>abort</var> will be called even if writes
-      are queued up; those <a>chunks</a> will be thrown away. If this process is asynchronous, it can return a promise
-      to signal success or failure. If no abort function is passed, by default the <var>close</var> function will be
-      called instead.
+    <li> <code>abort(reason)</code> is called when the producer signals they wish to abruptly close the stream
+      and put it in an <code>"errored"</code> state. It should clean up any held resources, much like
+      <code>close</code>, but perhaps with some custom handling. Unlike <code>close</code>, <var>abort</var> will be
+      called even if writes are queued up; those <a>chunks</a> will be thrown away. If this process is asynchronous, it
+      can return a promise to signal success or failure. If no abort method is passed, by default the
+      <code>close</code> method will be called instead.
   </ul>
+
+  The underlying sink can also have a <code>strategy</code> property containing a <a>queuing strategy</a> object with
+  two methods <code>shouldApplyBackpressure(queueSize)</code> and <code>size(chunk)</code>. These could be instances of
+  the built-in <code>CountQueuingStrategy</code> or <code>ByteLengthQueuingStrategy</code> classes, or custom strategy
+  objects. By default, a strategy that applies backpressure whenever writing into a non-empty queue will be used.
 </div>
 
 <div class="note">
-  Due to the way writable streams asynchronously close, it is possible for both <var>close</var> and <var>abort</var>
-  to be called, in cases where the <a>producer</a> aborts the stream while it is in the <code>"closing"</code> state.
-  Notably, since a stream always spends at least one turn in the <code>"closing"</code> state, code like
-  <code>ws.close(); ws.abort(...);</code> will cause both to be called, even if the <var>close</var> function itself
-  has no asynchronous behavior. A well-designed <a>underlying source</a> should be able to deal with this.
+  Due to the way writable streams asynchronously close, it is possible for both <code>close</code> and
+  <code>abort</code> to be called, in cases where the <a>producer</a> aborts the stream while it is in the
+  <code>"closing"</code> state. Notably, since a stream always spends at least one turn in the <code>"closing"</code>
+  state, code like <code>ws.close(); ws.abort(...);</code> will cause both to be called, even if the <code>close</code>
+  method itself has no asynchronous behavior. A well-designed <a>underlying sink</a> object should be able to deal with
+  this.
 </div>
 
 <ol>
-  <li> If <var>start</var> is <b>undefined</b>, set <var>start</var> to a no-op function.
-  <li> If IsCallable(<var>start</var>) is <b>false</b>, throw a <b>TypeError</b> exception.
-  <li> If <var>write</var> is <b>undefined</b>, set <var>write</var> to a no-op function.
-  <li> If IsCallable(<var>write</var>) is <b>false</b>, throw a <b>TypeError</b> exception.
-  <li> If <var>close</var> is <b>undefined</b>, set <var>close</var> to a no-op function.
-  <li> If IsCallable(<var>close</var>) is <b>false</b>, throw a <b>TypeError</b> exception.
-  <li> If <var>abort</var> is <b>undefined</b>, set <var>abort</var> to <var>close</var>.
-  <li> If IsCallable(<var>abort</var>) is <b>false</b>, throw a <b>TypeError</b> exception.
-  <li> If <var>strategy</var> is <b>undefined</b>, set <var>strategy</var> to %DefaultWritableStreamStrategy%.
-  <li> Set <b>this</b>@\[[onWrite]] to <var>write</var>.
-  <li> Set <b>this</b>@\[[onClose]] to <var>onClose</var>.
-  <li> Set <b>this</b>@\[[onAbort]] to <var>abort</var>.
-  <li> Set <b>this</b>@\[[strategy]] to <var>strategy</var>.
+  <li> Set <b>this</b>@\[[underlyingSink]] to <var>underlyingSink</var>.
   <li> Set <b>this</b>@\[[closedPromise]] to a new promise.
   <li> Set <b>this</b>@\[[readyPromise]] to a new promise resolved with <b>undefined</b>.
   <li> Set <b>this</b>@\[[queue]] to a new empty List.
@@ -1346,7 +1322,8 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   <li> Set <b>this</b>@\[[started]] and <b>this</b>@\[[writing]] to <b>false</b>.
   <li> Set <b>this</b>@\[[error]] to CreateWritableStreamErrorFunction(<b>this</b>).
   <li> Call-with-rethrow SyncWritableStreamStateWithQueue(<b>this</b>).
-  <li> Let <var>startResult</var> be the result calling <var>start</var>(<b>this</b>@\[[error]]).
+  <li> Let <var>startResult</var> be InvokeOrNoop(<var>underlyingSink</var>, <code>"start"</code>,
+    (<b>this</b>@\[[error]])).
   <li> ReturnIfAbrupt(<var>startResult</var>).
   <li> Set <b>this</b>@\[[startedPromise]] to the result of resolving <var>startResult</var> as a promise.
     <ol>
@@ -1430,7 +1407,8 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   <li> If <b>this</b>@\[[state]] is <code>"errored"</code>, return a new promise rejected with
     <b>this</b>@\[[storedError]].
   <li> Call-with-rethrow <b>this</b>@\[[error]](reason).
-  <li> Let <var>sinkAbortPromise</var> be the result of promise-calling <b>this</b>\[[onAbort]](<var>reason</var>).
+  <li> Let <var>sinkAbortPromise</var> be PromiseInvokeOrFallbackOrNoop(<b>this</b>\[[underlyingSink]],
+    <code>"abort"</code>, (<var>reason</var>), <code>"close"</code>, ()).
   <li> Return the result of transforming <var>sinkAbortPromise</var> by a fulfillment handler that returns <b>undefined</b>.
 </ol>
 
@@ -1473,15 +1451,24 @@ Instances of <code>WritableStream</code> are created with the internal slots des
     <b>TypeError</b>.
   <li> If <b>this</b>@\[[state]] is <code>"errored"</code>, return a promise rejected with
     <b>this</b>@\[[storedError]].
-  <li> Assert: <b>this</b>\[[state]] is either <code>"waiting"</code> or <code>"writable"</code>.
-  <li> Let <var>chunkSize</var> be Invoke(<b>this</b>@\[[strategy]], <code>"size"</code>, (<var>chunk</var>)).
-  <li> If <var>chunkSize</var> is an abrupt completion,
+  <li> Assert: <b>this</b>@\[[state]] is either <code>"waiting"</code> or <code>"writable"</code>.
+  <li> Let <var>chunkSize</var> be <b>1</b>.
+  <li> Let <var>strategy</var> be Get(<b>this</b>@\[[underlyingSink]], <code>"strategy"</code>).
+  <li> If <var>strategy</var> is an abrupt completion,
     <ol>
-      <li> Call-with-rethrow <b>this</b>@\[[error]](<var>chunkSize</var>.\[[value]]).
-      <li> Return a new promise rejected with <var>chunkSize</var>.\[[value]].
+      <li> Call-with-rethrow <b>this</b>@\[[error]](<var>strategy</var>.\[[value]]).
+      <li> Return a new promise rejected with <var>strategy</var>.\[[value]].
     </ol>
-  </li>
-  <li> Set <var>chunkSize</var> to <var>chunkSize</var>.\[[value]].
+  <li> Set <var>strategy</var> to <var>strategy</var>.\[[value]].
+  <li> If <var>strategy</var> is not <b>undefined</b>, then
+    <li> Set <var>chunkSize</var> to Invoke(<var>strategy</var>, <code>"size"</code>, (<var>chunk</var>)).
+    <li> If <var>chunkSize</var> is an abrupt completion,
+      <ol>
+        <li> Call-with-rethrow <b>this</b>@\[[error]](<var>chunkSize</var>.\[[value]]).
+        <li> Return a new promise rejected with <var>chunkSize</var>.\[[value]].
+      </ol>
+    </li>
+    <li> Set <var>chunkSize</var> to <var>chunkSize</var>.\[[value]].
   <li> Let <var>promise</var> be a new promise.
   <li> Let <var>writeRecord</var> be Record{\[[promise]]: <var>promise</var>, \[[chunk]]: <var>chunk</var>}.
   <li> Let <var>enqueueResult</var> be EnqueueValueWithSize(<b>this</b>@\[[queue]], <var>writeRecord</var>, <var>chunkSize</var>).
@@ -1520,7 +1507,8 @@ Instances of <code>WritableStream</code> are created with the internal slots des
 
 <ol>
   <li> Assert: <var>stream</var>@\[[state]] is <code>"closing"</code>.
-  <li> Let <var>sinkClosePromise</var> be the result of promise-calling <var>stream</var>@\[[onClose]]().
+  <li> Let <var>sinkClosePromise</var> be PromiseInvokeOrNoop(<var>stream</var>@\[[underlyingSink]],
+    <code>"close"</code>).
     <ol>
       <li> Upon fulfillment,
         <ol>
@@ -1565,9 +1553,15 @@ a variable <var>stream</var>, that performs the following steps:
   <li> Assert: <var>stream</var>@\[[state]] is either <code>"writable"</code> or <code>"waiting"</code>.
   <li> Let <var>queueSize</var> be GetTotalQueueSize(<var>stream</var>@\[[queue]]).
   <li> ReturnIfAbrupt(<var>queueSize</var>).
-  <li> Let <var>shouldApplyBackpressure</var> be ToBoolean(Invoke(<var>stream</var>@\[[strategy]],
-    <code>"shouldApplyBackpressure"</code>, (<var>queueSize</var>))).
-  <li> ReturnIfAbrupt(<var>shouldApplyBackpressure</var>).
+  <li> Let <var>shouldApplyBackpressure</var> be <b>true</b> if <var>queueSize</var> > 0, and <b>false</b> otherwise.
+  <li> Let <var>strategy</var> be Get(<var>stream</var>@\[[underlyingSink]], <code>"strategy"</code>).
+  <li> ReturnIfAbrupt(<var>strategy</var>).
+  <li> If <var>strategy</var> is not <b>undefined</b>, then
+    <ol>
+      <li> Set <var>shouldApplyBackpressure</var> to ToBoolean(Invoke(<var>strategy</var>,
+        <code>"shouldApplyBackpressure"</code>, (<var>queueSize</var>))).
+      <li> ReturnIfAbrupt(<var>shouldApplyBackpressure</var>).
+    </ol>
   <li> If <var>shouldApplyBackpressure</var> is <b>true</b> and <var>stream</var>@\[[state]] is
     <code>"writable"</code>, then
     <ol>
@@ -1597,43 +1591,21 @@ a variable <var>stream</var>, that performs the following steps:
       <li> Return CloseWritableStream(<var>stream</var>).
     </ol>
   <li> Set <var>stream</var>@\[[writing]] to <b>true</b>.
-  <li> Promise-call <var>stream</var>@\[[onWrite]](<var>writeRecord</var>.\[[chunk]]).
+  <li> Let <var>writeResult</var> be PromiseInvokeOrNoop(<var>stream</var>@\[[underlyingSink]], <code>"write"</code>,
+    (<var>writeRecord</var>.\[[chunk]])).
+  <li> Upon fulfillment of <var>writeResult</var>,
     <ol>
-      <li> Upon fulfillment,
-        <ol>
-          <li> If <var>stream</var>@\[[state]] is <code>"errored"</code>, return.
-          <li> Set <var>stream</var>@\[[writing]] to <b>false</b>.
-          <li> Resolve <var>writeRecord</var>.\[[promise]] with <b>undefined</b>.
-          <li> DequeueValue(<var>stream</var>@\[[queue]]).
-          <li> Let <var>syncResult</var> be SyncWritableStreamStateWithQueue(<var>stream</var>).
-          <li> If <var>syncResult</var> is an abrupt completion, then call-with-rethrow
-            <var>stream</var>@\[[error]](<var>syncResult</var>.\[[value]]).
-          <li> Otherwise, return WritableStreamAdvanceQueue(<var>stream</var>).
-        </ol>
-      <li> Upon rejection with reason <var>r</var>, call-with-rethrow <var>stream</var>@\[[error]](<var>r</var>).
+      <li> If <var>stream</var>@\[[state]] is <code>"errored"</code>, return.
+      <li> Set <var>stream</var>@\[[writing]] to <b>false</b>.
+      <li> Resolve <var>writeRecord</var>.\[[promise]] with <b>undefined</b>.
+      <li> DequeueValue(<var>stream</var>@\[[queue]]).
+      <li> Let <var>syncResult</var> be SyncWritableStreamStateWithQueue(<var>stream</var>).
+      <li> If <var>syncResult</var> is an abrupt completion, then call-with-rethrow
+        <var>stream</var>@\[[error]](<var>syncResult</var>.\[[value]]).
+      <li> Otherwise, return WritableStreamAdvanceQueue(<var>stream</var>).
     </ol>
-</ol>
-
-<h3 id="default-ws-strategy">%DefaultWritableStreamStrategy%</h3>
-
-%DefaultWritableStreamStrategy% is a well-known intrinsic object representing the default <a>queuing strategy</a> for
-<a>writable streams</a>. It has two methods.
-
-<div class="note">
-  As with %DefaultReadableStreamStrategy%, this object is simply a spec device, and its existence is not observable.
-</div>
-
-<h4 id="default-ws-strategy-should-apply-backpressure">shouldApplyBackpressure(queueSize)</h4>
-
-<ol>
-  <li> Assert: <var>queueSize</var> is a non-<b>NaN</b> number.</li>
-  <li> Return <var>queueSize</var> > 0.
-</ol>
-
-<h4 id="default-ws-strategy-size">size()</h4>
-
-<ol>
-  <li> Return 1.
+  <li> Upon rejection of <var>writeResult</var> with reason <var>r</var>, call-with-rethrow
+    <var>stream</var>@\[[error]](<var>r</var>).
 </ol>
 
 <h2 id="ts">Transform Streams</h2>

--- a/index.bs
+++ b/index.bs
@@ -150,6 +150,8 @@ based the total size of all chunks in the stream's internal queue.
   backpressure signal.
 </div>
 
+A queuing strategy is generally associated with a specific type of <a>underlying source</a> or <a>underlying sink</a>.
+
 <h3 id="locking">Locking</h3>
 
 <!-- TODO: writable streams too, probably -->
@@ -384,12 +386,7 @@ would look like
 
 <pre><code class="lang-javascript">
   class ReadableStream {
-    constructor({
-      start = (enqueue, close, error) => {},
-      pull = (enqueue, close, error) => {},
-      cancel = (reason) => {},
-      strategy = %DefaultReadableStreamStrategy%
-    } = {})
+    constructor(underlyingSource = {})
 
     get closed()
     get ready()
@@ -439,14 +436,6 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
       <code>"errored"</code> state
   </tr>
   <tr>
-    <td>\[[onCancel]]
-    <td>A function passed to the constructor, meant to clean up and release access to the <a>underlying source</a>
-  </tr>
-  <tr>
-    <td>\[[onPull]]
-    <td>A function passed to the constructor, meant to pull more data from the <a>underlying source</a>
-  </tr>
-  <tr>
     <td>\[[pulling]]
     <td>A boolean flag indicating whether data is currently being pulled from the underlying sink
   </tr>
@@ -472,48 +461,46 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
       on the stream while in the <code>"errored"</code> state
   </tr>
   <tr>
-    <td>\[[strategy]]
-    <td>An object containing the stream's <a>queuing strategy</a>
-  </tr>
-  <tr>
     <td>\[[readyPromise]]
     <td>A promise returned by the <code>ready</code> getter
   </tr>
+  <tr>
+    <td>\[[underlyingSource]]
+    <td>An object representation of the stream's <a>underlying source</a>, including its <a>queuing strategy</a>
+  </tr>
 </table>
 
-<h4 id="rs-constructor">new ReadableStream({ start, pull, cancel, strategy } = {})</h4>
+<h4 id="rs-constructor">new ReadableStream(underlyingSource = {})</h4>
 
 <div class="note">
-  The constructor is passed several functions, all optional, which govern how the constructed stream instance behaves:
+  The <var>underlyingSource</var> object passed to the constructor can implement any of the following methods to
+  govern how the constructed stream instance behaves:
 
   <ul>
-    <li> <var>start</var>(<var>enqueue</var>, <var>close</var>, <var>error</var>) is called immediately, and is
-      typically used to adapt a <a>push source</a> by setting up relevant event listeners, or to acquire access to a
-      <a>pull source</a>. If this process is asynchronous, it can return a promise to signal success or failure.
-    <li> <var>pull</var>(<var>enqueue</var>, <var>close</var>, <var>error</var>) is called when the stream's internal
-      queue of chunks is depleted, and the consumer has signaled that they wish to consume more data. Once it is
-      called, it will not be called again until the passed <var>enqueue</var> callback is called.
-    <li> <var>cancel</var>(<var>reason</var>) is called when the consumer signals that they are no longer interested
-      in the stream. It should perform any actions necessary to release access to the <a>underlying source</a>. If this
+    <li> <code>start(enqueue, close, error)</code> is called immediately, and is typically used to adapt a <a>push
+      source</a> by setting up relevant event listeners, or to acquire access to a <a>pull source</a>. If this process
+      is asynchronous, it can return a promise to signal success or failure.
+    <li> <code>pull(enqueue, close, error)</code> is called when the stream's internal queue of chunks is depleted, and
+      the consumer has signaled that they wish to consume more data. Once it is called, it will not be called again
+      until the passed <code>enqueue</code> callback is called.
+    <li> <code>cancel(reason)</code> is called when the consumer signals that they are no longer interested in the
+      stream. It should perform any actions necessary to release access to the <a>underlying source</a>. If this
       process is asynchronous, it can return a promise to signal success or failure.
   </ul>
 
-  Both <var>start</var> and <var>pull</var> are given the ability to manipulate the stream's internal queue and state
-  via the passed <var>enqueue</var>, <var>close</var>, and <var>error</var> callbacks. This is an example of the
-  <a href="http://domenic.me/2014/02/13/the-revealing-constructor-pattern/">revealing constructor pattern</a>.
+  Both <code>start</code> and <code>pull</code> are given the ability to manipulate the stream's internal queue and
+  state via the passed <code>enqueue</code>, <code>close</code>, and <code>error</code> callbacks. This is an example
+  of the <a href="https://blog.domenic.me/the-revealing-constructor-pattern/">revealing constructor pattern</a>.
+
+  The underlying source can also have a <code>strategy</code> property containing a <a>queuing strategy</a> object with
+  two methods <code>shouldApplyBackpressure(queueSize)</code> and <code>size(chunk)</code>. These could be instances of
+  the built-in <code>CountQueuingStrategy</code> or <code>ByteLengthQueuingStrategy</code> classes, or custom strategy
+  objects. If no strategy is supplied, the default behavior will be to apply backpressure (via the return value of
+  <code>enqueue</code>) when enqueuing into a non-empty queue.
 </div>
 
 <ol>
-  <li> If <var>start</var> is <b>undefined</b>, set <var>start</var> to a no-op function.
-  <li> If IsCallable(<var>start</var>) is <b>false</b>, throw a <b>TypeError</b> exception.
-  <li> If <var>pull</var> is <b>undefined</b>, set <var>pull</var> to a no-op function.
-  <li> If IsCallable(<var>pull</var>) is <b>false</b>, throw a <b>TypeError</b> exception.
-  <li> If <var>cancel</var> is <b>undefined</b>, set <var>cancel</var> to a no-op function.
-  <li> If IsCallable(<var>cancel</var>) is <b>false</b>, throw a <b>TypeError</b> exception.
-  <li> If <var>strategy</var> is <b>undefined</b>, set <var>strategy</var> to %DefaultReadableStreamStrategy%.
-  <li> Set <b>this</b>@\[[onPull]] to <var>pull</var>.
-  <li> Set <b>this</b>@\[[onCancel]] to <var>cancel</var>.
-  <li> Set <b>this</b>@\[[strategy]] to <var>strategy</var>.
+  <li> Set <b>this</b>@\[[underlyingSource]] to <var>underlyingSource</var>.
   <li> Set <b>this</b>@\[[readyPromise]] and <b>this</b>@\[[closedPromise]] to new promises.
   <li> Set <b>this</b>@\[[queue]] to a new empty List.
   <li> Set <b>this</b>@\[[state]] to <code>"waiting"</code>.
@@ -522,8 +509,8 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   <li> Set <b>this</b>@\[[enqueue]] to CreateReadableStreamEnqueueFunction(<b>this</b>).
   <li> Set <b>this</b>@\[[close]] to CreateReadableStreamCloseFunction(<b>this</b>).
   <li> Set <b>this</b>@\[[error]] to CreateReadableStreamErrorFunction(<b>this</b>).
-  <li> Let <var>startResult</var> be the result of calling <var>start</var>(<b>this</b>@\[[enqueue]],
-    <b>this</b>@\[[close]], <b>this</b>@\[[error]]).
+  <li> Let <var>startResult</var> be InvokeOrNoop(<var>underlyingSource</var>, <code>"start"</code>,
+    (<b>this</b>@\[[enqueue]], <b>this</b>@\[[close]], <b>this</b>@\[[error]])).
   <li> ReturnIfAbrupt(<var>startResult</var>).
   <li> Resolve <var>startResult</var> as a promise:
     <ol>
@@ -610,7 +597,8 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   <li> If <b>this</b>@\[[state]] is <code>"waiting"</code>, resolve <b>this</b>@\[[readyPromise]] with <b>undefined</b>.
   <li> Let <b>this</b>@\[[queue]] be a new empty List.
   <li> Call-with-rethrow CloseReadableStream(<b>this</b>).
-  <li> Let <var>sourceCancelPromise</var> be the result of promise-calling <b>this</b>@\[[onCancel]](<var>reason</var>).
+  <li> Let <var>sourceCancelPromise</var> be PromiseInvokeOrNoop(<b>this</b>@\[[underlyingSource]],
+    <code>"cancel"</code>, (<var>reason</var>)).
   <li> Return the result of transforming <var>sourceCancelPromise</var> by a fulfillment handler that returns <b>undefined</b>.
 </ol>
 
@@ -899,8 +887,8 @@ The <code>length</code> property of the <code>cancel</code> method is <b>1</b>.
   <li> Let <var>shouldApplyBackpressure</var> be ShouldReadableStreamApplyBackpressure(<var>stream</var>).
   <li> If <var>shouldApplyBackpressure</var> is <b>true</b>, return <b>undefined</b>.
   <li> Set <var>stream</var>@\[[pulling]] to <b>true</b>.
-  <li> Let <var>pullResult</var> be the result of calling <var>stream</var>@\[[onPull]](<var>stream</var>@\[[enqueue]],
-    <var>stream</var>@\[[close]], <var>stream</var>@\[[error]]).
+  <li> Let <var>pullResult</var> be InvokeOrNoop(<var>stream</var>@\[[underlyingSource]], <code>"pull"</code>,
+    (<var>stream</var>@\[[enqueue]], <var>stream</var>@\[[close]], <var>stream</var>@\[[error]]).
   <li> If <var>pullResult</var> is an abrupt completion,
     <ol>
       <li> Call-with-rethrow <var>stream</var>@\[[error]](<var>pullResult</var>.\[[value]]).
@@ -912,8 +900,8 @@ The <code>length</code> property of the <code>cancel</code> method is <b>1</b>.
 <h4 id="close-readable-stream">CloseReadableStream ( stream )</h4>
 
 <ol>
-  <li> Set <var>stream</stream>@\[[state]] to <code>"closed"</code>.
-  <li> Resolve <var>stream</stream>@\[[closedPromise]] with <b>undefined</b>.
+  <li> Set <var>stream</var>@\[[state]] to <code>"closed"</code>.
+  <li> Resolve <var>stream</var>@\[[closedPromise]] with <b>undefined</b>.
   <li> If <var>stream</var>@\[[readableStreamReader]] is not <b>undefined</b>, call-with-rethrow Invoke(<var>stream</var>@\[[readableStreamReader]], <code>"releaseLock"</code>).
   <li> Return <b>undefined</b>.
 </ol>
@@ -952,11 +940,23 @@ closing over a variable <var>stream</var>, that performs the following steps:
   <li> If <var>stream</var>@\[[state]] is <code>"errored"</code>, throw <var>stream</var>@\[[storedError]].
   <li> If <var>stream</var>@\[[state]] is <code>"closed"</code>, throw a <b>TypeError</b> exception.
   <li> If <var>stream</var>@\[[draining]] is <b>true</b>, throw a <b>TypeError</b> exception.
-  <li> Let <var>chunkSize</var> be Invoke(<var>stream</var>@\[[strategy]], <code>"size"</code>, (<var>chunk</var>)).
-  <li> If <var>chunkSize</var> is an abrupt completion,
+  <li> Let <var>chunkSize</var> be <b>1</b>.
+  <li> Let <var>strategy</var> be Get(<var>stream</var>@\[[underlyingSource]], <code>"strategy"</code>).
+  <li> If <var>strategy</var> is an abrupt completion,
     <ol>
-      <li> Call-with-rethrow <var>stream</var>@\[[error]](<var>chunkSize</var>.\[[value]]).
-      <li> Return <var>chunkSize</var>.
+      <li> Call-with-rethrow <var>stream</var>@\[[error]](<var>strategy</var>.\[[value]]).
+      <li> Return <var>strategy</var>.
+    </ol>
+  <li> Let <var>strategy</var> be <var>strategy</var>.\[[value]].
+  <li> If <var>strategy</var> is not <b>undefined</b>, then
+    <ol>
+      <li> Set <var>chunkSize</var> to Invoke(<var>strategy</var>, <code>"size"</code>, (<var>chunk</var>)).
+      <li> If <var>chunkSize</var> is an abrupt completion,
+        <ol>
+          <li> Call-with-rethrow <var>stream</var>@\[[error]](<var>chunkSize</var>.\[[value]]).
+          <li> Return <var>chunkSize</var>.
+        </ol>
+      <li> Let <var>chunkSize</var> be <var>chunkSize</var>.\[[value]].
     </ol>
   <li>Call-with-rethrow EnqueueValueWithSize(<var>stream</var>@\[[queue]], <var>chunk</var>,
     <var>chunkSize</var>.\[[value]]).
@@ -1018,38 +1018,23 @@ a variable <var>stream</var>, that performs the following steps:
 <ol>
   <li> Let <var>queueSize</var> be GetTotalQueueSize(<var>stream</var>@\[[queue]]).
   <li> ReturnIfAbrupt(<var>queueSize</var>).
-  <li> Let <var>shouldApplyBackpressure</var> be ToBoolean(Invoke(<var>stream</var>@\[[strategy]],
-    <code>"shouldApplyBackpressure"</code>, (<var>queueSize</var>))).
-  <li> If <var>shouldApplyBackpressure</var> is an abrupt completion,
+  <li> Let <var>shouldApplyBackpressure</var> be <b>true</b> if <var>queueSize</var> > <b>1</b>, and <b>false</b>
+    otherwise.
+  <li> Let <var>strategy</var> be Get(<var>stream</var>@\[[underlyingSource]], <code>"strategy"</code>).
+  <li> If <var>strategy</var> is an abrupt completion,
     <ol>
-      <li> Call-with-rethrow <var>stream</var>@\[[error]](<var>shouldApplyBackpressure</var>.\[[value]]).
-      <li> Return <var>shouldApplyBackpressure</var>.
+      <li> Call-with-rethrow <var>stream</var>@\[[error]](<var>strategy</var>.\[[value]]).
+      <li> Return <var>strategy</var>.
     </ol>
-  <li> Otherwise, return <var>shouldApplyBackpressure</var>.\[[value]].
-</ol>
-
-<h3 id="default-rs-strategy">%DefaultReadableStreamStrategy%</h3>
-
-%DefaultReadableStreamStrategy% is a well-known intrinsic object representing the default <a>queuing strategy</a> for
-<a>readable streams</a>. It has two methods.
-
-<div class="note">
-  The existence of an independent object for the default readable stream queuing strategy is not actually observable.
-  Thus, implementations could implement this default strategy by other means, e.g. by incorporating the default logic
-  into the readable stream algorithms themselves.
-</div>
-
-<h4 id="default-rs-strategy-should-apply-backpressure">shouldApplyBackpressure(queueSize)</h4>
-
-<ol>
-  <li> Assert: <var>queueSize</var> is a non-<b>NaN</b> number.</li>
-  <li> Return <var>queueSize</var> > 1.
-</ol>
-
-<h4 id="default-rs-strategy-size">size()</h4>
-
-<ol>
-  <li> Return 1.
+  <li> Let <var>strategy</var> be <var>strategy</var>.\[[value]].
+  <li> If <var>strategy</var> is not <b>undefined</b>, then
+    <ol>
+      <li> Set <var>shouldApplyBackpressure</var> to ToBoolean(Invoke(<var>strategy</var>,
+        <code>"shouldApplyBackpressure"</code>, (<var>queueSize</var>))).
+      <li> If <var>shouldApplyBackpressure</var> is an abrupt completion, call-with-rethrow
+        <var>stream</var>@\[[error]](<var>shouldApplyBackpressure</var>.\[[value]]).
+    </ol>
+  <li> Return <var>shouldApplyBackpressure</var>.
 </ol>
 
 <h2 id="ws">Writable Streams</h2>
@@ -1861,6 +1846,46 @@ throughout the rest of this standard.
   <li> Assert: <var>queue</var> is not empty.
   <li> Let <var>pair</var> be the first element of <var>queue</var>.
   <li> Return <var>pair</var>.\[[value]].
+</ol>
+
+<h3 id="misc-abstract-ops">Miscellaneous Operations</h3>
+
+A few abstract operations are used in this specification for utility purposes. We define them here.
+
+<h4 id="invoke-or-noop">InvokeOrNoop ( O, P, args )</h4>
+
+<div class="note">
+  InvokeOrNoop is a slight modification of the [[!ECMASCRIPT]]
+  <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-invoke">Invoke</a> abstract operation to return
+  <b>undefined</b> when the method is not present.
+</div>
+
+<ol>
+  <li> Assert: <var>P</var> is a valid property key.
+  <li> Let <var>method</var> be GetV(<var>O</var>, <var>P</var>).
+  <li> ReturnIfAbrupt(<var>method</var>).
+  <li> If <var>method</var> is <b>undefined</b>, return <b>undefined</b>.
+  <li> Return Call(<var>method</var>, <var>O</var>, <var>args</var>).
+</ol>
+
+<h4 id="promise-invoke-or-noop">PromiseInvokeOrNoop ( O, P, args )</h4>
+
+<div class="note">
+  PromiseInvokeOrNoop is a specialized version of
+  <a href="http://www.w3.org/2001/tag/doc/promises-guide#promise-calling">promise-calling</a> that both works on
+  methods and returns a promise for <b>undefined</b> when the method is not present.
+</div>
+
+<ol>
+  <li> Assert: <var>P</var> is a valid property key.
+  <li> Let <var>method</var> be GetV(<var>O</var>, <var>P</var>).
+  <li> If <var>method</var> is an abrupt completion, return a new promise rejected with <var>method</var>.\[[value]].
+  <li> Let <var>method</var> be <var>method</var>.\[[value]].
+  <li> If <var>method</var> is <b>undefined</b>, return a new promise resolved with <b>undefined</b>.
+  <li> Let <var>returnValue</var> be Call(<var>method</var>, <var>O</var>, <var>args</var>).
+  <li> If <var>returnValue</var> is an abrupt completion, return a new promise rejected with
+    <var>returnValue</var>.\[[value]].
+  <li> Otherwise, return a new promise resolved with <var>returnValue</var>.\[[value]].
 </ol>
 
 <h2 id="subclassing">Subclassing Streams</h2>

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -49,3 +49,22 @@ export function PromiseInvokeOrNoop(O, P, args) {
     return Promise.reject(e);
   }
 }
+
+export function PromiseInvokeOrFallbackOrNoop(O, P1, args1, P2, args2) {
+  var method;
+  try {
+    method = O[P1];
+  } catch (methodE) {
+    return Promise.reject(methodE);
+  }
+
+  if (method === undefined) {
+    return PromiseInvokeOrNoop(O, P2, args2);
+  }
+
+  try {
+    return Promise.resolve(method.apply(O, args1));
+  } catch (e) {
+    return Promise.reject(e);
+  }
+}

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -22,3 +22,30 @@ export function toInteger(v) {
 
   return Math.floor(Math.abs(v));
 }
+
+export function InvokeOrNoop(O, P, args) {
+  var method = O[P];
+  if (method === undefined) {
+    return undefined;
+  }
+  return method.apply(O, args);
+}
+
+export function PromiseInvokeOrNoop(O, P, args) {
+  var method;
+  try {
+    method = O[P];
+  } catch (methodE) {
+    return Promise.reject(methodE);
+  }
+
+  if (method === undefined) {
+    return Promise.resolve(undefined);
+  }
+
+  try {
+    return Promise.resolve(method.apply(O, args));
+  } catch (e) {
+    return Promise.reject(e);
+  }
+}

--- a/reference-implementation/test/bad-underlying-sinks.js
+++ b/reference-implementation/test/bad-underlying-sinks.js
@@ -1,0 +1,314 @@
+var test = require('tape');
+
+import WritableStream from '../lib/writable-stream';
+
+test('Throwing underlying sink start getter', t => {
+  var theError = new Error('a unique string');
+
+  t.throws(() => {
+    new WritableStream({
+      get start() {
+        throw theError;
+      }
+    });
+  }, /a unique string/);
+  t.end();
+});
+
+test('Throwing underlying sink start method', t => {
+  var theError = new Error('a unique string');
+
+  t.throws(() => {
+    new WritableStream({
+      start() {
+        throw theError;
+      }
+    });
+  }, /a unique string/);
+  t.end();
+});
+
+test('Throwing underlying source write getter', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var ws = new WritableStream({
+    get write() {
+      throw theError;
+    }
+  });
+
+  ws.write('a').then(
+    () => t.fail('write should not fulfill'),
+    r => t.equal(r, theError, 'write should reject with the thrown error')
+  );
+
+  ws.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source write method', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var ws = new WritableStream({
+    write() {
+      throw theError;
+    }
+  });
+
+  ws.write('a').then(
+    () => t.fail('write should not fulfill'),
+    r => t.equal(r, theError, 'write should reject with the thrown error')
+  );
+
+  ws.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying sink abort getter', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var abortReason = new Error('different string');
+  var ws = new WritableStream({
+    get abort() {
+      throw theError;
+    }
+  });
+
+  ws.abort(abortReason).then(
+    () => t.fail('abort should not fulfill'),
+    r => t.equal(r, theError, 'abort should reject with the abort reason')
+  );
+
+  ws.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, abortReason, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying sink abort method', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var abortReason = new Error('different string');
+  var ws = new WritableStream({
+    abort() {
+      throw theError;
+    }
+  });
+
+  ws.abort(abortReason).then(
+    () => t.fail('abort should not fulfill'),
+    r => t.equal(r, theError, 'abort should reject with the abort reason')
+  );
+
+  ws.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, abortReason, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying sink close getter', t => {
+  t.plan(1);
+
+  var theError = new Error('a unique string');
+  var ws = new WritableStream({
+    get close() {
+      throw theError;
+    }
+  });
+
+  ws.close().then(
+    () => t.fail('close should not fulfill'),
+    r => t.equal(r, theError, 'close should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying sink close method', t => {
+  t.plan(1);
+
+  var theError = new Error('a unique string');
+  var ws = new WritableStream({
+    close() {
+      throw theError;
+    }
+  });
+
+  ws.close().then(
+    () => t.fail('close should not fulfill'),
+    r => t.equal(r, theError, 'close should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source strategy getter: initial construction', t => {
+  var theError = new Error('a unique string');
+
+  t.throws(() => {
+    new WritableStream({
+      get strategy() {
+        throw theError;
+      }
+    });
+  }, /a unique string/);
+  t.end();
+});
+
+test('Throwing underlying source strategy getter: first write', t => {
+  t.plan(2);
+
+  var counter = 0;
+  var theError = new Error('a unique string');
+  var ws = new WritableStream({
+    get strategy() {
+      ++counter;
+      if (counter === 1) {
+        return {
+          size() {
+            return 1;
+          },
+          shouldApplyBackpressure() {
+            return true;
+          }
+        };
+      }
+
+      throw theError;
+    }
+  });
+
+  ws.write('a').then(
+    () => t.fail('write should not fulfill'),
+    r => t.equal(r, theError, 'write should reject with the thrown error')
+  );
+
+  ws.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source strategy.size getter: initial construction', t => {
+  t.doesNotThrow(() => {
+    new WritableStream({
+      strategy: {
+        get size() {
+          throw new Error('boo');
+        },
+        shouldApplyBackpressure() {
+          return true;
+        }
+      }
+    });
+  });
+  t.end();
+});
+
+test('Throwing underlying source strategy.size method: initial construction', t => {
+  t.doesNotThrow(() => {
+    new WritableStream({
+      strategy: {
+        size() {
+          throw new Error('boo');
+        },
+        shouldApplyBackpressure() {
+          return true;
+        }
+      }
+    });
+  });
+  t.end();
+});
+
+test('Throwing underlying source strategy.size getter: first write', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var ws = new WritableStream({
+    strategy: {
+      get size() {
+        throw theError;
+      },
+      shouldApplyBackpressure() {
+        return true;
+      }
+    }
+  });
+
+  ws.write('a').then(
+    () => t.fail('write should not fulfill'),
+    r => t.equal(r, theError, 'write should reject with the thrown error')
+  );
+
+  ws.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source strategy.size method: first write', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var ws = new WritableStream({
+    strategy: {
+      size() {
+        throw theError;
+      },
+      shouldApplyBackpressure() {
+        return true;
+      }
+    }
+  });
+
+  ws.write('a').then(
+    () => t.fail('write should not fulfill'),
+    r => t.equal(r, theError, 'write should reject with the thrown error')
+  );
+
+  ws.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source strategy.shouldApplyBackpressure getter: initial construction', t => {
+  var theError = new Error('a unique string');
+
+  t.throws(() => {
+    new WritableStream({
+      strategy: {
+        size() {
+          return 1;
+        },
+        get shouldApplyBackpressure() {
+          throw theError;
+        }
+      }
+    });
+  }, /a unique string/);
+  t.end();
+});
+
+test('Throwing underlying source strategy.shouldApplyBackpressure method: initial construction', t => {
+  var theError = new Error('a unique string');
+
+  t.throws(() => {
+    new WritableStream({
+      strategy: {
+        size() {
+          return 1;
+        },
+        shouldApplyBackpressure() {
+          throw theError;
+        }
+      }
+    });
+  }, /a unique string/);
+  t.end();
+});

--- a/reference-implementation/test/bad-underlying-sources.js
+++ b/reference-implementation/test/bad-underlying-sources.js
@@ -1,0 +1,239 @@
+var test = require('tape');
+
+import ReadableStream from '../lib/readable-stream';
+
+test('Throwing underlying source start getter', t => {
+  var theError = new Error('a unique string');
+
+  t.throws(() => {
+    new ReadableStream({
+      get start() {
+        throw theError;
+      }
+    });
+  }, /a unique string/);
+  t.end();
+});
+
+test('Throwing underlying source start method', t => {
+  var theError = new Error('a unique string');
+
+  t.throws(() => {
+    new ReadableStream({
+      start() {
+        throw theError;
+      }
+    });
+  }, /a unique string/);
+  t.end();
+});
+
+test('Throwing underlying source pull getter (initial pull)', t => {
+  t.plan(1);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    get pull() {
+      throw theError;
+    }
+  });
+
+  rs.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source pull method (initial pull)', t => {
+  t.plan(1);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    pull() {
+      throw theError;
+    }
+  });
+
+  rs.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source pull getter (second pull)', t => {
+  t.plan(3);
+
+  var theError = new Error('a unique string');
+  var counter = 0;
+  var rs = new ReadableStream({
+    get pull() {
+      ++counter;
+      if (counter === 1) {
+        return enqueue => enqueue('a');
+      }
+
+      throw theError;
+    }
+  });
+
+  rs.ready.then(() => {
+    t.equal(rs.state, 'readable', 'sanity check: the stream becomes readable without issue');
+
+    t.throws(() => rs.read(), /a unique string/, 'reading triggers a pull, and the error is re-thrown');
+  });
+
+  rs.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source pull method (second pull)', t => {
+  t.plan(3);
+
+  var theError = new Error('a unique string');
+  var counter = 0;
+  var rs = new ReadableStream({
+    pull(enqueue) {
+      ++counter;
+      if (counter === 1) {
+        enqueue('a');
+      } else {
+        throw theError;
+      }
+    }
+  });
+
+  rs.ready.then(() => {
+    t.equal(rs.state, 'readable', 'sanity check: the stream becomes readable without issue');
+
+    t.throws(() => rs.read(), /a unique string/, 'reading triggers a pull, and the error is re-thrown');
+  });
+
+  rs.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r, theError, 'closed should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source cancel getter', t => {
+  t.plan(1);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    get cancel() {
+      throw theError;
+    }
+  });
+
+  rs.cancel().then(
+    () => t.fail('cancel should not fulfill'),
+    r => t.equal(r, theError, 'cancel should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source cancel method', t => {
+  t.plan(1);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    cancel() {
+      throw theError;
+    }
+  });
+
+  rs.cancel().then(
+    () => t.fail('cancel should not fulfill'),
+    r => t.equal(r, theError, 'cancel should reject with the thrown error')
+  );
+});
+
+test('Throwing underlying source strategy getter', t => {
+  var theError = new Error('a unique string');
+
+  new ReadableStream({
+    start(enqueue) {
+      t.throws(() => enqueue('a'), /a unique string/);
+      t.end();
+    },
+    get strategy() {
+      throw theError;
+    }
+  });
+});
+
+test('Throwing underlying source strategy.size getter', t => {
+  var theError = new Error('a unique string');
+
+  new ReadableStream({
+    start(enqueue) {
+      t.throws(() => enqueue('a'), /a unique string/);
+      t.end();
+    },
+    strategy: {
+      get size() {
+        throw theError;
+      },
+      shouldApplyBackpressure() {
+        return true;
+      }
+    }
+  });
+});
+
+test('Throwing underlying source strategy.size method', t => {
+  var theError = new Error('a unique string');
+
+  new ReadableStream({
+    start(enqueue) {
+      t.throws(() => enqueue('a'), /a unique string/);
+      t.end();
+    },
+    strategy: {
+      size() {
+        throw theError;
+      },
+      shouldApplyBackpressure() {
+        return true;
+      }
+    }
+  });
+});
+
+test('Throwing underlying source strategy.shouldApplyBackpressure getter', t => {
+  var theError = new Error('a unique string');
+
+  new ReadableStream({
+    start(enqueue) {
+      t.throws(() => enqueue('a'), /a unique string/);
+      t.end();
+    },
+    strategy: {
+      size() {
+        return 1;
+      },
+      get shouldApplyBackpressure() {
+        throw theError;
+      }
+    }
+  });
+});
+
+test('Throwing underlying source strategy.shouldApplyBackpressure method', t => {
+  var theError = new Error('a unique string');
+
+  new ReadableStream({
+    start(enqueue) {
+      t.throws(() => enqueue('a'), /a unique string/);
+      t.end();
+    },
+    strategy: {
+      size() {
+        return 1;
+      },
+      shouldApplyBackpressure() {
+        throw theError;
+      }
+    }
+  });
+});

--- a/reference-implementation/test/readable-stream.js
+++ b/reference-implementation/test/readable-stream.js
@@ -594,3 +594,34 @@ test('ReadableStream cancel() and closed on an errored stream should return the 
   t.equal(rs.cancel(), rs.closed, 'the promises returned should be the same');
   t.end();
 });
+
+test('ReadableStream should call underlying source methods as methods', t => {
+  t.plan(6);
+
+  class Source {
+    start(enqueue) {
+      t.equal(this, theSource, 'start() should be called with the correct this');
+      enqueue('a');
+    }
+
+    pull() {
+      t.equal(this, theSource, 'pull() should be called with the correct this');
+    }
+
+    cancel() {
+      t.equal(this, theSource, 'cancel() should be called with the correct this');
+    }
+
+    get strategy() {
+      // Called three times
+      t.equal(this, theSource, 'strategy getter should be called with the correct this');
+      return undefined;
+    }
+  }
+
+  var theSource = new Source();
+  theSource.debugName = "the source object passed to the constructor";
+  var rs = new ReadableStream(theSource);
+
+  rs.ready.then(() => rs.cancel());
+});

--- a/reference-implementation/test/writable-stream-abort.js
+++ b/reference-implementation/test/writable-stream-abort.js
@@ -226,3 +226,15 @@ test('Aborting a WritableStream after it is closed is a no-op', t => {
     t.equal(ws.state, 'closed', 'state stays closed');
   }, 0);
 });
+
+test('WritableStream should call underlying sink\'s close if no abort is supplied', t => {
+  t.plan(1);
+
+  var ws = new WritableStream({
+    close() {
+      t.equal(arguments.length, 0, 'close() was called (with no arguments)');
+    }
+  });
+
+  ws.abort();
+});

--- a/reference-implementation/test/writable-stream.js
+++ b/reference-implementation/test/writable-stream.js
@@ -874,3 +874,41 @@ test('WritableStream queue lots of data and have all of them processed at once',
     );
   }, 0);
 });
+
+test('WritableStream should call underlying sink methods as methods', t => {
+  t.plan(7);
+
+  class Sink {
+    start() {
+      t.equal(this, theSink, 'start() should be called with the correct this');
+    }
+
+    write() {
+      t.equal(this, theSink, 'pull() should be called with the correct this');
+    }
+
+    close() {
+      t.equal(this, theSink, 'close() should be called with the correct this');
+    }
+
+    abort() {
+      t.equal(this, theSink, 'abort() should be called with the correct this');
+    }
+
+    get strategy() {
+      // Called three times
+      t.equal(this, theSink, 'strategy getter should be called with the correct this');
+      return undefined;
+    }
+  }
+
+  var theSink = new Sink();
+  theSink.debugName = "the sink object passed to the constructor";
+  var ws = new WritableStream(theSink);
+
+  ws.write('a');
+  ws.close();
+
+  var ws2 = new WritableStream(theSink);
+  ws.abort();
+});


### PR DESCRIPTION
Fixes #256 (/cc @jkrems).

Could use some careful review as the changes were pretty wide-ranging. I am not too worried about the algorithms---the reference implementation and its extensive test suite help with my confidence there---but the editorial changes always leave the potential for pointers, "dead code", etc.

Preview at https://streams.spec.whatwg.org/branch-snapshots/first-class-source-sink-objects/