### PR TITLE
Precise flow control for readable streams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -291,14 +291,15 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
       state and queue of this stream
   </tr>
   <tr>
-    <td>\[[pullScheduled]]
-    <td>A boolean flag set to <b>true</b> when the underlying source's <code>pull</code> method is scheduled to be
-      called again after the current call to it finishes
+    <td>\[[pullAgain]]
+    <td>A boolean flag set to <b>true</b> if the stream's mechanisms requested a call to the underlying source's
+      <code>pull</code> method to pull more data, but the pull could not yet be done since a previous call is still
+      executing
   </tr>
   <tr>
-    <td>\[[pullingPromise]]
-    <td>A promise returned by the <a>underlying source</a>'s <code>pull</code> method, stored so that the stream can
-      re-pull when it fulfills
+    <td>\[[pulling]]
+    <td>A boolean flag set to <b>true</b> while the underlying source's <code>pull</code> method is executing and has
+      not yet fulfilled, used to prevent reentrant calls
   </tr>
   <tr>
     <td>\[[queue]]
@@ -374,8 +375,8 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   1. Set *this*@[[underlyingSource]] to _underlyingSource_.
   1. Set *this*@[[queue]] to a new empty List.
   1. Set *this*@[[state]] to "readable".
-  1. Set *this*@[[started]], *this*@[[closeRequested]], and *this*@[[pullScheduled]] to *false*.
-  1. Set *this*@[[reader]], *this*@[[pullingPromise]], and *this*@[[storedError]] to *undefined*.
+  1. Set *this*@[[started]], *this*@[[closeRequested]], *this*@[[pullAgain]], and *this*@[[pulling]] to *false*.
+  1. Set *this*@[[reader]] and *this*@[[storedError]] to *undefined*.
   1. Set *this*@[[controller]] to Construct(`ReadableStreamController`, «*this*»).
   1. Let _strategy_ be Get(_underlyingSource_, "strategy").
   1. ReturnIfAbrupt(_strategy_).
@@ -386,7 +387,7 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   1. Resolve _startResult_ as a promise:
     1. Upon fulfillment,
       1. Set *this*@[[started]] to *true*.
-      1. Return CallReadableStreamPull(*this*).
+      1. Return RequestReadableStreamPull(*this*).
     1. Upon rejection with reason _r_,
       1. If *this*@[[state]] is "readable", return ErrorReadableStream(*this*, _r_).
 </pre>
@@ -809,26 +810,6 @@ reader</a> for a given stream.
   1. Return Construct(`ReadableStreamReader`, «‍_stream_»).
 </pre>
 
-<h4 id="call-readable-stream-pull" aoid="CallReadableStreamPull">CallReadableStreamPull ( stream )</h4>
-
-<pre is="emu-alg">
-  1. If _stream_@[[closeRequested]] is *true* or _stream_@[[started]] is *false* or _stream_@[[state]] is "closed" or _stream_@[[state]] is "errored" or _stream_@[[pullScheduled]] is *true*, return *undefined*.
-  1. If _stream_@[[pullingPromise]] is not *undefined*,
-    1. Set _stream_@[[pullScheduled]] to *true*.
-    1. Upon fulfillment of _stream_@[[pullingPromise]],
-      1. Set _stream_@[[pullScheduled]] to *false*.
-      1. Call-with-rethrow CallReadableStreamPull(_stream_).
-    1. Return *undefined*.
-  1. If IsReadableStreamLocked(_stream_) is *false* or _stream_@[[reader]]@[[readRequests]] is empty,
-    1. Let _desiredSize_ be GetReadableStreamDesiredSize(_stream_).
-    1. ReturnIfAbrupt(_desiredSize_).
-    1. If _desiredSize_ ≤ 0, return *undefined*.
-  1. Set _stream_@[[pullingPromise]] to PromiseInvokeOrNoop(_stream_@[[underlyingSource]], "pull", «‍_stream_@[[controller]]»).
-  1. Upon fulfillment of _stream_@[[pullingPromise]], set _stream_@[[pullingPromise]] to *undefined*.
-  1. Upon rejection of _stream_@[[pullingPromise]] with reason _e_, if _stream_@[[state]] is "readable", return ErrorReadableStream(_stream_, _e_).
-  1. Return *undefined*.
-</pre>
-
 <h4 id="cancel-readable-stream" aoid="CancelReadableStream">CancelReadableStream ( stream, reason )</h4>
 
 <pre is="emu-alg">
@@ -895,7 +876,7 @@ asserts).
     1. If _enqueueResult_ is an abrupt completion,
       1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_enqueueResult_.[[value]]).
       1. Return _enqueueResult_.
-  1. Call-with-rethrow CallReadableStreamPull(_stream_).
+  1. Call-with-rethrow RequestReadableStreamPull(_stream_).
   1. Return *undefined*.
 </pre>
 
@@ -967,11 +948,12 @@ readable stream is <a>locked to a reader</a>.
   1. If _reader_@[[ownerReadableStream]]@[[queue]] is not empty,
     1. Let _chunk_ be DequeueValue(_reader_@[[ownerReadableStream]]@[[queue]]).
     1. If _reader_@[[ownerReadableStream]]@[[closeRequested]] is *true* and _reader_@[[ownerReadableStream]]@[[queue]] is now empty, call-with-rethrow FinishClosingReadableStream(_reader_@[[ownerReadableStream]]).
-    1. Otherwise, call-with-rethrow CallReadableStreamPull(_reader_@[[ownerReadableStream]]).
+    1. Otherwise, call-with-rethrow RequestReadableStreamPull(_reader_@[[ownerReadableStream]]).
     1. Return a new promise resolved with CreateIterResultObject(_chunk_, *false*).
   1. Otherwise,
     1. Let _readRequestPromise_ be a new promise.
     1. Append _readRequestPromise_ as the last element of _reader_@[[readRequests]].
+    1. Call-with-rethrow RequestReadableStreamPull(_reader_@[[ownerReadableStream]]).
     1. Return _readRequestPromise_.
 </pre>
 
@@ -994,6 +976,40 @@ readable stream is <a>locked to a reader</a>.
   1. Set _reader_@[[readRequests]] to a new empty List.
   1. Set _reader_@[[ownerReadableStream]]@[[reader]] to *undefined*.
   1. Set _reader_@[[ownerReadableStream]] to *undefined*.
