### PR TITLE
doc: Fix some variable, properties and function references.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1278,8 +1278,8 @@ Instances of {{ReadableStreamBYOBReader}} are created with the internal slots de
 <h4 id="readable-stream-reader-release" aoid="ReadableStreamReaderGenericRelease" throws>ReadableStreamReaderGenericRelease ( reader )</h4>
 
 <emu-alg>
-  1. Assert: _reader_@[[ownerReadableStream]]@[[reader]] is not *undefined*.
   1. Assert: _reader_@[[ownerReadableStream]] is not *undefined*.
+  1. Assert: _reader_@[[ownerReadableStream]]@[[reader]] is not *undefined*.
   1. If _reader_@[[ownerReadableStream]]@[[state]] is `"readable"`, reject _reader_@[[closedPromise]] with a *TypeError* exception.
   1. Otherwise, set _reader_@[[closedPromise]] to a new promise rejected with a *TypeError* exception.
   1. Set _reader_@[[ownerReadableStream]]@[[reader]] to *undefined*.
@@ -1413,7 +1413,7 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
       1. Set _controller_@[[started]] to *true*.
       1. Perform ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
     1. Upon rejection with reason _r_,
-      1. If *this*@[[state]] is `"readable"`, perform ReadableStreamDefaultControllerError(_controller_, _r_).
+      1. If _stream_@[[state]] is `"readable"`, perform ReadableStreamDefaultControllerError(_controller_, _r_).
 </emu-alg>
 
 <h4 id="rs-default-controller-prototype">Properties of the {{ReadableStreamDefaultController}} Prototype</h4>
@@ -1440,7 +1440,7 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
 
 <emu-alg>
   1. If IsReadableStreamDefaultController(*this*) is *false*, throw a *TypeError* exception.
-  1. If _stream_@[[closeRequested]] is *true*, throw a *TypeError* exception.
+  1. If *this*@[[closeRequested]] is *true*, throw a *TypeError* exception.
   1. If *this*@[[controlledReadableStream]]@[[state]] is not `"readable"`, throw a *TypeError* exception.
   1. Perform ReadableStreamDefaultControllerClose(*this*).
 </emu-alg>
@@ -1453,7 +1453,7 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
 
 <emu-alg>
   1. If IsReadableStreamDefaultController(*this*) is *false*, throw a *TypeError* exception.
-  1. If _stream_@[[closeRequested]] is *true*, throw a *TypeError* exception.
+  1. If *this*@[[closeRequested]] is *true*, throw a *TypeError* exception.
   1. If *this*@[[controlledReadableStream]]@[[state]] is not `"readable"`, throw a *TypeError* exception.
   1. Return ReadableStreamDefaultControllerEnqueue(*this*, _chunk_).
 </emu-alg>
@@ -1523,9 +1523,9 @@ polymorphic dispatch from the readable stream implementation to either these or 
     1. Set _controller_@[[pulling]] to *false*.
     1. If _controller_@[[pullAgain]] is *true*,
       1. Set _controller_@[[pullAgain]] to *false*.
-      1. Perform ReadableStreamDefaultControllerCallPullIfNeeded(_stream_).
+      1. Perform ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
   1. Upon rejection of _pullPromise_ with reason _e_,
-    1. If _stream_@[[state]] is `"readable"`, perform ReadableStreamDefaultControllerError(_controller_, _e_).
+    1. If _controller_@[[controlledReadableStream]]@[[state]] is `"readable"`, perform ReadableStreamDefaultControllerError(_controller_, _e_).
   1. Return *undefined*.
 </emu-alg>
 
