### PR TITLE
Call ErrorReadableStream only when the state is "readable"

### DIFF
--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -398,7 +398,9 @@ function EnqueueInReadableStream(stream, chunk) {
       try {
         chunkSize = stream._strategySize(chunk);
       } catch (chunkSizeE) {
-        ErrorReadableStream(stream, chunkSizeE);
+        if (stream._state === 'readable') {
+          ErrorReadableStream(stream, chunkSizeE);
+        }
         throw chunkSizeE;
       }
     }
@@ -406,7 +408,9 @@ function EnqueueInReadableStream(stream, chunk) {
     try {
       EnqueueValueWithSize(stream._queue, chunk, chunkSize);
     } catch (enqueueE) {
-      ErrorReadableStream(stream, enqueueE);
+      if (stream._state === 'readable') {
+        ErrorReadableStream(stream, enqueueE);
+      }
       throw enqueueE;
     }
   }

--- a/reference-implementation/web-platform-tests/readable-streams/bad-strategies.js
+++ b/reference-implementation/web-platform-tests/readable-streams/bad-strategies.js
@@ -19,6 +19,60 @@ test(() => {
 
 }, 'Readable stream: throwing strategy.size getter');
 
+test(() => {
+
+  const theError = new Error('a unique string');
+
+  let controller;
+  const rs = new ReadableStream(
+    {
+      start(c) {
+        controller = c;
+      }
+    },
+    {
+      size() {
+        controller.error(theError);
+        throw theError;
+      },
+      highWaterMark: 5
+    }
+  );
+
+  assert_throws(theError, () => {
+    controller.enqueue('a');
+  }, 'enqueue should re-throw the error');
+
+}, 'Readable stream: strategy.size errors the stream and then throws');
+
+test(() => {
+
+  const theError = new Error('a unique string');
+
+  let controller;
+  const rs = new ReadableStream(
+    {
+      start(c) {
+        controller = c;
+      }
+    },
+    {
+      size() {
+        controller.error(theError);
+        return Infinity;
+      },
+      highWaterMark: 5
+    }
+  );
+
+  try {
+    controller.enqueue('a');
+  } catch (error) {
+    assert_equals(error.name, 'RangeError', 'enqueue should throw a RangeError');
+  }
+
+}, 'Readable stream: strategy.size errors the stream and then returns Infinity');
+
 promise_test(() => {
 
   const theError = new Error('a unique string');


### PR DESCRIPTION
Invocation of the strategy functions may make the stream errored. Though
such strategies are just broken, we should not throw an assertion error for
it.