### PR TITLE
Implement teeing, plus a bunch of stage-setting tweaks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -693,20 +693,8 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
 </div>
 
 <pre is="emu-alg">
-  1. If IsReadableStreamReader(*this*) is *false*, throw a *TypeError* exception.
-  1. If *this*@[[state]] is "closed", return a new promise resolved with CreateIterResultObject(*undefined*, *true*).
-  1. If *this*@[[state]] is "errored", return a new promise rejected with *this*@[[storedError]].
-  1. Assert: *this*@[[ownerReadableStream]] is not *undefined*.
-  1. Assert: *this*@[[ownerReadableStream]]@[[state]] is "readable".
-  1. If *this*@[[ownerReadableStream]]@[[queue]] is not empty,
-    1. Let _chunk_ be DequeueValue(*this*@[[ownerReadableStream]]@[[queue]]).
-    1. If *this*@[[ownerReadableStream]]@[[closeRequested]] is *true* and *this*@[[ownerReadableStream]]@[[queue]] is now empty, call-with-rethrow FinishClosingReadableStream(*this*@[[ownerReadableStream]]).
-    1. Otherwise, call-with-rethrow CallReadableStreamPull(*this*@[[ownerReadableStream]]).
-    1. Return a new promise resolved with CreateIterResultObject(_chunk_, *false*).
-  1. Otherwise,
-    1. Let _readRequestPromise_ be a new promise.
-    1. Append _readRequestPromise_ as the last element of *this*@[[readRequests]].
-    1. Return _readRequestPromise_.
+  1. If IsReadableStreamReader(*this*) is *false*, return a promise rejected with a *TypeError* exception.
+  1. Return ReadFromReadableStreamReader(*this*).
 </pre>
 
 <h5 id="reader-release-lock">releaseLock()</h5>
@@ -884,6 +872,24 @@ readable stream is <a>locked to a reader</a>.
   1. If Type(_x_) is not Object, return *false*.
   1. If _x_ does not have an [[ownerReadableStream]] internal slot, return *false*.
   1. Return *true*.
+</pre>
+
+<h4 id="read-from-readable-stream-reader" aoid="ReadFromReadableStreamReader">ReadFromReadableStreamReader ( reader )</h4>
+
+<pre is="emu-alg">
+  1. If _reader_@[[state]] is "closed", return a new promise resolved with CreateIterResultObject(*undefined*, *true*).
+  1. If _reader_@[[state]] is "errored", return a new promise rejected with _reader_@[[storedError]].
+  1. Assert: _reader_@[[ownerReadableStream]] is not *undefined*.
+  1. Assert: _reader_@[[ownerReadableStream]]@[[state]] is "readable".
+  1. If _reader_@[[ownerReadableStream]]@[[queue]] is not empty,
+    1. Let _chunk_ be DequeueValue(_reader_@[[ownerReadableStream]]@[[queue]]).
+    1. If _reader_@[[ownerReadableStream]]@[[closeRequested]] is *true* and _reader_@[[ownerReadableStream]]@[[queue]] is now empty, call-with-rethrow FinishClosingReadableStream(_reader_@[[ownerReadableStream]]).
+    1. Otherwise, call-with-rethrow CallReadableStreamPull(_reader_@[[ownerReadableStream]]).
+    1. Return a new promise resolved with CreateIterResultObject(_chunk_, *false*).
+  1. Otherwise,
+    1. Let _readRequestPromise_ be a new promise.
+    1. Append _readRequestPromise_ as the last element of _reader_@[[readRequests]].
+    1. Return _readRequestPromise_.
 </pre>
 
 <h4 id="release-readable-stream-reader" aoid="ReleaseReadableStreamReader">ReleaseReadableStreamReader ( reader )</h4>

--- a/index.bs
+++ b/index.bs
@@ -733,11 +733,8 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
 
 <h4 id="acquire-readable-stream-reader" aoid="AcquireReadableStreamReader">AcquireReadableStreamReader ( stream )</h4>
 
-<div class="note">
-  This abstract operation is meant to be called from other specifications that may wish to acquire an
-  <a>readable stream reader</a> for a given stream. Within this specification, it is only used once, in the definition
-  of <a href="#rs-get-reader"><code>ReadableStream.prototype.getReader</code></a>.
-</div>
+This abstract operation is meant to be called from other specifications that may wish to acquire an <a>readable stream
+reader</a> for a given stream.
 
 <pre is="emu-alg">
   1. Return Construct(`ReadableStreamReader`, «‍_stream_»).
@@ -774,6 +771,10 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
 
 <h4 id="close-readable-stream" aoid="CloseReadableStream">CloseReadableStream ( stream )</h4>
 
+This abstract operation can be called by other specifications that wish to close a readable stream, in the same way
+a developer-created stream would be closed by its associated controller object. Specifications should <em>not</em> do
+this to streams they did not create, and must ensure they have obeyed the preconditions (listed here as asserts).
+
 <pre is="emu-alg">
   1. Assert: _stream_@[[closeRequested]] is *false*.
   1. Assert: _stream_@[[state]] is not "errored".
@@ -798,6 +799,11 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
 </pre>
 
 <h4 id="enqueue-in-readable-stream" aoid="EnqueueInReadableStream">EnqueueInReadableStream ( stream, chunk )</h4>
+
+This abstract operation can be called by other specifications that wish to enqueue <a>chunks</a> in a readable stream,
+in the same way a developer would enqueue chunks using the stream's associated controller object. Specifications should
+<em>not</em> do this to streams they did not create, and must ensure they have obeyed the preconditions (listed here as
+asserts).
 
 <pre is="emu-alg">
   1. Assert: _stream_@[[state]] is "readable".
@@ -832,6 +838,10 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
 
 <h4 id="error-readable-stream" aoid="ErrorReadableStream">ErrorReadableStream ( stream, e )</h4>
 
+This abstract operation can be called by other specifications that wish to move a readable stream to an errored state,
+in the same way a developer would error a stream using its associated controller object. Specifications should
+<em>not</em> do this to streams they did not create, and must ensure they have obeyed the precondition (listed here as
+an assert).
 
 <pre is="emu-alg">
   1. Assert: _stream_@[[state]] is "readable".
@@ -859,10 +869,8 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
 
 <h4 id="is-readable-stream-locked" aoid="IsReadableStreamLocked">IsReadableStreamLocked ( stream )</h4>
 
