### PR TITLE
Implement flow-control in TransformStream fixes #330 maybe

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -11,20 +11,15 @@ export default class TransformStream {
       throw new TypeError('transform must be a function');
     }
 
-    let writeChunk, writeDone, errorWritable;
-    let transforming = false;
-    let chunkWrittenButNotYetTransformed = false;
+    let resolveWriteChunk, resolvePullRequested, nextTransformCompleted;
+    let errorWritable;
     this.writable = new WritableStream({
       start(error) {
         errorWritable = error;
       },
       write(chunk) {
-        writeChunk = chunk;
-        chunkWrittenButNotYetTransformed = true;
-
-        const p = new Promise(resolve => writeDone = resolve);
-        maybeDoTransform();
-        return p;
+        resolveWriteChunk(chunk);
+        return nextTransformCompleted;
       },
       close() {
         try {
@@ -44,30 +39,37 @@ export default class TransformStream {
         errorReadable = c.error.bind(c);
       },
       pull() {
-        if (chunkWrittenButNotYetTransformed === true) {
-          maybeDoTransform();
-        }
+        resolvePullRequested();
+        return nextTransformCompleted;
       }
     }, transformer.readableStrategy);
 
-    function maybeDoTransform() {
-      if (transforming === false) {
-        transforming = true;
-        try {
-          transformer.transform(writeChunk, enqueueInReadable, transformDone);
-          writeChunk = undefined;
-          chunkWrittenButNotYetTransformed = false;
-        } catch (e) {
-          transforming = false;
-          errorWritable(e);
-          errorReadable(e);
-        }
-      }
+    // Create promises to be resolved by the invocation of write() and pull()
+    // and hook up our transform invocation so that we only transform when we
+    // both have something to transform and an explicit pull request from the
+    // readable.
+    function prepareNextTransform() {
+      let haveWriteChunk = new Promise(resolve => {
+        resolveWriteChunk = resolve;
+      });
+      let pullRequested = new Promise(resolve => {
+        resolvePullRequested = resolve;
+      });
+      let readyForTransform  = Promise.all([haveWriteChunk, pullRequested]);
+      nextTransformCompleted = readyForTransform.then(([writeChunk]) => {
+        return new Promise(resolve => {
+          try {
+            transformer.transform(writeChunk, enqueueInReadable, () => {
+              prepareNextTransform();
+              resolve();
+            });
+          } catch (e) {
+            errorWritable(e);
+            errorReadable(e);
+          }
+        });
+      });
     }
-
-    function transformDone() {
-      transforming = false;
-      writeDone();
-    }
+    prepareNextTransform();
   }
 }


### PR DESCRIPTION
Promise-ify the TransformStream so that it always waits for both a
write() and a pull() to have happened, returning a Promise in both
cases so that callers can know when it's safe to call again.

Previously pull() had no effect and the TransformStream was strictly
pumped by its write() callers.

NB: I may be making a dangerous assumption about pull() always being called.  I will endeavor to better come up-to-speed on the spec and reference implementation and investigate this on my own in the next ~1 week.  But in the meantime, I figured I'd put this here since it does pass the existing tests and the test I added that's only slightly pyramid-of-doomy.