+</pre>
+
+<h4 id="request-readable-stream-pull" aoid="RequestReadableStreamPull">RequestReadableStreamPull ( stream )</h4>
+
+<pre is="emu-alg">
+  1. Let _shouldPull_ be ShouldReadableStreamPull(stream).
+  1. ReturnIfAbrupt(_shouldPull_).
+  1. If _shouldPull_ is *false*, return *undefined*.
+  1. If _stream_@[[pulling]] is *true*,
+    1. Set _stream_@[[pullAgain]] to *true*.
+    1. Return *undefined*.
+  1. Set _stream_@[[pulling]] to *true*.
+  1. Let _pullPromise_ be PromiseInvokeOrNoop(_stream_@[[underlyingSource]], "pull", «‍_stream_@[[controller]]»).
+  1. Upon fulfillment of _pullPromise_,
+    1. Set _stream_@[[pulling]] to *false*.
+    1. If _stream_@[[pullAgain]] is *true*,
+      1. Set _stream_@[[pullAgain]] to *false*.
+      1. Return RequestReadableStreamPull(_stream_).
+  1. Upon rejection of _pullPromise_ with reason _e_,
+    1. If _stream_@[[state]] is "readable", return ErrorReadableStream(_stream_, _e_).
+  1. Return *undefined*.
+</pre>
+
+<h4 id="should-readable-stream-pull" aoid="ShouldReadableStreamPull">ShouldReadableStreamPull ( stream )</h4>
+
+<pre is="emu-alg">
+  1. If _stream_@[[state]] is "closed" or _stream_@[[state]] is "errored", return *false*.
+  1. If _stream_@[[closeRequested]] is *true*, return *false*.
+  1. If _stream_@[[started]] is *false*, return *false*.
+  1. If IsReadableStreamLocked(_stream_) is *true* and _stream_@[[reader]]@[[readRequests]] is not empty, return *true*.
+  1. Let _desiredSize_ be GetReadableStreamDesiredSize(_stream_).
+  1. ReturnIfAbrupt(_desiredSize_).
+  1. If _desiredSize_ > 0, return *true*.
+  1. Return *false*.
 </pre>
 
 <h4 id="tee-readable-stream" aoid="TeeReadableStream">TeeReadableStream ( stream, shouldClone )</h4>

--- a/index.bs
+++ b/index.bs
@@ -387,7 +387,8 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
     1. Upon fulfillment,
       1. Set *this*@[[started]] to *true*.
       1. Return CallReadableStreamPull(*this*).
-    1. Upon rejection with reason _r_, return ErrorReadableStream(*this*, _r_).
+    1. Upon rejection with reason _r_,
+      1. If *this*@[[state]] is "readable", return ErrorReadableStream(*this*, _r_).
 </pre>
 
 <h4 id="rs-prototype">Properties of the <code>ReadableStream</code> Prototype</h4>
@@ -824,7 +825,7 @@ reader</a> for a given stream.
     1. If _desiredSize_ ≤ 0, return *undefined*.
   1. Set _stream_@[[pullingPromise]] to PromiseInvokeOrNoop(_stream_@[[underlyingSource]], "pull", «‍_stream_@[[controller]]»).
   1. Upon fulfillment of _stream_@[[pullingPromise]], set _stream_@[[pullingPromise]] to *undefined*.
-  1. Upon rejection of _stream_@[[pullingPromise]] with reason _e_, return ErrorReadableStream(_stream_, _e_).
+  1. Upon rejection of _stream_@[[pullingPromise]] with reason _e_, if _stream_@[[state]] is "readable", return ErrorReadableStream(_stream_, _e_).
   1. Return *undefined*.
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -167,16 +167,20 @@ source</a>, but not yet read by the consumer. In the case of a writable stream, 
 <a>chunks</a> which have been written to the stream by the producer, but not yet processed and acknowledged by the
 <a>underlying sink</a>.
 
-A <dfn>queuing strategy</dfn> is a pair of methods that help determine whether a stream should apply
-<a>backpressure</a> based on the state of its <a>internal queue</a>. The queuing strategy assigns a size to each
-<a>chunk</a>; later, the stream implementation asks the queuing strategy whether the stream should apply backpressure,
-based the total size of all chunks in the stream's internal queue.
+A <dfn>queuing strategy</dfn> is an object that determines how a stream should signal <a>backpressure</a> based on
+the state of its <a>internal queue</a>. The queuing strategy assigns a size to each <a>chunk</a>, and compares the
+total size of all chunks in the queue to a specified number, known as the <dfn>high water mark</dfn>. The resulting
+difference, high water mark minus total size, is used to determine the
+<dfn lt="desired size to fill a stream's internal queue">desired size to fill the stream's queue</dfn>.
+
+For readable streams, an underlying source can use this desired size as a backpressure signal, slowing down chunk
+generation so as to try to keep the desired size above or at zero. For writable streams, a producer can behave
+similarly, avoiding writes that would cause the desired size to go negative.
 
 <div class="example">
-  A simple example of a queuing strategy would be one that assigns a size of one to each chunk, and applies
-  backpressure whenever three or more chunks are in the internal queue. This would mean that up to three chunks could
-  be enqueued in a readable stream, or three chunks could be written to a writable stream, before they send a
-  backpressure signal.
+  A simple example of a queuing strategy would be one that assigns a size of one to each chunk, and has a high water
+  mark of three. This would mean that up to three chunks could be enqueued in a readable stream, or three chunks
+  written to a writable stream, before the streams are considered to be applying backpressure.
 </div>
 
 A queuing strategy is generally associated with a specific type of <a>underlying source</a> or <a>underlying sink</a>.
@@ -320,6 +324,16 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
       on an errored stream
   </tr>
   <tr>
+    <td>\[[strategySize]]
+    <td>A function supplied to the constructor as part of the stream's <a>queuing strategy</a>, designed to calculate
+      the size of enqueued <a>chunks</a>; can be <b>undefined</b> for the default behavior.
+  </tr>
+  <tr>
+    <td>\[[strategyHWM]]
+    <td>A number supplied to the constructor as part of the stream's <a>queuing strategy</a>, indicating the point at
+      which the stream will apply <a>backpressure</a> to its <a>underlying source</a>.
+  </tr>
+  <tr>
     <td>\[[underlyingSource]]
     <td>An object representation of the stream's <a>underlying source</a>, including its <a>queuing strategy</a>; also
       used for the <a href="#is-readable-stream">IsReadableStream</a> brand check
@@ -349,11 +363,11 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   state via the passed <code>controller</code> object. This is an example of the
   <a href="https://blog.domenic.me/the-revealing-constructor-pattern/">revealing constructor pattern</a>.
 
-  The underlying source can also have a <code>strategy</code> property containing a <a>queuing strategy</a> object with
-  two methods <code>shouldApplyBackpressure(queueSize)</code> and <code>size(chunk)</code>. These could be instances of
-  the built-in <code>CountQueuingStrategy</code> or <code>ByteLengthQueuingStrategy</code> classes, or custom strategy
-  objects. If no strategy is supplied, the default behavior will be to apply backpressure (via the return value of
-  <code>enqueue</code>) when enqueuing into a non-empty queue.
+  The underlying sink can also have a <code>strategy</code> property containing a <a>queuing strategy</a> object with
+  two properties: a non-negative number <code>highWaterMark</code>, and a function <code>size(chunk)</code>. The
+  supplied <code>strategy</code> could be an instance of the built-in <code>CountQueuingStrategy</code> or
+  <code>ByteLengthQueuingStrategy</code> classes, or it could be custom. If no strategy is supplied, the default
+  behavior will be the same as a <code>CountQueuingStrategy</code> with a high water mark of 1.
 </div>
 
 <pre is="emu-alg">
