### PR TITLE
Convert readable stream pull() to promise-returning

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -275,8 +275,9 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
       <code>"errored"</code> state
   </tr>
   <tr>
-    <td>\[[pulling]]
-    <td>A boolean flag indicating whether data is currently being pulled from the underlying sink
+    <td>\[[pullingPromise]]
+    <td>A promise returned by the <a>underlying source</a>'s <code>pull</code> method, stored so that the stream can
+      re-pull when it fulfills
   </tr>
   <tr>
     <td>\[[queue]]
@@ -320,9 +321,10 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
     <li> <code>start(enqueue, close, error)</code> is called immediately, and is typically used to adapt a <a>push
       source</a> by setting up relevant event listeners, or to acquire access to a <a>pull source</a>. If this process
       is asynchronous, it can return a promise to signal success or failure.
-    <li> <code>pull(enqueue, close, error)</code> is called when the stream's internal queue of chunks is depleted, and
-      the consumer has signaled that they wish to consume more data. Once it is called, it will not be called again
-      until the passed <code>enqueue</code> callback is called.
+    <li> <code>pull(enqueue, close)</code> is called when the stream's internal queue of chunks is depleted, and the
+      consumer has signaled that they wish to consume more data. If <code>pull</code> returns a promise, then it will
+      not be called again until the promise returned by the previous call has fulfilled; if the promise rejects, the
+      stream will become errored.
     <li> <code>cancel(reason)</code> is called when the consumer signals that they are no longer interested in the
       stream. It should perform any actions necessary to release access to the <a>underlying source</a>. If this
       process is asynchronous, it can return a promise to signal success or failure.
@@ -344,7 +346,7 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   <li> Set <b>this</b>@\[[readyPromise]] and <b>this</b>@\[[closedPromise]] to new promises.
   <li> Set <b>this</b>@\[[queue]] to a new empty List.
   <li> Set <b>this</b>@\[[state]] to <code>"waiting"</code>.
-  <li> Set <b>this</b>@\[[started]], <b>this</b>@\[[draining]], and <b>this</b>@\[[pulling]] to <b>false</b>.
+  <li> Set <b>this</b>@\[[started]] and <b>this</b>@\[[draining]] to <b>false</b>.
   <li> Set <b>this</b>@\[[readableStreamReader]] to <b>undefined</b>.
   <li> Set <b>this</b>@\[[enqueue]] to CreateReadableStreamEnqueueFunction(<b>this</b>).
   <li> Set <b>this</b>@\[[close]] to CreateReadableStreamCloseFunction(<b>this</b>).
@@ -781,20 +783,24 @@ The <code>length</code> property of the <code>cancel</code> method is <b>1</b>.
 <h4 id="call-readable-stream-pull">CallReadableStreamPull ( stream )</h4>
 
 <ol>
-  <li> If <var>stream</var>@\[[pulling]] is <b>true</b> or <var>stream</var>@\[[draining]] is <b>true</b> or
-    <var>stream</var>@\[[started]] is <b>false</b> or <var>stream</var>@\[[state]] is <code>"closed"</code> or
-    <var>stream</var>@\[[state]] is <code>"errored"</code>, return <b>undefined</b>.
+  <li> If <var>stream</var>@\[[draining]] is <b>true</b> or <var>stream</var>@\[[started]] is <b>false</b> or
+    <var>stream</var>@\[[state]] is <code>"closed"</code> or <var>stream</var>@\[[state]] is <code>"errored"</code>,
+    return <b>undefined</b>.
+  <li> If <var>stream</var>@\[[pullingPromise]] is not <b>undefined</b>,
+    <ol>
+      <li> Upon fulfillment of <var>stream</var>@\[[pullingPromise]], call-with-rethrow
+        CallReadableStreamPull(<var>stream</var>).
+      <li> Return <b>undefined</b>.
+    </ol>
   <li> Let <var>shouldApplyBackpressure</var> be ShouldReadableStreamApplyBackpressure(<var>stream</var>).
   <li> If <var>shouldApplyBackpressure</var> is <b>true</b>, return <b>undefined</b>.
