### PR TITLE
Tweak ReadableByteStreamControllerEnqueue algorithm structure

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2127,15 +2127,14 @@ nothrow>ReadableByteStreamControllerEnqueue ( <var>controller</var>, <var>chunk<
       1. Let _transferredView_ be ! Construct(<a idl>%Uint8Array%</a>, « _transferredBuffer_, _byteOffset_,
          _byteLength_ »).
       1. Perform ! ReadableStreamFulfillReadRequest(_stream_, _transferredView_, *false*).
+  1. Otherwise, if ! ReadableStreamHasBYOBReader(_stream_) is *true*,
+    1. Perform ! ReadableByteStreamControllerEnqueueChunkToQueue(_controller_, _transferredBuffer_, _byteOffset_,
+       _byteLength_).
+    1. Perform ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(_controller_).
   1. Otherwise,
-    1. If ! ReadableStreamHasBYOBReader(_stream_) is *true*,
-      1. Perform ! ReadableByteStreamControllerEnqueueChunkToQueue(_controller_, _transferredBuffer_, _byteOffset_,
-         _byteLength_).
-      1. Perform ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(_controller_).
-    1. Otherwise,
-      1. Assert: ! IsReadableStreamLocked(_stream_) is *false*.
-      1. Perform ! ReadableByteStreamControllerEnqueueChunkToQueue(_controller_, _transferredBuffer_, _byteOffset_,
-         _byteLength_).
+    1. Assert: ! IsReadableStreamLocked(_stream_) is *false*.
+    1. Perform ! ReadableByteStreamControllerEnqueueChunkToQueue(_controller_, _transferredBuffer_, _byteOffset_,
+       _byteLength_).
 </emu-alg>
 
 <h4 id="readable-byte-stream-controller-enqueue-chunk-to-queue" aoid="ReadableByteStreamControllerEnqueueChunkToQueue"

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1705,15 +1705,13 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
       const transferredView = new Uint8Array(transferredBuffer, byteOffset, byteLength);
       ReadableStreamFulfillReadRequest(stream, transferredView, false);
     }
+  } else if (ReadableStreamHasBYOBReader(stream) === true) {
+    // TODO: Ideally in this branch detaching should happen only if the buffer is not consumed fully.
+    ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
+    ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
   } else {
-    if (ReadableStreamHasBYOBReader(stream) === true) {
-      // TODO: Ideally in this branch detaching should happen only if the buffer is not consumed fully.
-      ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
-      ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
-    } else {
-      assert(IsReadableStreamLocked(stream) === false, 'stream must not be locked');
-      ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
-    }
+    assert(IsReadableStreamLocked(stream) === false, 'stream must not be locked');
+    ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
   }
 }
 


### PR DESCRIPTION
This makes the parallel nature of the algorithm more clear, in that it handles all three cases of default reader, BYOB reader, and no reader. See http://logs.glob.uno/?c=freenode%23whatwg#c999292.

/cc @wanderview