### PR TITLE
Make the context be the transform object when calling transform and flush

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -3,7 +3,7 @@ import WritableStream from './writable-stream';
 
 export default class TransformStream {
   constructor(transformer) {
-    if (transformer.flush == null) {
+    if (transformer.flush === undefined) {
       transformer.flush = (enqueue, close) => close();
     }
 

--- a/reference-implementation/test/transform-stream.js
+++ b/reference-implementation/test/transform-stream.js
@@ -367,3 +367,25 @@ test('TransformStream flush gets a chance to enqueue more into the readable, and
   })
   .catch(e => t.error(e));
 });
+
+test('Transform context', t => {
+  t.plan(1);
+  const ts = new TransformStream({
+    prefix: '-prefix',
+
+    transform(chunk, enqueue, done) {
+      enqueue(chunk + this.prefix);
+      done();
+    },
+
+    flush(enqueue, close) {
+      close();
+    }
+  });
+
+  ts.writable.write('a');
+  ts.writable.close();
+  ts.readable.getReader().read().then((result) => {
+    t.equal(result.value, 'a-prefix');
+  }, e => t.error(e));
+});


### PR DESCRIPTION
I know the TransformStream is a work in progress...

With the parameter destructuring used in the constructor of TransformStream class, the global context ends up being used when transform and flush are called.  That makes it difficult to use a transform object that wants to use its own state.

Here is a sample test and a change to transform-stream that allows my test to pass.