@@ -363,8 +377,12 @@ Instances of <code>ReadableStream</code> are created with the internal slots des
   1. Set *this*@[[started]], *this*@[[closeRequested]], and *this*@[[pullScheduled]] to *false*.
   1. Set *this*@[[reader]], *this*@[[pullingPromise]], and *this*@[[storedError]] to *undefined*.
   1. Set *this*@[[controller]] to Construct(`ReadableStreamController`, «*this*»).
+  1. Let _strategy_ be Get(_underlyingSource_, "strategy").
+  1. ReturnIfAbrupt(_strategy_).
+  1. Let _normalizedStrategy_ be ValidateAndNormalizeQueuingStrategy(_strategy_, 1).
+  1. Set *this*@[[strategySize]] to _normalizedStrategy_.[[size]] and *this*@[[strategyHWM]] to _normalizedStrategy_.[[highWaterMark]].
   1. Let _startResult_ be InvokeOrNoop(_underlyingSource_, "start", «*this*@[[controller]]»).
-  1. ReturnIfAbrupt(startResult).
+  1. ReturnIfAbrupt(_startResult_).
   1. Resolve _startResult_ as a promise:
     1. Upon fulfillment,
       1. Set *this*@[[started]] to *true*.
@@ -549,6 +567,8 @@ it would look like
   class ReadableStreamController {
     constructor(stream)
 
+    get desiredSize()
+
     close()
     enqueue(chunk)
     error(e)
@@ -586,6 +606,13 @@ Instances of <code>ReadableStreamController</code> are created with the internal
 </pre>
 
 <h4 id="rs-controller-prototype">Properties of the <code>ReadableStreamController</code> Prototype</h4>
+
+<h5 id="rs-controller-desired-size">get desiredSize</h5>
+
+<pre is="emu-alg">
+  1. If IsReadableStreamController(*this*) is *false*, throw a *TypeError* exception.
+  1. Return GetReadableStreamDesiredSize(*this*@[[controlledReadableStream]]).
+</pre>
 
 <h5 id="rs-controller-close">close()</h5>
 
@@ -791,8 +818,10 @@ reader</a> for a given stream.
       1. Set _stream_@[[pullScheduled]] to *false*.
       1. Call-with-rethrow CallReadableStreamPull(_stream_).
     1. Return *undefined*.
-  1. Let _shouldApplyBackpressure_ be ShouldReadableStreamApplyBackpressure(_stream_).
-  1. If _shouldApplyBackpressure_ is *true*, return *undefined*.
+  1. If IsReadableStreamLocked(_stream_) is *false* or _stream_@[[reader]]@[[readRequests]] is empty,
+    1. Let _desiredSize_ be GetReadableStreamDesiredSize(_stream_).
+    1. ReturnIfAbrupt(_desiredSize_).
+    1. If _desiredSize_ ≤ 0, return *undefined*.
   1. Set _stream_@[[pullingPromise]] to PromiseInvokeOrNoop(_stream_@[[underlyingSource]], "pull", «‍_stream_@[[controller]]»).
   1. Upon fulfillment of _stream_@[[pullingPromise]], set _stream_@[[pullingPromise]] to *undefined*.
   1. Upon rejection of _stream_@[[pullingPromise]] with reason _e_, return ErrorReadableStream(_stream_, _e_).
@@ -855,26 +884,18 @@ asserts).
     1. Resolve _readRequestPromise_ with CreateIterResultObject(_chunk_, *false*).
   1. Otherwise,
     1. Let _chunkSize_ be *1*.
-    1. Let _strategy_ be Get(_stream_@[[underlyingSource]], "strategy").
-    1. If _strategy_ is an abrupt completion,
-      1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_strategy_.[[value]]).
-      1. Return _strategy_.
-    1. Let _strategy_ be _strategy_.[[value]].
-    1. If _strategy_ is not *undefined*, then
-      1. Set _chunkSize_ to Invoke(_strategy_, "size", «‍_chunk_»).
+    1. If _stream_@[[strategySize]] is not *undefined*,
+      1. Set _chunkSize_ to Call(_stream_@[[strategySize]], *undefined*, «‍_chunk_»).
       1. If _chunkSize_ is an abrupt completion,
         1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_chunkSize_.[[value]]).
         1. Return _chunkSize_.
       1. Let _chunkSize_ be _chunkSize_.[[value]].
-    1. Let _enqueueResult_ be EnqueueValueWithSize(_stream_@[[queue]], _chunk_, _chunkSize_.[[value]]).
+    1. Let _enqueueResult_ be EnqueueValueWithSize(_stream_@[[queue]], _chunk_, _chunkSize_).
     1. If _enqueueResult_ is an abrupt completion,
       1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_enqueueResult_.[[value]]).
       1. Return _enqueueResult_.
   1. Call-with-rethrow CallReadableStreamPull(_stream_).
-  1. Let _shouldApplyBackpressure_ be ShouldReadableStreamApplyBackpressure(_stream_).
-  1. ReturnIfAbrupt(_shouldApplyBackpressure_).
-  1. If _shouldApplyBackpressure_ is *true*, return *false*.
-  1. Return *true*.
+  1. Return *undefined*.
 </pre>
 
 <h4 id="error-readable-stream" aoid="ErrorReadableStream">ErrorReadableStream ( stream, e )</h4>
@@ -890,6 +911,14 @@ an assert).
   1. Set _stream_@[[storedError]] to _e_.
   1. Set _stream_@[[state]] to "errored".
   1. If IsReadableStreamLocked(_stream_) is *true*, return ReleaseReadableStreamReader(_stream_@[[reader]]).
+</pre>
+
+<h4 id="get-readable-stream-desired-size" aoid="GetReadableStreamDesiredSize">GetReadableStreamDesiredSize ( stream )</h4>
+
+<pre is="emu-alg">
+  1. Let _queueSize_ be GetTotalQueueSize(_stream_@[[queue]]).
+  1. ReturnIfAbrupt(_queueSize_).
+  1. Return _stream_@[[strategyHWM]] − _queueSize_.
 </pre>
 
 <h4 id="is-readable-stream" aoid="IsReadableStream">IsReadableStream ( x )</h4>
@@ -964,23 +993,6 @@ readable stream is <a>locked to a reader</a>.
   1. Set _reader_@[[readRequests]] to a new empty List.
   1. Set _reader_@[[ownerReadableStream]]@[[reader]] to *undefined*.
   1. Set _reader_@[[ownerReadableStream]] to *undefined*.
