### PR TITLE
Fixed cancel test on errored stream

### DIFF
--- a/reference-implementation/test/readable-stream-cancel.js
+++ b/reference-implementation/test/readable-stream-cancel.js
@@ -150,7 +150,7 @@ test('ReadableStream rs.cancel() on a closed stream returns a promise resolved w
   });
 });
 
-test('ReadableStream rs.cancel() on an errored stream returns a promise resolved with undefined', t => {
+test('ReadableStream rs.cancel() on an errored stream returns a promise rejected with the error', t => {
   var passedError = new Error('aaaugh!!');
 
   var rs = new ReadableStream({


### PR DESCRIPTION
I think the description of that test is confusing if you read what it is really checking, that the promise is rejected with the passed error.