@@ -1624,7 +1624,7 @@ would look like
 
 <pre><code class="lang-javascript">
   class ReadableByteStreamController {
-    constructor(stream)
+    constructor(stream, underlyingByteSource, highWaterMark)
 
     get byobRequest()
     get desiredSize()
@@ -1743,7 +1743,7 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
       1. Assert: _controller_@[[pullAgain]] is *false*.
       1. Perform ReadableByteStreamControllerCallPullIfNeeded(_controller_).
     1. Upon rejection with reason _r_,
-      1. If *this*@[[state]] is `"readable"`, perform ReadableByteStreamControllerError(_controller_, _r_).
+      1. If _stream_@[[state]] is `"readable"`, perform ReadableByteStreamControllerError(_controller_, _r_).
 </emu-alg>
 
 <h4 id="rbs-controller-prototype">Properties of the {{ReadableByteStreamController}} Prototype</h4>
@@ -1856,7 +1856,7 @@ dispatch from the readable stream implementation to either these or their counte
   1. Otherwise,
     1. Assert: *this*@[[autoAllocateChunkSize]] is *undefined*.
   1. Let _promise_ be ReadableStreamAddReadRequest(_stream_).
-  1. Perform ReadableStreamDefaultControllerCallPullIfNeeded(*this*).
+  1. Perform ReadableByteStreamControllerCallPullIfNeeded(*this*).
   1. Return _promise_.
 </emu-alg>
 
@@ -1873,7 +1873,7 @@ would look like
 
 <pre><code class="lang-javascript">
   class ReadableStreamBYOBRequest {
-    constructor(controller, descriptor)
+    constructor(controller, view)
 
     get view()
 
@@ -2007,7 +2007,6 @@ Instances of {{ReadableStreamBYOBRequest}} are created with the internal slots d
 
 <emu-alg>
   1. Assert: _stream_@[[state]] is not `"errored"`.
-  1. Let _byteOffset_ be _readIntoRequest_.[[byteOffset]].
   1. Let _done_ be *false*.
   1. If _stream_@[[state]] is `"closed"`,
     1. Assert: _pullIntoDescriptor_.[[bytesFilled]] is not 0.
@@ -2035,7 +2034,7 @@ Instances of {{ReadableStreamBYOBRequest}} are created with the internal slots d
 <emu-alg>
   1. Let _stream_ be _controller_@[[controlledReadableStream]].
   1. Assert: _controller_@[[closeRequested]] is *false*.
-  1. Assert: _controller_@[[state]] is `"readable"`.
+  1. Assert: _stream_@[[state]] is `"readable"`.
   1. Let _buffer_ be _chunk_@[[ViewedArrayBuffer]].
   1. Let _byteOffset_ be _chunk_@[[ByteOffset]].
   1. Let _byteLength_ be _chunk_@[[ByteLength]].


### PR DESCRIPTION
`index.bs` contains some reference errors, where the wrong variables are used
in describing algorithm steps. Additionally, there's one step that uses an
outside function for a different class.

### List of changes

* * *

[3.7.5 ReadableStreamReaderGenericRelease( reader )](https://streams.spec.whatwg.org/#readable-stream-reader-release)
steps `1-2` should be inverted. Current:
> 1\. Assert: reader@[[ownerReadableStream]]@[[reader]] is not undefined.
> 2\. Assert: reader@[[ownerReadableStream]] is not undefined.

should read:
> 1\. Assert: reader@[[ownerReadableStream]] is not undefined.
> 2\. Assert: reader@[[ownerReadableStream]]@[[reader]] is not undefined.

_**Reason**: Attempting to read `[[reader]]` of `undefined` will throw an unexpected exception._
* * *

[3.8.3 new ReadableStreamDefaultController()](https://streams.spec.whatwg.org/#rs-default-controller-constructor)
step `12.b.i`
> i\. If this@[[state]] is "readable", perform ReadableStreamDefaultControllerError(controller, r).

should read
> i\. If stream@[[state]] is "readable", perform ReadableStreamDefaultControllerError(controller, r).

* * *

[3.8.4.2. close()](https://streams.spec.whatwg.org/#rs-default-controller-close)
step `2`
> 2\. If stream@[[closeRequested]] is true, throw a TypeError exception.

should read
> 2\. If this@[[closeRequested]] is true, throw a TypeError exception.

* * *

[3.8.4.3. enqueue(chunk)](https://streams.spec.whatwg.org/#rs-default-controller-enqueue)
step `2`
> 2\. If stream@[[closeRequested]] is true, throw a TypeError exception.

should read
> 2\. If this@[[closeRequested]] is true, throw a TypeError exception.

* * *

[3.9.2. ReadableStreamDefaultControllerCallPullIfNeeded](https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed)
step `6.b.ii`
> ii\. Perform ReadableStreamDefaultControllerCallPullIfNeeded(stream).

should read
> ii\. Perform ReadableStreamDefaultControllerCallPullIfNeeded(controller).

* * *

[3.9.2. ReadableStreamDefaultControllerCallPullIfNeeded](https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed)
step `7.a`
> a\. If stream@[[state]] is "readable", perform ReadableStreamDefaultControllerError(controller, e).

should read
> a\. If controller@[[controlledReadableStream]@[[state]] is "readable", perform ReadableStreamDefaultControllerError(controller, e).

_**Reason**: `stream` is not defined._

* * *

[3.10.1. Class Definition](https://streams.spec.whatwg.org/#rbs-controller-class-definition)
the JavaScript syntax
```javascript
class ReadableByteStreamController {
  constructor(stream)
```

should read
```javascript
class ReadableByteStreamController {
  constructor(stream, underlyingByteSource, highWaterMark)
```

* * *

[3.10.3. new ReadableByteStreamController()](https://streams.spec.whatwg.org/#rbs-controller-constructor)
step `18.b.i`
> i\. If this@[[state]] is "readable", perform ReadableByteStreamControllerError(controller, r).

should read
> i\. If stream@[[state]] is "readable", perform ReadableByteStreamControllerError(controller, r).

* * *

[3.10.5.2. [[Pull]]()](https://streams.spec.whatwg.org/#rbs-controller-private-pull) 
step `5`
> 5\. Perform ReadableStreamDefaultControllerCallPullIfNeeded(this)

should read
> 5\. Perform ReadableByteStreamControllerCallPullIfNeeded(this)

_**Reason**: `this` is a `ReadableByteStreamController` instance._

* * *

[3.11.1. Class Definition](https://streams.spec.whatwg.org/#rs-byob-request-class-definition)
the JavaScript syntax
```javascript
  constructor(controller, descriptor)
```

should read
```javascript
  constructor(controller, view)
```

* * *

[3.12.6. ReadableByteStreamControllerCommitPullIntoDescriptor](https://streams.spec.whatwg.org/#readable-byte-stream-controller-commit-pull-into-descriptor)
step `2`
> 2\. Let byteOffset be readIntoRequest.[[byteOffset]].

should be removed. _**Reason**: not used anywhere in algorithm._

* * *

[3.12.8. ReadableByteStreamControllerEnqueue](https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue)
step `3`
> 3\. Assert: controller@[[state]] is "readable".

should read
> 3\. Assert: stream@[[state]] is "readable".