### PR TITLE
Fix constness bug

### DIFF
--- a/reference-implementation/bench/recording-differ.js
+++ b/reference-implementation/bench/recording-differ.js
@@ -31,7 +31,7 @@ function comparisonTable(reference, other) {
 
   const table = Object.keys(filteredDelta).map(k => {
     const values = JSON.parse(k);
-    const { time, pauses } = filteredDelta[k];
+    let { time, pauses } = filteredDelta[k];
     [time, pauses] = [addSign(time / 1e6), addSign(pauses)];
 
     return [values, time, pauses];


### PR DESCRIPTION
Make `time` and `pauses` a `let` rather than `const`, as they are modified.

Discovered while compiling with babeljs.