-</pre>
-
-<h4 id="should-readable-stream-apply-backpressure" aoid="ShouldReadableStreamApplyBackpressure">ShouldReadableStreamApplyBackpressure ( stream )</h4>
-
-<pre is="emu-alg">
-  1. Let _queueSize_ be GetTotalQueueSize(_stream_@[[queue]]).
-  1. ReturnIfAbrupt(_queueSize_).
-  1. Let _shouldApplyBackpressure_ be *true* if _queueSize_ > *1*, and *false* otherwise.
-  1. Let _strategy_ be Get(_stream_@[[underlyingSource]], "strategy").
-  1. If _strategy_ is an abrupt completion,
-    1. Call-with-rethrow ErrorReadableStream(_stream_, ‍_strategy_.[[value]]).
-    1. Return _strategy_.
-  1. Let _strategy_ be _strategy_.[[value]].
-  1. If _strategy_ is not *undefined*, then
-    1. Set _shouldApplyBackpressure_ to ToBoolean(Invoke(_strategy_, "shouldApplyBackpressure", «‍_queueSize_»)).
-    1. If _shouldApplyBackpressure_ is an abrupt completion, call-with-rethrow ErrorReadableStream(_stream_, ‍_shouldApplyBackpressure_.[[value]]).
-  1. Return _shouldApplyBackpressure_.
 </pre>
 
 <h4 id="tee-readable-stream" aoid="TeeReadableStream">TeeReadableStream ( stream, shouldClone )</h4>
@@ -1229,13 +1241,23 @@ Instances of <code>WritableStream</code> are created with the internal slots des
       on the stream while in the <code>"errored"</code> state
   </tr>
   <tr>
+    <td>\[[strategySize]]
+    <td>A function supplied to the constructor as part of the stream's <a>queuing strategy</a>, designed to calculate
+      the size of <a>chunks</a> written; can be <b>undefined</b> for the default behavior.
+  </tr>
+  <tr>
+    <td>\[[strategyHWM]]
+    <td>A number supplied to the constructor as part of the stream's <a>queuing strategy</a>, indicating the point at
+      which the stream will apply <a>backpressure</a> to any <a>producers</a>.
+  </tr>
+  <tr>
     <td>\[[readyPromise]]
     <td>A promise returned by the <code>ready</code> getter
   </tr>
   <tr>
     <td>\[[underlyingSink]]
-    <td>An object representation of the stream's <a>underlying sink</a>, including its <a>queuing strategy</a>; also
-      used for the <a href="#is-writable-stream">IsWritableStream</a> brand check
+    <td>An object representation of the stream's <a>underlying sink</a>; also used for the
+      <a href="#is-writable-stream">IsWritableStream</a> brand check
   </tr>
   <tr>
     <td>\[[writing]]
@@ -1272,9 +1294,10 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   </ul>
 
   The underlying sink can also have a <code>strategy</code> property containing a <a>queuing strategy</a> object with
-  two methods <code>shouldApplyBackpressure(queueSize)</code> and <code>size(chunk)</code>. These could be instances of
-  the built-in <code>CountQueuingStrategy</code> or <code>ByteLengthQueuingStrategy</code> classes, or custom strategy
-  objects. By default, a strategy that applies backpressure whenever writing into a non-empty queue will be used.
+  two properties: a non-negative number <code>highWaterMark</code>, and a function <code>size(chunk)</code>. The
+  supplied <code>strategy</code> could be an instance of the built-in <code>CountQueuingStrategy</code> or
+  <code>ByteLengthQueuingStrategy</code> classes, or it could be custom. If no strategy is supplied, the default
+  behavior will be the same as a <code>CountQueuingStrategy</code> with a high water mark of 0.
 </div>
 
 <div class="note">
@@ -1294,6 +1317,10 @@ Instances of <code>WritableStream</code> are created with the internal slots des
   1. Set *this*@[[state]] to "writable".
   1. Set *this*@[[started]] and *this*@[[writing]] to *false*.
   1. Call-with-rethrow SyncWritableStreamStateWithQueue(*this*).
+  1. Let _strategy_ be Get(_underlyingSink_, "strategy").
+  1. ReturnIfAbrupt(_strategy_).
+  1. Let _normalizedStrategy_ be ValidateAndNormalizeQueuingStrategy(_strategy_, 0).
+  1. Set *this*@[[strategySize]] to _normalizedStrategy_.[[size]] and *this*@[[strategyHWM]] to _normalizedStrategy_.[[highWaterMark]].
   1. Let _error_ be a new <a><code>WritableStream</code> error function</a>.
   1. Set _error_@[[stream]] to *this*.
   1. Let _startResult_ be InvokeOrNoop(_underlyingSink_, "start", «_error_»).
@@ -1432,13 +1459,8 @@ a \[[stream]] internal slot. When a <code>WritableStream</code> error function <
   1. If *this*@[[state]] is "errored", return a promise rejected with *this*@[[storedError]].
   1. Assert: *this*@[[state]] is either "waiting" or "writable".
   1. Let _chunkSize_ be *1*.
-  1. Let _strategy_ be Get(*this*@[[underlyingSink]], "strategy").
-  1. If _strategy_ is an abrupt completion,
-    1. Call-with-rethrow ErrorWritableStream(*this*, _strategy_.[[value]]).
-    1. Return a new promise rejected with _strategy_.[[value]].
-  1. Set _strategy_ to _strategy_.[[value]].
-  1. If _strategy_ is not *undefined*, then
-    1. Set _chunkSize_ to Invoke(_strategy_, "size", «‍_chunk_»).
+  1. If *this*@[[strategySize]] is not *undefined*, then
+    1. Set _chunkSize_ to Call(*this*@[[strategySize]], *undefined*, «‍_chunk_»).
     1. If _chunkSize_ is an abrupt completion,
       1. Call-with-rethrow ErrorWritableStream(*this*, _chunkSize_.[[value]]).
       1. Return a new promise rejected with _chunkSize_.[[value]].
@@ -1511,12 +1533,7 @@ a \[[stream]] internal slot. When a <code>WritableStream</code> error function <
   1. Assert: _stream_@[[state]] is either "writable" or "waiting".
   1. Let _queueSize_ be GetTotalQueueSize(_stream_@[[queue]]).
   1. ReturnIfAbrupt(_queueSize_).
-  1. Let _shouldApplyBackpressure_ be *true* if _queueSize_ > 0, and *false* otherwise.
-  1. Let _strategy_ be Get(_stream_@[[underlyingSink]], "strategy").
-  1. ReturnIfAbrupt(_strategy_).
-  1. If _strategy_ is not *undefined*, then
-    1. Set _shouldApplyBackpressure_ to ToBoolean(Invoke(_strategy_, "shouldApplyBackpressure", «‍_queueSize_»)).
-    1. ReturnIfAbrupt(_shouldApplyBackpressure_).
+  1. Let _shouldApplyBackpressure_ be *true* if _queueSize_ > _stream_@[[strategyHWM]], and *false* otherwise.
   1. If _shouldApplyBackpressure_ is *true* and _stream_@[[state]] is "writable", then
     1. Set _stream_@[[state]] to "waiting".
     1. Set _stream_@[[readyPromise]] to a new promise.
