### PR TITLE
[WIP] Putting a chunk back in the readable stream queue

### DIFF
--- a/reference-implementation/lib/exclusive-stream-reader.js
+++ b/reference-implementation/lib/exclusive-stream-reader.js
@@ -1,5 +1,9 @@
 var assert = require('assert');
-import { ReadFromReadableStream, IsExclusiveStreamReader } from './readable-stream-abstract-ops';
+import {
+  IsExclusiveStreamReader,
+  PutBackIntoReadableStream,
+  ReadFromReadableStream
+} from './readable-stream-abstract-ops';
 
 export default class ExclusiveStreamReader {
   constructor(stream) {
@@ -80,6 +84,18 @@ export default class ExclusiveStreamReader {
     }
 
     return ReadFromReadableStream(this._encapsulatedReadableStream);
+  }
+
+  putBack(chunk) {
+    if (!IsExclusiveStreamReader(this)) {
+      throw new TypeError('ExclusiveStreamReader.prototype.putBack can only be used on a ExclusiveStreamReader');
+    }
+
+    if (this._encapsulatedReadableStream._readableStreamReader !== this) {
+      throw new TypeError('This stream reader has released its lock on the stream and can no longer be used');
+    }
+
+    return PutBackIntoReadableStream(this._encapsulatedReadableStream, chunk);
   }
 
   cancel(reason, ...args) {

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -12,7 +12,7 @@ export function EnqueueValueWithSize(queue, value, size) {
     throw new RangeError('Size must be a finite, non-NaN number.');
   }
 
-  queue.push({ value: value, size: size });
+  queue.push({ value, size });
 }
 
 export function GetTotalQueueSize(queue) {
@@ -32,4 +32,13 @@ export function PeekQueueValue(queue) {
   assert(queue.length > 0, 'Spec-level failure: should never peek at an empty queue.');
   var pair = queue[0];
   return pair.value;
+}
+
+export function PutBackValueWithSize(queue, value, size) {
+  size = Number(size);
+  if (Number.isNaN(size) || size === +Infinity || size === -Infinity) {
+    throw new RangeError('Size must be a finite, non-NaN number.');
+  }
+
+  queue.unshift({ value, size });
 }

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,8 +1,8 @@
 var assert = require('assert');
 import * as helpers from './helpers';
 import { AcquireExclusiveStreamReader, CallReadableStreamPull, CloseReadableStream, CreateReadableStreamCloseFunction,
-  CreateReadableStreamEnqueueFunction, CreateReadableStreamErrorFunction, IsReadableStream, ReadFromReadableStream,
-  ShouldReadableStreamApplyBackpressure } from './readable-stream-abstract-ops';
+  CreateReadableStreamEnqueueFunction, CreateReadableStreamErrorFunction, IsReadableStream, PutBackIntoReadableStream,
+  ReadFromReadableStream, ShouldReadableStreamApplyBackpressure } from './readable-stream-abstract-ops';
 
 export default class ReadableStream {
   constructor(underlyingSource = {}) {
@@ -183,6 +183,18 @@ export default class ReadableStream {
     }
 
     return ReadFromReadableStream(this);
+  }
+
+  putBack(chunk) {
+    if (!IsReadableStream(this)) {
+      throw new TypeError('ReadableStream.prototype.read can only be used on a ReadableStream');
+    }
+
+    if (this._readableStreamReader !== undefined) {
+      throw new TypeError('This stream is locked to a single exclusive reader and putBack cannot be used directly');
+    }
+
+    return PutBackIntoReadableStream(this, chunk);
   }
 
   get ready() {

--- a/reference-implementation/test/bad-underlying-sources.js
+++ b/reference-implementation/test/bad-underlying-sources.js
@@ -148,11 +148,10 @@ test('Throwing underlying source cancel method', t => {
   );
 });
 
-test('Throwing underlying source strategy getter', t => {
+test('Throwing underlying source strategy getter: enqueue', t => {
   t.plan(2);
 
   var theError = new Error('a unique string');
-
   var rs = new ReadableStream({
     start(enqueue) {
       t.throws(() => enqueue('a'), /a unique string/);
@@ -165,7 +164,21 @@ test('Throwing underlying source strategy getter', t => {
   t.equal(rs.state, 'errored', 'state should be errored');
 });
 
-test('Throwing underlying source strategy.size getter', t => {
+test('Throwing underlying source strategy getter: putBack', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    get strategy() {
+      throw theError;
+    }
+  });
+
+  t.throws(() => rs.putBack('a'), /a unique string/);
+  t.equal(rs.state, 'errored', 'state should be errored');
+});
+
+test('Throwing underlying source strategy.size getter: enqueue', t => {
   t.plan(2);
 
   var theError = new Error('a unique string');
@@ -186,7 +199,26 @@ test('Throwing underlying source strategy.size getter', t => {
   t.equal(rs.state, 'errored', 'state should be errored');
 });
 
-test('Throwing underlying source strategy.size method', t => {
+test('Throwing underlying source strategy.size getter: putBack', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    strategy: {
+      get size() {
+        throw theError;
+      },
+      shouldApplyBackpressure() {
+        return true;
+      }
+    }
+  });
+
+  t.throws(() => rs.putBack('a'), /a unique string/);
+  t.equal(rs.state, 'errored', 'state should be errored');
+});
+
+test('Throwing underlying source strategy.size method: enqueue', t => {
   t.plan(2);
 
   var theError = new Error('a unique string');
@@ -207,7 +239,26 @@ test('Throwing underlying source strategy.size method', t => {
   t.equal(rs.state, 'errored', 'state should be errored');
 });
 
-test('Throwing underlying source strategy.shouldApplyBackpressure getter', t => {
+test('Throwing underlying source strategy.size method: putBack', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    strategy: {
+      size() {
+        throw theError;
+      },
+      shouldApplyBackpressure() {
+        return true;
+      }
+    }
+  });
+
+  t.throws(() => rs.putBack('a'), /a unique string/);
+  t.equal(rs.state, 'errored', 'state should be errored');
+});
+
+test('Throwing underlying source strategy.shouldApplyBackpressure getter: enqueue', t => {
   t.plan(2);
 
   var theError = new Error('a unique string');
@@ -228,7 +279,26 @@ test('Throwing underlying source strategy.shouldApplyBackpressure getter', t => 
   t.equal(rs.state, 'errored', 'state should be errored');
 });
 
-test('Throwing underlying source strategy.shouldApplyBackpressure method', t => {
+test('Throwing underlying source strategy.shouldApplyBackpressure getter: putBack', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    strategy: {
+      size() {
+        return 1;
+      },
+      get shouldApplyBackpressure() {
+        throw theError;
+      }
+    }
+  });
+
+  t.doesNotThrow(() => rs.putBack('a'), 'putBack should not consult shouldApplyBackpressure and thus should not throw');
+  t.equal(rs.state, 'readable', 'state should be readable');
+});
+
+test('Throwing underlying source strategy.shouldApplyBackpressure method: enqueue', t => {
   t.plan(2);
 
   var theError = new Error('a unique string');
@@ -247,4 +317,23 @@ test('Throwing underlying source strategy.shouldApplyBackpressure method', t => 
   });
 
   t.equal(rs.state, 'errored', 'state should be errored');
+});
+
+test('Throwing underlying source strategy.shouldApplyBackpressure method: putBack', t => {
+  t.plan(2);
+
+  var theError = new Error('a unique string');
+  var rs = new ReadableStream({
+    strategy: {
+      size() {
+        return 1;
+      },
+      shouldApplyBackpressure() {
+        throw theError;
+      }
+    }
+  });
+
+  t.doesNotThrow(() => rs.putBack('a'), 'putBack should not consult shouldApplyBackpressure and thus should not throw');
+  t.equal(rs.state, 'readable', 'state should be readable');
 });

--- a/reference-implementation/test/brand-checks.js
+++ b/reference-implementation/test/brand-checks.js
@@ -166,6 +166,12 @@ test('ReadableStream.prototype.pipeTo works generically on its this and its argu
   t.doesNotThrow(() => ReadableStream.prototype.pipeTo.call(fakeReadableStream(), fakeWritableStream()));
 });
 
+test('ReadableStream.prototype.putBack enforces a brand check', t => {
+  t.plan(2);
+  methodThrows(t, ReadableStream.prototype, 'putBack', fakeReadableStream());
+  methodThrows(t, ReadableStream.prototype, 'putBack', realWritableStream());
+});
+
 test('ReadableStream.prototype.read enforces a brand check', t => {
   t.plan(2);
   methodThrows(t, ReadableStream.prototype, 'read', fakeReadableStream());


### PR DESCRIPTION
See #3, and especially the real-world use case in the [MSE spec](https://w3c.github.io/media-source/#sourcebuffer-stream-append-loop), step 9.

This doesn't contain any spec updates or examples yet, just prototype in the reference implementation---including some fairly-exhaustive tests. Suggestions for more tests welcome!

Thoughts:

- putBack was a name thrown around in #3. It's better than Node's "unshift", certainly. The Wikipedia [double-ended queue](https://en.wikipedia.org/wiki/Double-ended_queue) article is entirely unhelpful (and we're using `read()` instead of `dequeue()` anyway). One idea that I came up with and am starting to like is `rs.unRead(chunk)`. (Or should it be `unread`, no capital-R?) I might go with that if nobody objects or comes up with something better.

- It might be nice to let the underlying source provide some sort of hook that gets called upon putBack. This could allow things like: causing any array buffers that are putBack to be transferred (see discussion in #3), or validating that all chunks in a stream stay the same type, or just disallowing putBack altogether for a given stream. I am hesitant to add this until someone explicitly asks for it though. Anyone want to convince me it's a really good idea, or shall we leave it for later?

- Unlike `enqueue`, right now `putBack` does not return any backpressure-indicating value. We could easily add it, but I am not sure it should be the consumers responsibility to worry about whether they're putting back too much data? putBack is supposed to be a pretty rare, out-of-band occurrence, and not part of the normal backpressure negotation protocol.

- How does this extend to ReadableByteStream, exactly?