### PR TITLE
Fixing 'ReadableStream: should call pull when trying to read from a started, empty stream' flakiness

### DIFF
--- a/reference-implementation/web-platform-tests/readable-streams/general.js
+++ b/reference-implementation/web-platform-tests/readable-streams/general.js
@@ -293,8 +293,12 @@ promise_test(() => {
 promise_test(() => {
 
   let pullCount = 0;
+  const startPromise = Promise.resolve();
 
   const rs = new ReadableStream({
+    start() {
+      return startPromise;
+    },
     pull(c) {
       // Don't enqueue immediately after start. We want the stream to be empty when we call .read() on it.
       if (pullCount > 0) {
@@ -304,9 +308,9 @@ promise_test(() => {
     }
   });
 
-  return delay(1).then(() => {
+  return startPromise.then(() => {
     assert_equals(pullCount, 1, 'pull should be called once start finishes');
-
+  }).then(() => {
     const reader = rs.getReader();
     const read = reader.read();
     assert_equals(pullCount, 2, 'pull should be called when read is called');


### PR DESCRIPTION
Some slow WebKit bots have difficulties with this test.
The delay(1) callback is sometimes called  before the callback to the first pull request promise, which makes the call to the first read() call waiting for the first pull request promise to finish.

Increasing the delay from 1 to 10 before actually reading the data is solving the issue on WebKit bots.
As a side note, 10 ms is usually considered as too small for slow WebKit bots.

This patch tries to make the test more deterministic.