-<div class="note">
-  This abstract operation is meant to be called from other specifications that may wish to query whether or not a
-  readable stream is <a>locked to a reader</a>.
-</div>
+This abstract operation is meant to be called from other specifications that may wish to query whether or not a
+readable stream is <a>locked to a reader</a>.
 
 <pre is="emu-alg">
   1. Assert: IsReadableStream(_stream_) is *true*.

--- a/index.bs
+++ b/index.bs
@@ -559,6 +559,7 @@ Instances of <code>ReadableStreamController</code> are created with the internal
 
 <pre is="emu-alg">
   1. If IsReadableStreamController(*this*) is *false*, throw a *TypeError* exception.
+  1. If *this*@[[controlledReadableStream]]@[[state]] is not "readable", throw a *TypeError* exception.
   1. Return ErrorReadableStream(*this*@[[controlledReadableStream]]).
 </pre>
 
@@ -831,8 +832,9 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
 
 <h4 id="error-readable-stream" aoid="ErrorReadableStream">ErrorReadableStream ( stream, e )</h4>
 
+
 <pre is="emu-alg">
-  1. If _stream_@[[state]] is not "readable", throw a *TypeError* exception.
+  1. Assert: _stream_@[[state]] is "readable".
   1. Let _stream_@[[queue]] be a new empty List.
   1. Set _stream_@[[storedError]] to _e_.
   1. Set _stream_@[[state]] to "errored".

--- a/index.bs
+++ b/index.bs
@@ -552,32 +552,7 @@ Instances of <code>ReadableStreamController</code> are created with the internal
   1. If _stream_@[[state]] is "errored", throw _stream_@[[storedError]].
   1. If _stream_@[[state]] is "closed", throw a *TypeError* exception.
   1. If _stream_@[[closeRequested]] is *true*, throw a *TypeError* exception.
-  1. If IsReadableStreamLocked(_stream_) is *true* and _stream_@[[reader]]@[[readRequests]] is not empty,
-    1. Let _readRequestPromise_ be the first element of _stream_@[[reader]]@[[readRequests]].
-    1. Remove _readRequestPromise_ from _stream_@[[reader]]@[[readRequests]], shifting all other elements downward (so that the second becomes the first, and so on).
-    1. Resolve _readRequestPromise_ with CreateIterResultObject(_chunk_, *false*).
-  1. Otherwise,
-    1. Let _chunkSize_ be *1*.
-    1. Let _strategy_ be Get(_stream_@[[underlyingSource]], "strategy").
-    1. If _strategy_ is an abrupt completion,
-      1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_strategy_.[[value]]).
-      1. Return _strategy_.
-    1. Let _strategy_ be _strategy_.[[value]].
-    1. If _strategy_ is not *undefined*, then
-      1. Set _chunkSize_ to Invoke(_strategy_, "size", «‍_chunk_»).
-      1. If _chunkSize_ is an abrupt completion,
-        1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_chunkSize_.[[value]]).
-        1. Return _chunkSize_.
-      1. Let _chunkSize_ be _chunkSize_.[[value]].
-    1. Let _enqueueResult_ be EnqueueValueWithSize(_stream_@[[queue]], _chunk_, _chunkSize_.[[value]]).
-    1. If _enqueueResult_ is an abrupt completion,
-      1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_enqueueResult_.[[value]]).
-      1. Return _enqueueResult_.
-  1. Call-with-rethrow CallReadableStreamPull(_stream_).
-  1. Let _shouldApplyBackpressure_ be ShouldReadableStreamApplyBackpressure(_stream_).
-  1. ReturnIfAbrupt(_shouldApplyBackpressure_).
-  1. If _shouldApplyBackpressure_ is *true*, return *false*.
-  1. Return *true*.
+  1. Return EnqueueInReadableStream(_stream_, _chunk_).
 </pre>
 
 <h5 id="rs-controller-error">error(e)</h5>
@@ -819,6 +794,39 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
   1. Set _stream_@[[state]] to "closed".
   1. If IsReadableStreamLocked(_stream_) is *true*, return ReleaseReadableStreamReader(_stream_).
   1. Return *undefined*.
+</pre>
+
+<h4 id="enqueue-in-readable-stream" aoid="EnqueueInReadableStream">EnqueueInReadableStream ( stream, chunk )</h4>
+
+<pre is="emu-alg">
+  1. Assert: _stream_@[[state]] is "readable".
+  1. Assert: _stream_@[[closeRequested]] is *false*.
+  1. If IsReadableStreamLocked(_stream_) is *true* and _stream_@[[reader]]@[[readRequests]] is not empty,
+    1. Let _readRequestPromise_ be the first element of _stream_@[[reader]]@[[readRequests]].
+    1. Remove _readRequestPromise_ from _stream_@[[reader]]@[[readRequests]], shifting all other elements downward (so that the second becomes the first, and so on).
+    1. Resolve _readRequestPromise_ with CreateIterResultObject(_chunk_, *false*).
+  1. Otherwise,
+    1. Let _chunkSize_ be *1*.
+    1. Let _strategy_ be Get(_stream_@[[underlyingSource]], "strategy").
+    1. If _strategy_ is an abrupt completion,
+      1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_strategy_.[[value]]).
+      1. Return _strategy_.
+    1. Let _strategy_ be _strategy_.[[value]].
+    1. If _strategy_ is not *undefined*, then
+      1. Set _chunkSize_ to Invoke(_strategy_, "size", «‍_chunk_»).
+      1. If _chunkSize_ is an abrupt completion,
+        1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_chunkSize_.[[value]]).
+        1. Return _chunkSize_.
+      1. Let _chunkSize_ be _chunkSize_.[[value]].
+    1. Let _enqueueResult_ be EnqueueValueWithSize(_stream_@[[queue]], _chunk_, _chunkSize_.[[value]]).
+    1. If _enqueueResult_ is an abrupt completion,
+      1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_enqueueResult_.[[value]]).
+      1. Return _enqueueResult_.
+  1. Call-with-rethrow CallReadableStreamPull(_stream_).
+  1. Let _shouldApplyBackpressure_ be ShouldReadableStreamApplyBackpressure(_stream_).
+  1. ReturnIfAbrupt(_shouldApplyBackpressure_).
+  1. If _shouldApplyBackpressure_ is *true*, return *false*.
+  1. Return *true*.
 </pre>
 
 <h4 id="error-readable-stream" aoid="ErrorReadableStream">ErrorReadableStream ( stream, e )</h4>