@@ -1600,58 +1617,24 @@ If one were to write the <code>ByteLengthQueuingStrategy</code> class in somethi
 <pre><code class="lang-javascript">
   class ByteLengthQueuingStrategy {
     constructor({ highWaterMark })
-    shouldApplyBackpressure(queueSize)
     size(chunk)
   }
 </code></pre>
 
-<h4 id="blqs-internal-slots">Internal Slots</h4>
-
-Instances of <code>ByteLengthQueuingStrategy</code> are created with the internal slots described in the following
-table:
-
-<table>
-  <thead>
-    <tr>
-      <th>Internal Slot</th>
-      <th>Description (<em>non-normative</em>)</th>
-    </tr>
-  </thead>
-  <tr>
-    <td>\[[blqsHighWaterMark]]
-    <td>A nonnegative number that determines when the strategy applies <a>backpressure</a>
-  </tr>
-</table>
+Each <code>ByteLengthQueuingStrategy</code> instance will additionally have an own data property
+<code>highWaterMark</code> set by its constructor.
 
 <h4 id="blqs-constructor">new ByteLengthQueuingStrategy({ highWaterMark })</h4>
 
 <div class="note">
-  The constructor takes a nonnegative number for the high-water mark, and stores it for later use.
+  The constructor takes a nonnegative number for the high-water mark, and stores it on the object as a property.
 </div>
 
 <pre is="emu-alg">
-  1. Let _highWaterMark_ be ToNumber(_highWaterMark_).
-  1. If _highWaterMark_ is *NaN*, throw a *TypeError* exception.
-  1. If _highWaterMark_ < 0, throw a *RangeError* exception.
-  1. Set *this*@[[blqsHighWaterMark]] to _highWaterMark_.
+  1. CreateDataProperty(*this*, "highWaterMark", _highWaterMark_).
 </pre>
 
 <h4 id="blqs-prototype">Properties of the <code>ByteLengthQueuingStrategy</code> Prototype</h4>
-
-<h5 id="blqs-should-apply-backpressure">shouldApplyBackpressure(queueSize)</h5>
-
-<div class="note">
-  The <code>shouldApplyBackpressure</code> method returns whether or not the given queue size is greater than the
-  queuing strategy's high-water mark.
-</div>
-
-<pre is="emu-alg">
-  1. If Type(*this*) is not Object, throw a *TypeError* exception.
-  1. If *this* does not have a [[blqsHighWaterMark]] internal slot, throw a *TypeError* exception.
-  1. Let _queueSize_ be ToNumber(_queueSize_).
-  1. If _queueSize_ is *NaN*, return *false*.
-  1. Return _queueSize_ > *this*@[[blqsHighWaterMark]].
-</pre>
 
 <h5 id="blqs-size">size(chunk)</h5>
 
@@ -1708,57 +1691,24 @@ it would look like
 <pre><code class="lang-javascript">
   class CountQueuingStrategy {
     constructor({ highWaterMark })
-    shouldApplyBackpressure(queueSize)
     size()
   }
 </code></pre>
 
-<h4 id="cqs-internal-slots">Internal Slots</h4>
+Each <code>CountQueuingStrategy</code> instance will additionally have an own data property <code>highWaterMark</code>
+set by its constructor.
 
-Instances of <code>CountQueuingStrategy</code> are created with the internal slots described in the following table:
-
-<table>
-  <thead>
-    <tr>
-      <th>Internal Slot</th>
-      <th>Description (<em>non-normative</em>)</th>
-    </tr>
-  </thead>
-  <tr>
-    <td>\[[cqsHighWaterMark]]
-    <td>A nonnegative number that determines when the strategy applies <a>backpressure</a>
-  </tr>
-</table>
-
-<h4 id="cqs-constructor">new CountQueuingStrategy({ highWaterMark })</h4>
+<h4 id="blqs-constructor">new CountQueuingStrategy({ highWaterMark })</h4>
 
 <div class="note">
-  The constructor takes a nonnegative number for the high-water mark, and stores it for later use.
+  The constructor takes a nonnegative number for the high-water mark, and stores it on the object as a property.
 </div>
 
 <pre is="emu-alg">
-  1. Let _highWaterMark_ be ToNumber(_highWaterMark_).
-  1. If _highWaterMark_ is *NaN*, throw a *TypeError* exception.
-  1. If _highWaterMark_ < 0, throw a *RangeError* exception.
-  1. Set *this*@[[cqsHighWaterMark]] to _highWaterMark_.
+  1. CreateDataProperty(*this*, "highWaterMark", _highWaterMark_).
 </pre>
 
 <h4 id="cqs-prototype">Properties of the <code>CountQueuingStrategy</code> Prototype</h4>
-
-<h5 id="cqs-should-apply-backpressure">shouldApplyBackpressure(queueSize)</h5>
-
-<div class="note">
-  The <code>shouldApplyBackpressure</code> method returns whether or not the given queue size is greater than the
-  queuing strategy's high-water mark.
-</div>
-
-<pre is="emu-alg">
-  1. If Type(*this*) is not Object, throw a *TypeError* exception.
-  1. If *this* does not have a [[cqsHighWaterMark]] internal slot, throw a *TypeError* exception.
-  1. Let _queueSize_ be ToNumber(_queueSize_).
-  1. If _queueSize_ is *NaN*, return *false*.
-  1. Return _queueSize_ > *this*@[[cqsHighWaterMark]].
-</pre>
 
 <h5 id="cqs-size">size()</h5>
 
@@ -1879,6 +1829,22 @@ A few abstract operations are used in this specification for utility purposes. W
   1. Let _returnValue_ be Call(_method_, _O_, _args_).
   1. If _returnValue_ is an abrupt completion, return a new promise rejected with _returnValue_.[[value]].
   1. Otherwise, return a new promise resolved with _returnValue_.[[value]].
+</pre>
+
+<h4 id="validate-and-normalize-queuing-strategy" aoid="ValidateAndNormalizeQueuingStrategy">ValidateAndNormalizeQueuingStrategy ( strategy, defaultHWM )</h4>
+
+<pre is="emu-alg">
+  1. Assert: Type(_defaultHWM_) is Number.
+  1. Assert: _defaultHWM_ ≥ 0.
+  1. If _strategy_ is *undefined*, return Record{[[size]]: *undefined*, [[highWaterMark]]: _defaultHWM_ }.
+  1. Let _size_ be Get(_strategy_, "size").
+  1. ReturnIfAbrupt(_size_).
+  1. If IsCallable(_size_) is *false*, throw a *TypeError* exception.
+  1. Let _highWaterMark_ be ToNumber(Get(_strategy_, "highWaterMark")).
+  1. ReturnIfAbrupt(_highWaterMark_).
+  1. If _highWaterMark_ is *NaN*, throw a *TypeError* exception.
+  1. If _highWaterMark_ < *0*, throw a *RangeError* exception.
+  1. Return Record{[[size]]: size, [[highWaterMark]]: highWaterMark}.
 </pre>
 
 <h2 id="globals">Global Properties</h2>