-  <li> Set <var>stream</var>@\[[pulling]] to <b>true</b>.
-  <li> Let <var>pullResult</var> be InvokeOrNoop(<var>stream</var>@\[[underlyingSource]], <code>"pull"</code>,
-    (<var>stream</var>@\[[enqueue]], <var>stream</var>@\[[close]], <var>stream</var>@\[[error]]).
-  <li> If <var>pullResult</var> is an abrupt completion,
-    <ol>
-      <li> Call-with-rethrow Call(<var>stream</var>@\[[error]], <b>undefined</b>, «‍<var>pullResult</var>.\[[value]]»).
-      <li> Return <var>pullResult</var>.
-    </ol>
-  <li> Otherwise, return <b>undefined</b>.
+  <li> Set <var>stream</var>@\[[pullingPromise]] to PromiseInvokeOrNoop(<var>stream</var>@\[[underlyingSource]],
+    <code>"pull"</code>, (<var>stream</var>@\[[enqueue]], <var>stream</var>@\[[close]])).
+  <li> Upon fulfillment of <var>stream</var>@\[[pullingPromise]], set <var>stream</var>@\[[pullingPromise]] to
+    <b>undefined</b>.
+  <li> Upon rejection of <var>stream</var>@\[[pullingPromise]] with reason <var>e</var>, call-with-rethrow
+    <var>stream</var>@\[[error]](<var>e</var>).
+  <li> Return <b>undefined</b>.
 </ol>
 
 <h4 id="close-readable-stream">CloseReadableStream ( stream )</h4>
@@ -868,7 +874,6 @@ closing over a variable <var>stream</var>, that performs the following steps:
         «‍<var>enqueueResult</var>.\[[value]]»).
       <li> Return <var>enqueueResult</var>.
     </ol>
-  <li> Set <var>stream</var>@\[[pulling]] to <b>false</b>.
   <li> Let <var>shouldApplyBackpressure</var> be ShouldReadableStreamApplyBackpressure(<var>stream</var>).
   <li> If <var>stream</var>@\[[state]] is <code>"waiting"</code>,
     <ol>
@@ -1953,18 +1958,17 @@ sources</a>. Note how in contrast to the examples with push sources, most of the
         });
       },
 