--- a/index.bs
+++ b/index.bs
@@ -1026,11 +1026,6 @@ Instances of <code>WritableStream</code> are created with the internal slots des
       <code>closed</code> getter
   </tr>
   <tr>
-    <td>\[[error]]
-    <td>A <a>Writable Stream Error Function</a> created with the ability to move this stream to an
-      <code>"errored"</code> state
-  </tr>
-  <tr>
     <td>\[[queue]]
     <td>A List representing the stream's internal queue of pending writes
   </tr>
@@ -1117,15 +1112,26 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   1. Set *this*@[[queue]] to a new empty List.
   1. Set *this*@[[state]] to "writable".
   1. Set *this*@[[started]] and *this*@[[writing]] to *false*.
-  1. Set *this*@[[error]] to CreateWritableStreamErrorFunction(*this*).
   1. Call-with-rethrow SyncWritableStreamStateWithQueue(*this*).
-  1. Let _startResult_ be InvokeOrNoop(_underlyingSink_, "start", «‍*this*@[[error]]»).
+  1. Let _error_ be a new <a><code>WritableStream</code> error function</a>.
+  1. Set _error_@[[stream]] to *this*.
+  1. Let _startResult_ be InvokeOrNoop(_underlyingSink_, "start", «_error_»).
   1. ReturnIfAbrupt(_startResult_).
   1. Set *this*@[[startedPromise]] to the result of resolving _startResult_ as a promise.
     1. Upon fulfillment,
       1. Set *this*@[[started]] to *true*.
       1. Set *this*@[[startedPromise]] to *undefined*.
-    1. Upon rejection with reason _r_, call-with-rethrow Call(*this*@[[error]], *undefined*, «‍_r_»).
+    1. Upon rejection with reason _r_, return ErrorWritableStream(*this*, _r_).
+</pre>
+
+A <dfn><code>WritableStream</code> error function</dfn> is an anonymous built-in function that is used to allow
+<a>underlying sinks</a> to error their associated writable stream. Each <code>WritableStream</code> error function has
+a \[[stream]] internal slot. When a <code>WritableStream</code> error function <var>F</var> is called with argument
+<var>e</var>, it performs the following steps:
+
+<pre is="emu-alg">
+  1. Let _stream_ be _F_@[[stream]].
+  1. Return ErrorWritableStream(_stream_, _e_).
 </pre>
 
 <h4 id="ws-prototype">Properties of the <code>WritableStream</code> Prototype</h4>
@@ -1201,7 +1207,7 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   1. If IsWritableStream(*this*) is *false*, return a promise rejected with a *TypeError* exception.
   1. If *this*@[[state]] is "closed", return a new promise resolved with *undefined*.
   1. If *this*@[[state]] is "errored", return a new promise rejected with *this*@[[storedError]].
-  1. Call-with-rethrow Call(*this*@[[error]], *undefined*, «‍reason»).
+  1. Call-with-rethrow ErrorWritableStream(*this*, _reason_).
   1. Let _sinkAbortPromise_ be PromiseInvokeOrFallbackOrNoop(*this*@[[underlyingSink]], "abort", «_reason_», "close", «»).
   1. Return the result of transforming _sinkAbortPromise_ by a fulfillment handler that returns *undefined*.
 </pre>
@@ -1247,24 +1253,24 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   1. Let _chunkSize_ be *1*.
   1. Let _strategy_ be Get(*this*@[[underlyingSink]], "strategy").
   1. If _strategy_ is an abrupt completion,
-    1. Call-with-rethrow Call(*this*@[[error]], *undefined*, «‍_strategy_.[[value]]»).
+    1. Call-with-rethrow ErrorWritableStream(*this*, _strategy_.[[value]]).
     1. Return a new promise rejected with _strategy_.[[value]].
   1. Set _strategy_ to _strategy_.[[value]].
   1. If _strategy_ is not *undefined*, then
     1. Set _chunkSize_ to Invoke(_strategy_, "size", «‍_chunk_»).
     1. If _chunkSize_ is an abrupt completion,
-      1. Call-with-rethrow Call(*this*@[[error]], *undefined*, «‍_chunkSize_.[[value]]»).
+      1. Call-with-rethrow ErrorWritableStream(*this*, _chunkSize_.[[value]]).
       1. Return a new promise rejected with _chunkSize_.[[value]].
     1. Set _chunkSize_ to _chunkSize_.[[value]].
   1. Let _promise_ be a new promise.
   1. Let _writeRecord_ be Record{[[promise]]: _promise_, [[chunk]]: _chunk_}.
   1. Let _enqueueResult_ be EnqueueValueWithSize(*this*@[[queue]], _writeRecord_, _chunkSize_).
   1. If _enqueueResult_ is an abrupt completion,
-    1. Call-with-rethrow Call(*this*@[[error]], *undefined*, «‍_enqueueResult_.[[value]]»).
+    1. Call-with-rethrow ErrorWritableStream(*this*, _enqueueResult_.[[value]]).
     1. Return a new promise rejected with _enqueueResult_.[[value]].
   1. Let _syncResult_ be SyncWritableStreamStateWithQueue(*this*).
   1. If _syncResult_ is an abrupt completion,
-    1. Call-with-rethrow Call(*this*@[[error]], *undefined*, «‍_syncResult_.[[value]]»).
+    1. Call-with-rethrow ErrorWritableStream(*this*, _syncResult_.[[value]]).
     1. Return _promise_.
   1. Call-with-rethrow CallOrScheduleWritableStreamAdvanceQueue(*this*).
   1. Return _promise_.
@@ -1291,18 +1297,11 @@ Instances of <code>WritableStream</code> are created with the internal slots des
       1. Assert: _stream_@[[state]] is "closing".
       1. Resolve _stream_@[[closedPromise]] with *undefined*.
       1. Set _stream_@[[state]] to "closed".
-    1. Upon rejection with reason _r_, call-with-rethrow Call(_stream_@[[error]], *undefined*, «‍_r_»).
+    1. Upon rejection with reason _r_, return ErrorWritableStream(_stream_, _r_).
   1. Return *undefined*.
 </pre>
 