--- a/reference-implementation/lib/byte-length-queuing-strategy.js
+++ b/reference-implementation/lib/byte-length-queuing-strategy.js
@@ -1,29 +1,8 @@
-import { typeIsObject } from './helpers';
+import { createDataProperty } from './helpers';
 
 export default class ByteLengthQueuingStrategy {
   constructor({ highWaterMark }) {
-    highWaterMark = Number(highWaterMark);
-
-    if (Number.isNaN(highWaterMark)) {
-      throw new TypeError('highWaterMark must be a number.');
-    }
-    if (highWaterMark < 0) {
-      throw new RangeError('highWaterMark must be nonnegative.');
-    }
-
-    this._blqsHighWaterMark = highWaterMark;
-  }
-
-  shouldApplyBackpressure(queueSize) {
-    if (!typeIsObject(this)) {
-      throw new TypeError('ByteLengthQueuingStrategy.prototype.shouldApplyBackpressure can only be applied to objects');
-    }
-    if (!Object.prototype.hasOwnProperty.call(this, '_blqsHighWaterMark')) {
-      throw new TypeError('ByteLengthQueuingStrategy.prototype.shouldApplyBackpressure can only be applied to a ' +
-        'ByteLengthQueuingStrategy');
-    }
-
-    return queueSize > this._blqsHighWaterMark;
+    createDataProperty(this, 'highWaterMark', highWaterMark);
   }
 
   size(chunk) {

--- a/reference-implementation/lib/count-queuing-strategy.js
+++ b/reference-implementation/lib/count-queuing-strategy.js
@@ -1,29 +1,8 @@
-import { typeIsObject } from './helpers';
+import { createDataProperty } from './helpers';
 
 export default class CountQueuingStrategy {
   constructor({ highWaterMark }) {
-    highWaterMark = Number(highWaterMark);
-
-    if (Number.isNaN(highWaterMark)) {
-      throw new TypeError('highWaterMark must be a number.');
-    }
-    if (highWaterMark < 0) {
-      throw new RangeError('highWaterMark must be nonnegative.');
-    }
-
-    this._cqsHighWaterMark = highWaterMark;
-  }
-
-  shouldApplyBackpressure(queueSize) {
-    if (!typeIsObject(this)) {
-      throw new TypeError('CountQueuingStrategy.prototype.shouldApplyBackpressure can only be applied to objects');
-    }
-    if (!Object.prototype.hasOwnProperty.call(this, '_cqsHighWaterMark')) {
-      throw new TypeError('CountQueuingStrategy.prototype.shouldApplyBackpressure can only be applied to a ' +
-        'CountQueuingStrategy');
-    }
-
-    return queueSize > this._cqsHighWaterMark;
+    createDataProperty(this, 'highWaterMark', highWaterMark);
   }
 
   size(chunk) {

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -89,3 +89,27 @@ export function PromiseInvokeOrFallbackOrNoop(O, P1, args1, P2, args2) {
     return Promise.reject(e);
   }
 }
+
+export function ValidateAndNormalizeQueuingStrategy(strategy, defaultHWM) {
+  assert(typeof defaultHWM === 'number');
+  assert(defaultHWM >= 0);
+
+  if (strategy === undefined) {
+    return { size: undefined, highWaterMark: defaultHWM };
+  }
+
+  const size = strategy.size;
+  if (typeof size !== 'function') {
+    throw new TypeError('size property of a queuing strategy must be a function');
+  }
+
+  const highWaterMark = Number(strategy.highWaterMark);
+  if (Number.isNaN(highWaterMark)) {
+    throw new TypeError('highWaterMark property of a queuing strategy must be convertible to a non-NaN number');
+  }
+  if (highWaterMark < 0) {
+    throw new RangeError('highWaterMark property of a queuing strategy must be nonnegative');
+  }
+
+  return { size, highWaterMark };
+}

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 import { CreateIterResultObject, InvokeOrNoop, PromiseInvokeOrNoop, ValidateAndNormalizeQueuingStrategy } from './helpers';
 import { createArrayFromList, createDataProperty, typeIsObject } from './helpers';
+import { rethrowAssertionErrorRejection } from './utils';
 import { DequeueValue, EnqueueValueWithSize, GetTotalQueueSize } from './queue-with-sizes';
 
 export default class ReadableStream {
@@ -29,7 +30,8 @@ export default class ReadableStream {
         CallReadableStreamPull(this);
       },
       r => ErrorReadableStream(this, r)
-    );
+    )
+    .catch(rethrowAssertionErrorRejection);
   }
 
   cancel(reason) {
@@ -328,7 +330,8 @@ function CallReadableStreamPull(stream) {
     stream._pullingPromise.then(() => {
       stream._pullScheduled = false;
       CallReadableStreamPull(stream);
-    });
+    })
+    .catch(rethrowAssertionErrorRejection);
     return undefined;
   }
 
@@ -343,7 +346,8 @@ function CallReadableStreamPull(stream) {
   stream._pullingPromise.then(
     () => { stream._pullingPromise = undefined; },
     e => ErrorReadableStream(stream, e)
-  );
+  )
+  .catch(rethrowAssertionErrorRejection);
 
   return undefined;
 }

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -29,7 +29,11 @@ export default class ReadableStream {
         this._started = true;
         CallReadableStreamPull(this);
       },
-      r => ErrorReadableStream(this, r)
+      r => {
+        if (this._state === 'readable') {
+          return ErrorReadableStream(this, r);
+        }
+      }
     )
     .catch(rethrowAssertionErrorRejection);
   }