-      pull(enqueue, close, error) {
+      pull(enqueue, close) {
         const buffer = new ArrayBuffer(CHUNK_SIZE);
 
-        fs.read(fd, buffer, 0, CHUNK_SIZE, position).then(bytesRead => {
+        return fs.read(fd, buffer, 0, CHUNK_SIZE, position).then(bytesRead => {
           if (bytesRead === 0) {
             return fs.close(fd).then(close);
           } else {
             position += bytesRead;
             enqueue(buffer);
           }
-        })
-        .catch(error);
+        });
       },
 
       cancel() {

--- a/index.bs
+++ b/index.bs
@@ -275,6 +275,11 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
       <code>"errored"</code> state
   </tr>
   <tr>
+    <td>\[[pullScheduled]]
+    <td>A boolean flag set to <b>true</b> when the underlying source's <code>pull</code> method is scheduled to be
+      called again after the current call to it finishes
+  </tr>
+  <tr>
     <td>\[[pullingPromise]]
     <td>A promise returned by the <a>underlying source</a>'s <code>pull</code> method, stored so that the stream can
       re-pull when it fulfills
@@ -346,7 +351,7 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   <li> Set <b>this</b>@\[[readyPromise]] and <b>this</b>@\[[closedPromise]] to new promises.
   <li> Set <b>this</b>@\[[queue]] to a new empty List.
   <li> Set <b>this</b>@\[[state]] to <code>"waiting"</code>.
-  <li> Set <b>this</b>@\[[started]] and <b>this</b>@\[[draining]] to <b>false</b>.
+  <li> Set <b>this</b>@\[[started]], <b>this</b>@\[[draining]], and <b>this</b>@\[[pullScheduled]] to <b>false</b>.
   <li> Set <b>this</b>@\[[readableStreamReader]] to <b>undefined</b>.
   <li> Set <b>this</b>@\[[enqueue]] to CreateReadableStreamEnqueueFunction(<b>this</b>).
   <li> Set <b>this</b>@\[[close]] to CreateReadableStreamCloseFunction(<b>this</b>).
@@ -784,12 +789,16 @@ The <code>length</code> property of the <code>cancel</code> method is <b>1</b>.
 
 <ol>
   <li> If <var>stream</var>@\[[draining]] is <b>true</b> or <var>stream</var>@\[[started]] is <b>false</b> or
-    <var>stream</var>@\[[state]] is <code>"closed"</code> or <var>stream</var>@\[[state]] is <code>"errored"</code>,
-    return <b>undefined</b>.
+    <var>stream</var>@\[[state]] is <code>"closed"</code> or <var>stream</var>@\[[state]] is <code>"errored"</code> or
+    <var>stream</var>@\[[pullScheduled]] is <b>true</b>, return <b>undefined</b>.
   <li> If <var>stream</var>@\[[pullingPromise]] is not <b>undefined</b>,
     <ol>
-      <li> Upon fulfillment of <var>stream</var>@\[[pullingPromise]], call-with-rethrow
-        CallReadableStreamPull(<var>stream</var>).
+      <li> Set <var>stream</var>@\[[pullScheduled]] to <b>true</b>.
+      <li> Upon fulfillment of <var>stream</var>@\[[pullingPromise]],
+        <ol>
+          <li> Set <var>stream</var>@\[[pullScheduled]] to <b>false</b>.
+          <li> Call-with-rethrow CallReadableStreamPull(<var>stream</var>).
+        </ol>
       <li> Return <b>undefined</b>.
     </ol>
   <li> Let <var>shouldApplyBackpressure</var> be ShouldReadableStreamApplyBackpressure(<var>stream</var>).

--- a/reference-implementation/lib/readable-stream-abstract-ops.js
+++ b/reference-implementation/lib/readable-stream-abstract-ops.js
@@ -16,12 +16,17 @@ export function AcquireExclusiveStreamReader(stream) {
 
 export function CallReadableStreamPull(stream) {
   if (stream._draining === true || stream._started === false ||
-      stream._state === 'closed' || stream._state === 'errored') {
+      stream._state === 'closed' || stream._state === 'errored' ||
+      stream._pullScheduled === true) {
     return undefined;
   }
 
   if (stream._pullingPromise !== undefined) {
-    stream._pullingPromise.then(() => CallReadableStreamPull(stream));
+    stream._pullScheduled = true;
+    stream._pullingPromise.then(() => {
+      stream._pullScheduled = false;
+      CallReadableStreamPull(stream);
+    });
     return undefined;
   }
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -13,6 +13,7 @@ export default class ReadableStream {
     this._state = 'waiting';
     this._started = false;
     this._draining = false;
+    this._pullScheduled = false;
     this._pullingPromise = undefined;
     this._readableStreamReader = undefined;
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -13,7 +13,7 @@ export default class ReadableStream {
     this._state = 'waiting';
     this._started = false;
     this._draining = false;
-    this._pulling = false;
+    this._pullingPromise = undefined;
     this._readableStreamReader = undefined;
 
     this._enqueue = CreateReadableStreamEnqueueFunction(this);

--- a/reference-implementation/test/bad-underlying-sources.js
+++ b/reference-implementation/test/bad-underlying-sources.js
@@ -78,8 +78,7 @@ test('Throwing underlying source pull getter (second pull)', t => {
 
   rs.ready.then(() => {
     t.equal(rs.state, 'readable', 'sanity check: the stream becomes readable without issue');
-
-    t.throws(() => rs.read(), /a unique string/, 'reading triggers a pull, and the error is re-thrown');
+    t.equal(rs.read(), 'a', 'the initially-enqueued chunk can be read from the stream');
   });
 
   rs.closed.then(
@@ -106,8 +105,7 @@ test('Throwing underlying source pull method (second pull)', t => {
 
   rs.ready.then(() => {
     t.equal(rs.state, 'readable', 'sanity check: the stream becomes readable without issue');
-
-    t.throws(() => rs.read(), /a unique string/, 'reading triggers a pull, and the error is re-thrown');
+    t.equal(rs.read(), 'a', 'the initially-enqueued chunk can be read from the stream');
   });
 
   rs.closed.then(

--- a/reference-implementation/test/pipe-to.js
+++ b/reference-implementation/test/pipe-to.js
@@ -238,7 +238,7 @@ test('Piping from a ReadableStream in readable state which becomes closed after 
     },
     close() {
       t.assert(writeCalled);
-      t.equal(pullCount, 1);
+      t.equal(pullCount, 2);
 
       t.end();
     },
@@ -296,7 +296,7 @@ test('Piping from a ReadableStream in readable state which becomes errored after
     abort(reason) {
       t.equal(reason, passedError);
       t.assert(writeCalled);
-      t.equal(pullCount, 1);
+      t.equal(pullCount, 2);
 
       t.end();
     }
@@ -332,7 +332,7 @@ test('Piping from a ReadableStream in waiting state which becomes readable after
   var ws = new WritableStream({
     write(chunk) {
       t.equal(chunk, 'Hello');
-      t.equal(pullCount, 1);
+      t.equal(pullCount, 2);
       t.end();
     },
     close() {
@@ -473,7 +473,7 @@ test('Piping from a ReadableStream in readable state to a WritableStream in wait
       } else {
         t.equal(chunk, 'World');
 
-        t.equal(pullCount, 1);
+        t.equal(pullCount, 2);
 
         t.end();
       }

--- a/reference-implementation/test/utils/sequential-rs.js
+++ b/reference-implementation/test/utils/sequential-rs.js
@@ -16,20 +16,24 @@ export default function sequentialReadableStream(limit, options) {
       });
     },
 
-    pull(enqueue, finish, error) {
-      sequentialSource.read((err, done, chunk) => {
-        if (err) {
-          error(err);
-        } else if (done) {
-          sequentialSource.close(err => {
-            if (err) {
-              error(err);
-            }
-            finish();
-          });
-        } else {
-          enqueue(chunk);
-        }
+    pull(enqueue, close) {
+      return new Promise((resolve, reject) => {
+        sequentialSource.read((err, done, chunk) => {
+          if (err) {
+            reject(err);
+          } else if (done) {
+            sequentialSource.close(err => {
+              if (err) {
+                reject(err);
+              }
+              close();
+              resolve();
+            });
+          } else {
+            enqueue(chunk);
+            resolve();
+          }
+        });
       });
     }
   });


### PR DESCRIPTION
See discussion in #185 for background.

This allows more convenient integration with promise-returning underlying source functions, removing the need for `.catch(error)` as seen in the modified example.

It also rationalizes the slightly-strange way in which pull() is mutexed based on whether enqueue() has been called: instead, it is now mutexed so as to not be called again until the previous iteration's promise has fulfilled. This gives more direct control to the underlying source, and allows them to deal more easily with cases where there are just no chunks to enqueue.

Although superficially it seems this may reduce performance for cases where underlying sources can enqueue many chunks synchronously, this is not actually the case, as can be seen from the modified test illustrating such a scenario. If an underlying source can enqueue multiple chunks synchronously, then it should just do so! It shouldn't wait to be pull()ed, as the previous test was doing.