-<h4 id="create-writable-stream-error-function" aoid="CreateWritableStreamErrorFunction">CreateWritableStreamErrorFunction ( stream )</h4>
-
-<pre is="emu-alg">
-  1. Return a new <a>Writable Stream Error Function</a> closing over _stream_.
-</pre>
-
-A <dfn>Writable Stream Error Function</dfn> is a built-in anonymous function of one argument <var>e</var>, closing over
-a variable <var>stream</var>, that performs the following steps:
+<h4 id="error-writable-stream" aoid="ErrorWritableStream">ErrorWritableStream ( stream, e )</h4>
 
 <pre is="emu-alg">
   1. If _stream_@[[state]] is "closed" or "errored", return *undefined*.
@@ -1313,6 +1312,7 @@ a variable <var>stream</var>, that performs the following steps:
   1. If _stream_@[[state]] is "waiting", resolve _stream_@[[readyPromise]] with *undefined*.
   1. Reject _stream_@[[closedPromise]] with _e_.
   1. Set _stream_@[[state]] to "errored".
+  1. Return *undefined*.
 </pre>
 
 <h4 id="is-writable-stream" aoid="IsWritableStream">IsWritableStream ( x )</h4>
@@ -1363,9 +1363,9 @@ a variable <var>stream</var>, that performs the following steps:
     1. Resolve _writeRecord_.[[promise]] with *undefined*.
     1. DequeueValue(_stream_@[[queue]]).
     1. Let _syncResult_ be SyncWritableStreamStateWithQueue(_stream_).
-    1. If _syncResult_ is an abrupt completion, then call-with-rethrow Call(_stream_@[[error]], *undefined*, «‍_syncResult_.[[value]]»).
+    1. If _syncResult_ is an abrupt completion, then return ErrorWritableStream(_stream_, ‍_syncResult_.[[value]]).
     1. Otherwise, return WritableStreamAdvanceQueue(_stream_).
-  1. Upon rejection of _writeResult_ with reason _r_, call-with-rethrow Call(_stream_@[[error]], *undefined*, «‍_r_»).
+  1. Upon rejection of _writeResult_ with reason _r_, return ErrorWritableStream(_stream_, _r_).
 </pre>
 
 <h2 id="ts">Transform Streams</h2>
@@ -2140,9 +2140,6 @@ itself will evolve in these ways.
     ReturnIfAbrupt(<var>opResult</var>)."
   <li> We use <a href="https://w3ctag.github.io/promises-guide/#shorthand-phrases">the shorthand phrases from the W3C
     TAG promises guide</a> to operate on promises at a higher level than the ECMAScript spec does.
-  <li> We introduce the notion of creating a function that "closes over" a given variable. This is meant to work the
-    same as how the ECMAScript spec gives such functions internal slots which get filled in upon creation and then
-    have their values pulled out of during execution, but require less formal contortions.
 </ul>
 
 <h2 id="acks" class="no-num">Acknowledgments</h2>

--- a/index.bs
+++ b/index.bs
@@ -541,16 +541,8 @@ Instances of <code>ReadableStreamController</code> are created with the internal
   1. Let _stream_ be *this*@[[controlledReadableStream]].
   1. If _stream_@[[closeRequested]] is *true*, throw a *TypeError* exception.
   1. If _stream_@[[state]] is "errored", throw a *TypeError* exception.
-  1. If _stream_@[[state]] is "closed", return *undefined*.
-  1. Set _stream_@[[closeRequested]] to *true*.
-  1. If _stream_@[[queue]] is empty, return CloseReadableStream(_stream_).
+  1. Return CloseReadableStream(_stream_).
 </pre>
-
-<div class="note">
-  The case where <var>stream</var>@\[[state]] is <code>"closed"</code>, but <var>stream</var>@\[[closeRequested]] is
-  <emu-val>false</emu-val>, will happen if the stream was closed without this close function ever being called: i.e.,
-  if the stream was closed by a call to <code>stream.cancel()</code>.
-</div>
 
 <h5 id="rs-controller-enqueue">enqueue(chunk)</h5>
 
@@ -732,7 +724,7 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
   1. Assert: *this*@[[ownerReadableStream]]@[[state]] is "readable".
   1. If *this*@[[ownerReadableStream]]@[[queue]] is not empty,
     1. Let _chunk_ be DequeueValue(*this*@[[ownerReadableStream]]@[[queue]]).
-    1. If *this*@[[ownerReadableStream]]@[[closeRequested]] is *true* and *this*@[[ownerReadableStream]]@[[queue]] is now empty, call-with-rethrow CloseReadableStream(*this*@[[ownerReadableStream]]).
+    1. If *this*@[[ownerReadableStream]]@[[closeRequested]] is *true* and *this*@[[ownerReadableStream]]@[[queue]] is now empty, call-with-rethrow FinishClosingReadableStream(*this*@[[ownerReadableStream]]).
     1. Otherwise, call-with-rethrow CallReadableStreamPull(*this*@[[ownerReadableStream]]).
     1. Return a new promise resolved with CreateIterResultObject(_chunk_, *false*).
   1. Otherwise,
@@ -799,12 +791,28 @@ Instances of <code>ReadableStreamReader</code> are created with the internal slo
   1. If _stream_@[[state]] is "closed", return a new promise resolved with *undefined*.
   1. If _stream_@[[state]] is "errored", return a new promise rejected with _stream_@[[storedError]].
   1. Set _stream_@[[queue]] to a new empty List.
-  1. Call-with-rethrow CloseReadableStream(_stream_).
+  1. Call-with-rethrow FinishClosingReadableStream(_stream_).
   1. Let _sourceCancelPromise_ be PromiseInvokeOrNoop(_stream_@[[underlyingSource]], "cancel", «‍_reason_»).
   1. Return the result of transforming _sourceCancelPromise_ by a fulfillment handler that returns *undefined*.
 </pre>
 
 <h4 id="close-readable-stream" aoid="CloseReadableStream">CloseReadableStream ( stream )</h4>