@@ -345,7 +349,11 @@ function CallReadableStreamPull(stream) {
   stream._pullingPromise = PromiseInvokeOrNoop(stream._underlyingSource, 'pull', [stream._controller]);
   stream._pullingPromise.then(
     () => { stream._pullingPromise = undefined; },
-    e => ErrorReadableStream(stream, e)
+    e => {
+      if (stream._state === 'readable') {
+        return ErrorReadableStream(stream, e);
+      }
+    }
   )
   .catch(rethrowAssertionErrorRejection);
 

--- a/reference-implementation/lib/utils.js
+++ b/reference-implementation/lib/utils.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+export function rethrowAssertionErrorRejection(e) {
+  // Used throughout the reference implementation, as `.catch(rethrowAssertionErrorRejection)`, to ensure any errors
+  // get shown. There are places in the spec where we do promise transformations and purposefully ignore or don't
+  // expect any errors, but assertion errors are always problematic.
+  if (e && e.constructor === assert.AssertionError) {
+    setTimeout(() => {
+      throw e;
+    }, 0);
+  }
+}

--- a/reference-implementation/test/bad-underlying-sinks.js
+++ b/reference-implementation/test/bad-underlying-sinks.js
@@ -1,6 +1,6 @@
 const test = require('tape-catch');
 
-test('Throwing underlying sink start getter', t => {
+test('Underlying sink: throwing start getter', t => {
   const theError = new Error('a unique string');
 
   t.throws(() => {
@@ -13,7 +13,7 @@ test('Throwing underlying sink start getter', t => {
   t.end();
 });
 
-test('Throwing underlying sink start method', t => {
+test('Underlying sink: throwing start method', t => {
   const theError = new Error('a unique string');
 
   t.throws(() => {
@@ -26,7 +26,7 @@ test('Throwing underlying sink start method', t => {
   t.end();
 });
 
-test('Throwing underlying source write getter', t => {
+test('Underlying sink: throwing write getter', t => {
   t.plan(2);
 
   const theError = new Error('a unique string');
@@ -47,7 +47,7 @@ test('Throwing underlying source write getter', t => {
   );
 });
 
-test('Throwing underlying source write method', t => {
+test('Underlying sink: throwing write method', t => {
   t.plan(2);
 
   const theError = new Error('a unique string');
@@ -68,7 +68,7 @@ test('Throwing underlying source write method', t => {
   );
 });
 
-test('Throwing underlying sink abort getter', t => {
+test('Underlying sink: throwing abort getter', t => {
   t.plan(2);
 
   const theError = new Error('a unique string');
@@ -90,7 +90,7 @@ test('Throwing underlying sink abort getter', t => {
   );
 });
 
-test('Throwing underlying sink abort method', t => {
+test('Underlying sink: throwing abort method', t => {
   t.plan(2);
 
   const theError = new Error('a unique string');
@@ -112,7 +112,7 @@ test('Throwing underlying sink abort method', t => {
   );
 });
 
-test('Throwing underlying sink close getter', t => {
+test('Underlying sink: throwing close getter', t => {
   t.plan(1);
 
   const theError = new Error('a unique string');
@@ -128,7 +128,7 @@ test('Throwing underlying sink close getter', t => {
   );
 });
 
-test('Throwing underlying sink close method', t => {
+test('Underlying sink: throwing close method', t => {
   t.plan(1);
 
   const theError = new Error('a unique string');
@@ -144,7 +144,9 @@ test('Throwing underlying sink close method', t => {
   );
 });
 
-test('Throwing underlying source strategy getter: initial construction', t => {
+test('Underlying sink: throwing strategy getter', t => {
+  t.plan(1);
+
   const theError = new Error('a unique string');
 
   t.throws(() => {
@@ -153,90 +155,41 @@ test('Throwing underlying source strategy getter: initial construction', t => {
         throw theError;
       }
     });
-  }, /a unique string/);
-  t.end();
+  }, /a unique string/, 'construction should re-throw the error');
 });
 
-test('Throwing underlying source strategy getter: first write', t => {
-  t.plan(2);
+test('Underlying sink: throwing strategy.size getter', t => {
+  t.plan(1);
 
-  let counter = 0;
   const theError = new Error('a unique string');
-  const ws = new WritableStream({
-    get strategy() {
-      ++counter;
-      if (counter === 1) {
-        return {
-          size() {
-            return 1;
-          },
-          shouldApplyBackpressure() {
-            return true;
-          }
-        };
-      }
 
-      throw theError;
-    }
-  });
-
-  ws.write('a').then(
-    () => t.fail('write should not fulfill'),
-    r => t.equal(r, theError, 'write should reject with the thrown error')
-  );
-
-  ws.closed.then(
-    () => t.fail('closed should not fulfill'),
-    r => t.equal(r, theError, 'closed should reject with the thrown error')
-  );
-});
-
-test('Throwing underlying source strategy.size getter: initial construction', t => {
-  t.doesNotThrow(() => {
+  t.throws(() => {
     new WritableStream({
       strategy: {
         get size() {
-          throw new Error('boo');
+          throw theError;
         },
-        shouldApplyBackpressure() {
-          return true;
-        }
+        highWaterMark: 5
       }
     });
-  });
-  t.end();
+  }, /a unique string/, 'construction should re-throw the error');
 });
 
-test('Throwing underlying source strategy.size method: initial construction', t => {
+test('Underlying sink: throwing strategy.size method', t => {
+  t.plan(3);
+
+  const theError = new Error('a unique string');
+  let ws;
   t.doesNotThrow(() => {
-    new WritableStream({
+    ws = new WritableStream({
       strategy: {
         size() {
-          throw new Error('boo');
+          throw theError;
         },
-        shouldApplyBackpressure() {
-          return true;
-        }
+        highWaterMark: 5
       }
     });
-  });
-  t.end();
-});
-
-test('Throwing underlying source strategy.size getter: first write', t => {
-  t.plan(2);
-
-  const theError = new Error('a unique string');
-  const ws = new WritableStream({
-    strategy: {
-      get size() {
-        throw theError;
-      },
-      shouldApplyBackpressure() {
-        return true;
-      }
-    }
-  });
+  }, 'initial construction should not throw');
 
   ws.write('a').then(
     () => t.fail('write should not fulfill'),
@@ -249,33 +202,9 @@ test('Throwing underlying source strategy.size getter: first write', t => {
   );
 });
 
-test('Throwing underlying source strategy.size method: first write', t => {
-  t.plan(2);
+test('Underlying sink: throwing strategy.highWaterMark getter', t => {
+  t.plan(1);
 
-  const theError = new Error('a unique string');
-  const ws = new WritableStream({
-    strategy: {
-      size() {
-        throw theError;
-      },
-      shouldApplyBackpressure() {
-        return true;
-      }
-    }
-  });
-
-  ws.write('a').then(
-    () => t.fail('write should not fulfill'),
-    r => t.equal(r, theError, 'write should reject with the thrown error')
-  );
-
-  ws.closed.then(
-    () => t.fail('closed should not fulfill'),
-    r => t.equal(r, theError, 'closed should reject with the thrown error')
-  );
-});
-
-test('Throwing underlying source strategy.shouldApplyBackpressure getter: initial construction', t => {
   const theError = new Error('a unique string');
 
   t.throws(() => {
@@ -284,17 +213,46 @@ test('Throwing underlying source strategy.shouldApplyBackpressure getter: initia
         size() {
           return 1;
         },
-        get shouldApplyBackpressure() {
+        get highWaterMark() {
           throw theError;
         }
       }
     });
-  }, /a unique string/);
-  t.end();
+  }, /a unique string/, 'construction should re-throw the error');
 });
 
-test('Throwing underlying source strategy.shouldApplyBackpressure method: initial construction', t => {
-  const theError = new Error('a unique string');
+test('Underlying sink: invalid strategy.highWaterMark', t => {
+  t.plan(5);
+
+  for (const highWaterMark of [-1, -Infinity]) {
+    t.throws(() => {
+      new WritableStream({
+        strategy: {
+          size() {
+            return 1;
+          },
+          highWaterMark
+        }
+      });
+    }, /RangeError/, `construction should throw a RangeError for ${highWaterMark}`);
+  }
+
+  for (const highWaterMark of [NaN, 'foo', {}]) {
+    t.throws(() => {
+      new WritableStream({
+        strategy: {
+          size() {
+            return 1;
+          },
+          highWaterMark
+        }
+      });
+    }, /TypeError/, `construction should throw a TypeError for ${highWaterMark}`);
+  }
+});
+
+test('Underlying sink: negative strategy.highWaterMark', t => {
+  t.plan(1);
 
   t.throws(() => {
     new WritableStream({
@@ -302,11 +260,8 @@ test('Throwing underlying source strategy.shouldApplyBackpressure method: initia
         size() {
           return 1;
         },
-        shouldApplyBackpressure() {
-          throw theError;
-        }
+        highWaterMark: -1
       }
     });
-  }, /a unique string/);
-  t.end();
+  }, /RangeError/, 'construction should throw a RangeError');
 });

--- a/reference-implementation/test/bad-underlying-sources.js
+++ b/reference-implementation/test/bad-underlying-sources.js
@@ -427,3 +427,35 @@ test('Underlying source: calling error after close should throw', t => {
   })
   .getReader().closed.then(() => t.pass('closed should fulfill'));
 });
+
+test('Underlying source: calling error and returning a rejected promise from start should cause the stream to error ' +
+     'with the first error', t => {
+  t.plan(1);
+
+  const firstError = new Error('1');
+  const secondError = new Error('2');
+  new ReadableStream({
+    start(c) {
+      c.error(firstError);
+
+      return Promise.reject(secondError);
+    }
+  })
+  .getReader().closed.catch(e => t.equal(e, firstError, 'stream should error with the first error'));
+});
+
+test('Underlying source: calling error and returning a rejected promise from pull should cause the stream to error ' +
+     'with the first error', t => {
+  t.plan(1);
+
+  const firstError = new Error('1');
+  const secondError = new Error('2');
+  new ReadableStream({
+    pull(c) {
+      c.error(firstError);
+
+      return Promise.reject(secondError);
+    }
+  })
+  .getReader().closed.catch(e => t.equal(e, firstError, 'stream should error with the first error'));
+});

--- a/reference-implementation/test/brand-checks.js
+++ b/reference-implementation/test/brand-checks.js
@@ -71,9 +71,7 @@ function fakeReadableStreamController() {
 
 function fakeByteLengthQueuingStrategy() {
   return {
-    shouldApplyBackpressure(queueSize) {
-      return queueSize > 1;
-    },
+    highWaterMark: 0,
     size(chunk) {
       return chunk.byteLength;
     }
@@ -86,9 +84,7 @@ function realByteLengthQueuingStrategy() {
 
 function fakeCountQueuingStrategy() {
   return {
-    shouldApplyBackpressure(queueSize) {
-      return queueSize > 1;
-    },
+    highWaterMark: 0,
     size(chunk) {
       return 1;
     }
@@ -272,12 +268,6 @@ test('WritableStream.prototype.close enforces a brand check', t => {
 });
 
 
-test('ByteLengthQueuingStrategy.prototype.shouldApplyBackpressure enforces a brand check', t => {
-  t.plan(2);
-  methodThrows(t, ByteLengthQueuingStrategy.prototype, 'shouldApplyBackpressure', fakeByteLengthQueuingStrategy());
-  methodThrows(t, ByteLengthQueuingStrategy.prototype, 'shouldApplyBackpressure', realCountQueuingStrategy());
-});
-
 test('ByteLengthQueuingStrategy.prototype.size should work generically on its this and its arguments', t => {
   t.plan(1);
   const thisValue = null;
@@ -289,12 +279,6 @@ test('ByteLengthQueuingStrategy.prototype.size should work generically on its th
   };
 
   t.equal(ByteLengthQueuingStrategy.prototype.size.call(thisValue, chunk), returnValue);
-});
-
-test('CountQueuingStrategy.prototype.shouldApplyBackpressure enforces a brand check', t => {
-  t.plan(2);
-  methodThrows(t, CountQueuingStrategy.prototype, 'shouldApplyBackpressure', fakeCountQueuingStrategy());
-  methodThrows(t, CountQueuingStrategy.prototype, 'shouldApplyBackpressure', realByteLengthQueuingStrategy());
 });
 
 test('CountQueuingStrategy.prototype.size should work generically on its this and its arguments', t => {

--- a/reference-implementation/test/byte-length-queuing-strategy.js
+++ b/reference-implementation/test/byte-length-queuing-strategy.js
@@ -6,6 +6,26 @@ test('Can construct a ByteLengthQueuingStrategy with a valid high water mark', t
   t.end();
 });
 
+test('Can construct a ByteLengthQueuingStrategy with any value as its high water mark', t => {
+  for (const highWaterMark of [-Infinity, NaN, 'foo', {}, function () {}]) {
+    const strategy = new ByteLengthQueuingStrategy({ highWaterMark });
+    t.ok(Object.is(strategy.highWaterMark, highWaterMark), `${highWaterMark} gets set correctly`);
+  }
+
+  t.end();
+});
+
+test('ByteLengthQueuingStrategy instances have the correct properties', t => {
+  const strategy = new ByteLengthQueuingStrategy({ highWaterMark: 4 });
+
+  t.deepEqual(Object.getOwnPropertyDescriptor(strategy, 'highWaterMark'),
+    { value: 4, writable: true, enumerable: true, configurable: true },
+    'highWaterMark property should be a data property with the value passed the connstructor');
+  t.equal(typeof strategy.size, 'function');
+
+  t.end();
+});
+
 test('Closing a writable stream with in-flight writes below the high water mark delays the close call properly', t => {
   t.plan(1);
 

--- a/reference-implementation/test/pipe-to.js
+++ b/reference-implementation/test/pipe-to.js
@@ -325,7 +325,7 @@ test('Piping from an empty ReadableStream to a WritableStream in the writable st
     },
     cancel(reason) {
       t.equal(reason, theError, 'underlying source cancellation reason should be the writable stream error');
-      t.equal(pullCount, 1, 'pull should have been called once by cancel-time');
+      t.equal(pullCount, 2, 'pull should have been called twice by cancel-time');
     }
   });
 
@@ -620,7 +620,7 @@ test('Piping from an empty ReadableStream to a WritableStream in the waiting sta
 
     resolveWritePromise();
     setTimeout(() => {
-      t.equal(pullCount, 1);
+      t.equal(pullCount, 2);
 
       t.end();
     }, 100);


### PR DESCRIPTION
Please read the commit messages for more detail.

Review welcome, of course, but also soliciting feedback on:

- desiredSize name
- Should we move strategy to a second constructor parameter, instead of putting it on the underlying source and sink?

Link to notably-changed spec sections:

- https://streams.spec.whatwg.org/branch-snapshots/precise-flow-control/#queuing-strategies
- https://streams.spec.whatwg.org/branch-snapshots/precise-flow-control/#rs-constructor
- https://streams.spec.whatwg.org/branch-snapshots/precise-flow-control/#other-stuff (both built-in queuing strategies changed significantly)