### PR TITLE
Fix pendingPullIntos access in ReadableByteStreamControllerClose()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2067,12 +2067,12 @@ throws>ReadableByteStreamControllerClose ( <var>controller</var> )</h4>
   1. If _controller_.[[totalQueuedBytes]] > *0*,
     1. Set _controller_.[[closeRequested]] to *true*.
     1. Return.
-  1. Let _firstPendingPullInto_ be the first element of _controller_.[[pendingPullIntos]].
-  1. If ! ReadableStreamHasBYOBReader(_stream_) is *true*, _controller_.[[pendingPullIntos]] is not empty, and
-    _firstPendingPullInto_.[[bytesFilled]] > *0*.
-    1. Let _e_ be a new *TypeError* exception.
-    1. Perform ! ReadableByteStreamControllerError(_controller_, _e_).
-    1. Throw _e_.
+  1. If _controller_.[[pendingPullIntos]] is not empty,
+    1. Let _firstPendingPullInto_ be the first element of _controller_.[[pendingPullIntos]].
+    1. If  _firstPendingPullInto_.[[bytesFilled]] > *0*,
+      1. Let _e_ be a new *TypeError* exception.
+      1. Perform ! ReadableByteStreamControllerError(_controller_, _e_).
+      1. Throw _e_.
   1. Perform ! ReadableStreamClose(_stream_).
 </emu-alg>
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1672,14 +1672,14 @@ function ReadableByteStreamControllerClose(controller) {
     return;
   }
 
-  const firstPendingPullInto = controller._pendingPullIntos[0];
-  if (ReadableStreamHasBYOBReader(stream) === true &&
-      controller._pendingPullIntos.length > 0 &&
-      firstPendingPullInto.bytesFilled > 0) {
-    const e = new TypeError('Insufficient bytes to fill elements in the given buffer');
-    ReadableByteStreamControllerError(controller, e);
+  if (controller._pendingPullIntos.length > 0) {
+    const firstPendingPullInto = controller._pendingPullIntos[0];
+    if (firstPendingPullInto.bytesFilled > 0) {
+      const e = new TypeError('Insufficient bytes to fill elements in the given buffer');
+      ReadableByteStreamControllerError(controller, e);
 
-    throw e;
+      throw e;
+    }
   }
 
   ReadableStreamClose(stream);


### PR DESCRIPTION
The size of pendingPullIntos must be checked before getting the head of it.

As a bonus, this commit removes unnecessary ReadableStreamHasBYOBReader
checking.

Fixes #470