### PR TITLE
Tighten the assertion on the owner stream in ReadableStreamReaderGene…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1304,7 +1304,7 @@ nothrow>ReadableStreamReaderGenericRelease ( <var>reader</var> )</h4>
 
 <emu-alg>
   1. Assert: _reader_.[[ownerReadableStream]] is not *undefined*.
-  1. Assert: _reader_.[[ownerReadableStream]].[[reader]] is not *undefined*.
+  1. Assert: _reader_.[[ownerReadableStream]].[[reader]] is _reader_.
   1. If _reader_.[[ownerReadableStream]].[[state]] is `"readable"`, reject _reader_.[[closedPromise]] with a *TypeError*
      exception.
   1. Otherwise, set _reader_.[[closedPromise]] to a new promise rejected with a *TypeError* exception.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -735,7 +735,7 @@ function ReadableStreamReaderGenericCancel(reader, reason) {
 
 function ReadableStreamReaderGenericRelease(reader) {
   assert(reader._ownerReadableStream !== undefined);
-  assert(reader._ownerReadableStream._reader !== undefined);
+  assert(reader._ownerReadableStream._reader === reader);
 
   if (reader._ownerReadableStream._state === 'readable') {
     reader._closedPromise_reject(


### PR DESCRIPTION
…ricRelease()

We can expect reader@[[ownerReadableStream]]@[[reader]] to be reader than
just non-undefined-ness.

Fixes: #466