+
+<pre is="emu-alg">
+  1. Assert: _stream_@[[closeRequested]] is *false*.
+  1. Assert: _stream_@[[state]] is not "errored".
+  1. If _stream_@[[state]] is "closed", return *undefined*.
+  1. Set _stream_@[[closeRequested]] to *true*.
+  1. If _stream_@[[queue]] is empty, return FinishClosingReadableStream(_stream_).
+</pre>
+
+<div class="note">
+  The case where <var>stream</var>@\[[state]] is <code>"closed"</code>, but <var>stream</var>@\[[closeRequested]] is
+  <emu-val>false</emu-val>, will happen if the stream was closed without its controller's close method ever being
+  called: i.e., if the stream was closed by a call to <code>stream.cancel()</code>.
+</div>
+
+<h4 id="finish-closing-readable-stream" aoid="FinishClosingReadableStream">FinishClosingReadableStream ( stream )</h4>
 
 <pre is="emu-alg">
   1. Assert: _stream_@[[state]] is "readable".

--- a/index.bs
+++ b/index.bs
@@ -17,6 +17,8 @@ Logo: https://resources.whatwg.org/logo-streams.svg
 !Version History: <a href="https://github.com/whatwg/streams/commits">https://github.com/whatwg/streams/commits</a>
 !Version History: [SNAPSHOT-LINK]
 !Version History: <a href="https://twitter.com/streamsstandard">@streamsstandard</a>
+
+Link Defaults: html5 (dfn) structured clone
 </pre>
 
 <style>
@@ -97,6 +99,10 @@ Consumers also have the ability to <dfn lt="cancel a readable stream">cancel</df
 that the consumer has lost interest in the stream, and will immediately close the stream, throw away any queued
 <a>chunks</a>, and execute any cancellation mechanism of the <a>underlying source</a>.
 
+Consumers can also <dfn lt="tee a readable stream">tee</dfn> a readable stream. This will
+<a lt="locked to a reader">lock</a> the stream, making it no longer directly usable; however, it will create two new
+streams, called <dfn lt="branches of a readable stream tee">branches</dfn>, which can be consumed independently.
+
 <h3 id="ws-model">Writable Streams</h3>
 
 A <dfn>writable stream</dfn> represents a destination for data, into which you can write. In other words, data goes
@@ -144,6 +150,10 @@ Once a pipe chain is constructed, it can be used to propagate signals regarding 
 through it. If any step in the chain cannot yet accept chunks, it propagates a signal backwards through the pipe chain,
 until eventually the original source is told to stop producing chunks so fast. This process of normalizing flow from
 the original source according to how fast the chain can process chunks is called <dfn>backpressure</dfn>.
+
+When <a lt="tee a readable stream">teeing</a> a readable stream, the <a>backpressure</a> signals from its two
+<a href="branches of a readable stream tee">branches</a> will aggregate, such that if neither branch is read from, a
+backpressure signal will be sent to the <a>underlying source</a> of the original stream.
 
 <!-- TODO when we have writable stream writers
 Piping a readable stream <a href="locked to a reader">locks</a> the readable stream, preventing it from being accessed
@@ -247,6 +257,7 @@ would look like
     getReader()
     pipeThrough({ writable, readable }, options)
     pipeTo(dest, { preventClose, preventAbort, preventCancel } = {})
+    tee()
   }
 </code></pre>
 
@@ -351,7 +362,7 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   1. Set *this*@[[state]] to "readable".
   1. Set *this*@[[started]], *this*@[[closeRequested]], and *this*@[[pullScheduled]] to *false*.
   1. Set *this*@[[reader]], *this*@[[pullingPromise]], and *this*@[[storedError]] to *undefined*.
-  1. Set *this*@[[controller]] to Construct(<code>ReadableStreamController</code>, «*this*»).
+  1. Set *this*@[[controller]] to Construct(`ReadableStreamController`, «*this*»).
   1. Let _startResult_ be InvokeOrNoop(_underlyingSource_, "start", «*this*@[[controller]]»).
   1. ReturnIfAbrupt(startResult).
   1. Resolve _startResult_ as a promise:
@@ -478,6 +489,48 @@ bulletproofing before we write it up in prose.
 For now, please consider the reference implementation normative:
 <a href="https://github.com/whatwg/streams/blob/master/reference-implementation/lib/readable-stream.js">reference-implementation/lib/readable-stream.js</a>,
 look for the <code>pipeTo</code> method.
+
+<h5 id="rs-tee">tee()</h5>
+
+<div class="note">
+  The <code>tee</code> method <a lt="tee a readable stream">tees</a> this readable stream, returning a two-element
+  array containing the two resulting branches as new <code>ReadableStream</code> instances.
+
+  Teeing a stream will <a lt="locked to a reader">lock</a> it, preventing any other consumer from acquiring a reader.
+  To <a lt="cancel a readable stream">cancel</a> the stream, cancel both of the resulting branches; a composite
+  cancellation reason will then be propagated to the stream's <a>underlying source</a>.
+
+  Note that the <a>chunks</a> seen in each branch will be the same object. If the chunks are not immutable, this could
+  allow interference between the two branches. (<a href="https://github.com/whatwg/streams/issues/new">Let us know</a>
+  if you think we should add an option to <code>tee</code> that creates <a>structured clones</a> of the chunks for each
+  branch.)
+</div>
+
+<pre is="emu-alg">
+  1. If IsReadableStream(*this*) is *false*, throw a *TypeError* exception.
+  1. Let _branches_ be TeeReadableStream(*this*, *false*).
+  1. ReturnIfAbrupt(_branches_).
+  1. Return CreateArrayFromList(_branches_).
+</pre>
+
+<div class="example">
+  Teeing a stream is most useful when you wish to let two independent consumers read from the stream in parallel,
+  perhaps even at different speeds. For example, given a writable stream <code>cacheEntry</code> representing an
+  on-disk file, and another writable stream <code>httpRequestBody</code> representing an upload to a remote server,
+  you could pipe the same readable stream to both destinations at once:
+
+  <pre><code class="lang-javascript">
+    const [forLocal, forRemote] = readableStream.tee();
+
+    Promise.all([
+      forLocal.pipeTo(cacheEntry),
+      forRemote.pipeTo(httpRequestBody)
+    ])
+    .then(() => console.log("Saved the stream to the cache and also uploaded it!"))
+    .catch(e => console.error("Either caching or uploading failed: ", e));
+  </code></pre>
+</div>
+
 
 <h3 id="rs-controller-class" lt="ReadableStreamController">Class <code>ReadableStreamController</code></h3>
 
@@ -929,6 +982,126 @@ readable stream is <a>locked to a reader</a>.
     1. If _shouldApplyBackpressure_ is an abrupt completion, call-with-rethrow ErrorReadableStream(_stream_, ‍_shouldApplyBackpressure_.[[value]]).
   1. Return _shouldApplyBackpressure_.
 </pre>
+
+<h4 id="tee-readable-stream" aoid="TeeReadableStream">TeeReadableStream ( stream, shouldClone )</h4>
+
+This abstract operation is meant to be called from other specifications that may wish to
+<a lt="tee a readable stream">tee</a> a given readable stream. Its second argument governs whether or not the data from
+the original stream will be <a lt="structured clone">structured cloned</a> before becoming visible in the returned
+branches.
+
+<pre is="emu-alg">
+  1. Assert: IsReadableStream(_stream_) is *true*.
+  1. Assert: Type(_shouldClone_) is Boolean.
+  1. Let _reader_ be AcquireReadableStreamReader(_reader_).
+  1. ReturnIfAbrupt(_reader_).
+  1. Let _teeState_ be Record{[[closedOrErrored]]: *false*, [[canceled1]]: *false*, [[canceled2]]: *false*, [[reason1]]: *undefined*, [[reason2]]: *undefined*, [[promise]]: a new promise}.
+  1. Let _pull_ be a new <a>TeeReadableStream pull function</a>.
+  1. Set _pull_@[[reader]] to _reader_, _pull_@[[teeState]] to _teeState_, and _pull_@[[shouldClone]] to _shouldClone_.
+  1. Let _cancel1_ be a new <a>TeeReadableStream branch 1 cancel function</a>.
+  1. Set _cancel1_@[[stream]] to _stream_ and _cancel1_@[[teeState]] to _teeState_.
+  1. Let _cancel2_ be a new <a>TeeReadableStream branch 2 cancel function</a>.
+  1. Set _cancel2_@[[stream]] to _stream_ and _cancel2_@[[teeState]] to _teeState_.
+  1. Let _underlyingSource1_ be ObjectCreate(%ObjectPrototype%).
+  1. Perform CreateDataProperty(_underlyingSource1_, "pull", _pull_).
+  1. Perform CreateDataProperty(_underlyingSource1_, "cancel", _cancel1_).
+  1. Let _branch1_ be Construct(`ReadableStream`, _underlyingSource1_).
+  1. Let _underlyingSource2_ be ObjectCreate(%ObjectPrototype%).
+  1. Perform CreateDataProperty(_underlyingSource2_, "pull", _pull_).
+  1. Perform CreateDataProperty(_underlyingSource2_, "cancel", _cancel2_).
+  1. Let _branch2_ be Construct(`ReadableStream`, _underlyingSource2_).
+  1. Set _pull_@[[branch1]] to _branch1_.
+  1. Set _pull_@[[branch2]] to _branch2_.
+  1. Upon rejection of _reader_@[[closedPromise]] with reason _r_,
+    1. If _teeState_.[[closedOrErrored]] is *true*, return *undefined*.
+    1. Call-with-rethrow ErrorReadableStream(_branch1_, _r_).
+    1. Call-with-rethrow ErrorReadableStream(_branch2_, _r_).
+    1. Set _teeState_.[[closedOrErrored]] to *true*.
+  1. Return «branch1, branch2».
+</pre>
+
+<div class="note">
+  The given algorithm creates two clones of each chunk, and discards the original, instead of creating one clone and
+  giving the original to one branch and the clone to another. This is done to ensure symmetry between the chunks seen
+  by each branch; for example, the clone of <code class="lang-javascript">const r = /?:/; r.expando = "!";</code> is
+  distinguishable from the original since the clone will not have the expando property.
+
+  However, in specific cases implementations may be able to do something more optimal, without observable consequences.
+  For example if each chunk is created by the implementation, and cannot otherwise be modified by the developer, it may
+  be possible to ensure the original and its clone are not distinguishable, in which case only one clone operation
+  would be necessary. <a href="https://lists.w3.org/Archives/Public/public-webcrypto/2014Mar/0141.html">But, be
+  careful!</a>
+</div>
+
+A <dfn>TeeReadableStream pull function</dfn> is an anonymous built-in function that pulls data from a given <a>readable
+stream reader</a> and enqueues it into two other streams ("branches" of the associated tee). Each TeeReadableStream
+pull function has \[[reader]], \[[branch1]], \[[branch2]], \[[teeState]], and \[[shouldClone]] internal slots. When a
+TeeReadableStream pull function <var>F</var> is called, it performs the following steps:
+
+<pre is="emu-alg">
+  1. Let _reader_ be _F_@[[reader]], _branch1_ be _F_@[[branch1]], _branch2_ be _F_@[[branch2]], _teeState_ be _F_@[[teeState]], and _shouldClone_ be _F_@[[shouldClone]].
+  1. Return the result of transforming ReadFromReadableStreamReader(_reader_) by a fulfillment handler which takes the argument _result_ and performs the following steps:
+    1. Assert: Type(_result_) is Object.
+    1. Let _value_ be Get(_result_, "value").
+    1. ReturnIfAbrupt(_value_).
+    1. Let _done_ be Get(_result_, "done").
+    1. ReturnIfAbrupt(_done_).
+    1. Assert: Type(_done_) is Boolean.
+    1. If _done_ is *true* and _teeState_.[[closedOrErrored]] is *false*,
+      1. Call-with-rethrow CloseReadableStream(_branch1_).
+      1. Call-with-rethrow CloseReadableStream(_branch2_).
+      1. Set _teeState_.[[closedOrErrored]] to *true*.
+    1. If _teeState_.[[closedOrErrored]] is *true*, return *undefined*.
+    1. If _teeState_.[[canceled1]] is *false*,
+      1. Let _value1_ be _value_.
+      1. If _shouldClone_ is *true*, set _value1_ to a <a>structured clone</a> of _value_.
+      1. Call-with-rethrow EnqueueInReadableStream(_branch1_, _value1_).
+    1. If _teeState_.[[canceled2]] is *false*,
+      1. Let _value2_ be _value_.
+      1. If _shouldClone_ is *true*, set _value2_ to a <a>structured clone</a> of _value_.
+      1. Call-with-rethrow EnqueueInReadableStream(_branch2_, _value2_).
+</pre>
+
+A <dfn>TeeReadableStream branch 1 cancel function</dfn> is an anonymous built-in function that reacts to the
+cancellation of the first of the two branches of the associated tee. Each TeeReadableStream branch 1 cancel function
+has \[[stream]] and \[[teeState]] internal slots. When a TeeReadableStream branch 1 cancel function <var>F</var> is
+called with argument <var>r</var>, it performs the following steps:
+
+<pre is="emu-alg">
+  1. Let _stream_ be _F_@[[stream]] and _teeState_ be _F_@[[teeState]].
+  1. Set _teeState_.[[canceled1]] to *true*.
+  1. Set _teeState_.[[reason1]] to _r_.
+  1. If _teeState_.[[canceled2]] is *true*,
+    1. Let _compositeReason_ be CreateArrayFromList(«_teeState_.[[reason1]], _teeState_.[[reason2]]»).
+    1. Let _cancelResult_ be CancelReadableStream(_stream_, _compositeReason_).
+    1. ReturnIfAbrupt(_cancelResult_).
+    1. Resolve _teeState_.[[promise]] with _cancelResult_.
+  1. Return _teeState_.[[promise]].
+</pre>
+
+A <dfn>TeeReadableStream branch 2 cancel function</dfn> is an anonymous built-in function that reacts to the
+cancellation of the second of the two branches of the associated tee. Each TeeReadableStream branch 2 cancel function
+has \[[stream]] and \[[teeState]] internal slots. When a TeeReadableStream branch 2 cancel function <var>F</var> is
+called with argument <var>r</var>, it performs the following steps:
+
+<pre is="emu-alg">
+  1. Let _stream_ be _F_@[[stream]] and _teeState_ be _F_@[[teeState]].
+  1. Set _teeState_.[[canceled2]] to *true*.
+  1. Set _teeState_.[[reason2]] to _r_.
+  1. If _teeState_.[[canceled1]] is *true*,
+    1. Let _compositeReason_ be CreateArrayFromList(«_teeState_.[[reason1]], _teeState_.[[reason2]]»).
+    1. Let _cancelResult_ be CancelReadableStream(_stream_, _compositeReason_).
+    1. ReturnIfAbrupt(_cancelResult_).
+    1. Resolve _teeState_.[[promise]] with _cancelResult_.
+  1. Return _teeState_.[[promise]].
+</pre>
+
+<div class="note">
+  The algorithm given here is written such that three new function objects are created for each call to to
+  TeeReadableStream. This is just a simplification, and is not actually necessary, since it is unobservable to
+  developer code. For example, a self-hosted implementation could optimize by creating a class whose prototype contains
+  methods for these functions, with the state stored as instance variables.
+</div>
 
 <h2 id="ws">Writable Streams</h2>
 

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -25,6 +25,17 @@ export function toInteger(v) {
   return Math.floor(Math.abs(v));
 }
 
+export function createDataProperty(o, p, v) {
+  assert(typeIsObject(o));
+  Object.defineProperty(o, p, { value: v, writable: true, enumerable: true, configurable: true });
+}
+
+export function createArrayFromList(elements) {
+  // We use arrays to represent lists, so this is basically a no-op.
+  // Do a slice though just in case we happen to depend on the unique-ness.
+  return elements.slice();
+}
+
 export function CreateIterResultObject(value, done) {
   assert(typeof done === 'boolean');
   const obj = {};

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -198,6 +198,10 @@ class ReadableStreamController {
       throw new TypeError('ReadableStreamController.prototype.error can only be used on a ReadableStreamController');
     }
 
+    if (this._controlledReadableStream._state !== 'readable') {
+      throw new TypeError(`The stream is ${this._controlledReadableStream._state} and so cannot be errored`);
+    }
+
     return ErrorReadableStream(this._controlledReadableStream, e);
   }
 }
@@ -425,9 +429,7 @@ function EnqueueInReadableStream(stream, chunk) {
 }
 
 function ErrorReadableStream(stream, e) {
-  if (stream._state !== 'readable') {
-    throw new TypeError(`The stream is ${stream._state} and so cannot be errored`);
-  }
+  assert(stream._state === 'readable');
 
   stream._queue = [];
   stream._storedError = e;

--- a/reference-implementation/test/brand-checks.js
+++ b/reference-implementation/test/brand-checks.js
@@ -26,9 +26,10 @@ test('Can get the ReadableStreamController constructor indirectly', t => {
 function fakeReadableStream() {
   return {
     cancel(reason) { return Promise.resolve(); },
+    getReader() { return new ReadableStream(new ReadableStream()); },
     pipeThrough({ writable, readable }, options) { return readable; },
     pipeTo(dest, { preventClose, preventAbort, preventCancel } = {}) { return Promise.resolve(); },
-    getReader() { return new ReadableStream(new ReadableStream()); }
+    tee() { return [realReadableStream(), realReadableStream()]; }
   };
 }
 
@@ -164,6 +165,12 @@ test('ReadableStream.prototype.pipeTo works generically on its this and its argu
   // TODO: expand this with a full fake that records what happens to it?
 
   t.doesNotThrow(() => ReadableStream.prototype.pipeTo.call(fakeReadableStream(), fakeWritableStream()));
+});
+
+test('ReadableStream.prototype.tee enforces a brand check', t => {
+  t.plan(2);
+  methodThrows(t, ReadableStream.prototype, 'tee', fakeReadableStream());
+  methodThrows(t, ReadableStream.prototype, 'tee', realWritableStream());
 });
 
 

--- a/reference-implementation/test/readable-stream-tee.js
+++ b/reference-implementation/test/readable-stream-tee.js
@@ -1,0 +1,170 @@
+const test = require('tape-catch');
+
+import readableStreamToArray from './utils/readable-stream-to-array';
+
+test('ReadableStream teeing: rs.tee() returns an array of two ReadableStreams', t => {
+  const rs = new ReadableStream();
+
+  const result = rs.tee();
+
+  t.ok(Array.isArray(result), 'return value should be an array');
+  t.equal(result.length, 2, 'array should have length 2');
+  t.equal(result[0].constructor, ReadableStream, '0th element should be a ReadableStream');
+  t.equal(result[1].constructor, ReadableStream, '1st element should be a ReadableStream');
+  t.end();
+});
+
+test('ReadableStream teeing: should be able to read one branch to the end without affecting the other', t => {
+  t.plan(5);
+
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+      c.close();
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  const [reader1, reader2] = [branch1.getReader(), branch2.getReader()];
+
+  reader1.closed.then(() => t.pass('branch1 should be closed')).catch(e => t.error(e));
+  reader2.closed.then(() => t.fail('branch2 should not be closed'));
+
+  reader1.read().then(r => t.deepEqual(r, { value: 'a', done: false }, 'first chunk from branch1 should be correct'));
+  reader1.read().then(r => t.deepEqual(r, { value: 'b', done: false }, 'second chunk from branch1 should be correct'));
+  reader1.read().then(r => t.deepEqual(r, { value: undefined, done: true },
+    'third read() from branch1 should be done'));
+
+  reader2.read().then(r => t.deepEqual(r, { value: 'a', done: false }, 'first chunk from branch2 should be correct'));
+});
+
+test('ReadableStream teeing: values should be equal across each branch', t => {
+  t.plan(1);
+
+  const theObject = { the: 'test object' };
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue(theObject);
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  const [reader1, reader2] = [branch1.getReader(), branch2.getReader()];
+
+  Promise.all([reader1.read(), reader2.read()]).then(([{ value: value1 }, { value: value2 }]) => {
+    t.equal(value1, value2, 'the values should be equal');
+  });
+});
+
+test('ReadableStream teeing: errors in the source should propagate to both branches', t => {
+  t.plan(6);
+
+  const theError = new Error('boo!');
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+    },
+    pull() {
+      throw theError;
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  const [reader1, reader2] = [branch1.getReader(), branch2.getReader()];
+
+  reader1.label = 'reader1';
+  reader2.label = 'reader2';
+
+  reader1.closed.catch(e => t.equal(e, theError, 'branch1 closed promise should reject with the error'));
+  reader2.closed.catch(e => t.equal(e, theError, 'branch2 closed promise should reject with the error'));
+
+  reader1.read().then(r => t.deepEqual(r, { value: 'a', done: false },
+    'should be able to read the first chunk in branch1'));
+
+  reader1.read().then(r => {
+    t.deepEqual(r, { value: 'b', done: false }, 'should be able to read the second chunk in branch1');
+
+    return reader2.read().then(
+      () => t.fail('once the root stream has errored, you should not be able to read from branch2'),
+      e => t.equal(e, theError, 'branch2 read() promise should reject with the error')
+    );
+  })
+  .then(() => {
+    return reader1.read().then(
+      () => t.fail('once the root stream has errored, you should not be able to read from branch1 either'),
+      e => t.equal(e, theError, 'branch1 read() promise should reject with the error')
+    );
+  })
+  .catch(e => t.error(e));
+});
+
+test('ReadableStream teeing: canceling branch1 should not impact branch2', t => {
+  t.plan(2);
+
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+      c.close();
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  branch1.cancel();
+
+  readableStreamToArray(branch1).then(chunks => t.deepEqual(chunks, [], 'branch1 should have no chunks'));
+  readableStreamToArray(branch2).then(chunks => t.deepEqual(chunks, ['a', 'b'], 'branch2 should have two chunks'));
+});
+
+test('ReadableStream teeing: canceling branch2 should not impact branch1', t => {
+  t.plan(2);
+
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+      c.close();
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  branch2.cancel();
+
+  readableStreamToArray(branch1).then(chunks => t.deepEqual(chunks, ['a', 'b'], 'branch1 should have two chunks'));
+  readableStreamToArray(branch2).then(chunks => t.deepEqual(chunks, [], 'branch2 should have no chunks'));
+});
+
+test('ReadableStream teeing: canceling both branches should aggregate the cancel reasons into an array', t => {
+  t.plan(1);
+
+  const reason1 = new Error('We\'re wanted men.');
+  const reason2 = new Error('I have the death sentence on twelve systems.');
+
+  const rs = new ReadableStream({
+    cancel(reason) {
+      t.deepEqual(reason, [reason1, reason2],
+        'the cancel reason should be an array containing those from the branches');
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  branch1.cancel(reason1);
+  branch2.cancel(reason2);
+});
+
+test('ReadableStream teeing: failing to cancel the original stream should cause cancel() to reject on branches', t => {
+  t.plan(2);
+
+  const theError = new Error('I\'ll be careful.');
+  const rs = new ReadableStream({
+    cancel() {
+      throw theError;
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+  branch1.cancel().catch(e => t.equal(e, theError, 'branch1.cancel() should reject with the error'));
+  branch2.cancel().catch(e => t.equal(e, theError, 'branch2.cancel() should reject with the error'));
+});


### PR DESCRIPTION
This PR supercedes #302. It is based on the same algorithm, but fully formalized and moved into the spec.

To get it formalized, I had to do a lot of cleanup around other abstract operations---mostly factoring out abstract operations from places that used to be accessible only through the public API. This should help create a better version of https://github.com/yutakahirano/fetch-with-streams/pull/28, for example. Each of the commits should be pretty simple to review individually.

The only real decisions that I want to highlight are:

- From https://github.com/whatwg/streams/pull/302#issuecomment-83484519, I chose "both cancels reject".
- The public `rs.tee()` method does not do any cloning; the TeeReadableStream abstract operation takes a second parameter that lets you decide whether to do structured cloning or not. Presumably for uses that will share across threads, like much of fetch, we'll need cloning.
- Should we expose `rs.tee()` at all? I mostly exposed it because otherwise my unit testing setup was not able to test it :P. But I can work around that, certainly. Maybe it is best to leave it off for now? I am a bit afraid that having non-cloning `rs.tee()` available would be a footgun for fetch body streams, given that many of the things you do with fetch body streams involve shuffling them off to another thread. Or do we assume that if you're going to do such things, you'll use the whole `response` object, and if you do `response.body.tee()`, you know what you're getting in to? That also seems plausible.

Branch snapshot at https://streams.spec.whatwg.org/branch-snapshots/tee-again/; sections of note:

- https://streams.spec.whatwg.org/branch-snapshots/tee-again/#tee-a-readable-stream
- https://streams.spec.whatwg.org/branch-snapshots/tee-again/#rs-tee
- https://streams.spec.whatwg.org/branch-snapshots/tee-again/#tee-readable-stream