### PR TITLE
Align WritableStream structure with ReadableStream structure

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -224,21 +224,24 @@ similarly, avoiding writes that would cause the desired size to go negative.
 
 <h3 id="locking">Locking</h3>
 
-<!-- TODO: writable streams too, probably -->
-
 A <dfn>readable stream reader</dfn>, or simply reader, is an object that allows direct reading of <a>chunks</a> from a
 <a>readable stream</a>. Without a reader, a <a>consumer</a> can only perform high-level operations on the readable
-stream: waiting for the stream to become closed or errored, <a lt="cancel a readable stream">canceling</a> the stream,
-or <a>piping</a> the readable stream to a writable stream. Many of those high-level operations actually use a reader
-themselves.
+stream: <a lt="cancel a readable stream">canceling</a> the stream, or <a>piping</a> the readable stream to a writable
+stream.
 
-A given readable stream only has at most one reader at a time. We say in this case the stream is
-<dfn lt="locked to a reader">locked to the reader</dfn>, and that the reader is <dfn lt="active reader">active</dfn>.
+Similarly, a <dfn>writable stream writer</dfn>, or simply writer, is an object that allows direct writing of
+<a>chunks</a> to a <a>writable stream</a>. Without a writer, a <a>producer</a> can only perform the high-level
+operations of <a lt="abort a writable stream">aborting</a> the stream or <a>piping</a> a readable stream to the writable
+stream.
 
-A reader also has the capability to <dfn lt="release a read lock">release its read lock</dfn>, which makes it no
-longer active. At this point another reader can be acquired at will. If the stream becomes closed or errored as a
-result of the behavior of its <a>underlying source</a> or via <a lt="cancel a readable stream">cancellation</a>, its
-reader (if one exists) will automatically release its lock.
+(Under the covers, these high-level operations actually use a reader or writer themselves.)
+
+A given readable or writable stream only has at most one reader or writer at a time. We say in this case the stream is
+<dfn lt="locked to a reader|locked to a writer">locked</dfn>, and that the reader or writer is <dfn
+lt="active reader|active writer">active</dfn>.
+
+A reader or writer also has the capability to <dfn lt="release a read lock|release a write lock">release its
+lock</dfn>, which makes it no longer active, and allows further readers or writers to be acquired.
 
 A <a>readable byte stream</a> has the ability to vend two types of readers: <dfn>default readers</dfn> and <dfn>BYOB
 readers</dfn>. BYOB ("bring your own buffer") readers allow reading into a developer-supplied buffer, thus minimizing
@@ -379,13 +382,13 @@ Instances of {{ReadableStream}} are created with the internal slots described in
     </tr>
   </thead>
   <tr>
+    <td>\[[disturbed]]
+    <td>A boolean flag set to <emu-val>true</emu-val> when the stream has been read from or canceled
+  </tr>
+  <tr>
     <td>\[[readableStreamController]]
     <td>A {{ReadableStreamDefaultController}} or {{ReadableByteStreamController}} created with the ability to control
     the state and queue of this stream; also used for the IsReadableStream brand check
-  </tr>
-  <tr>
-    <td>\[[disturbed]]
-    <td>A boolean flag set to <emu-val>true</emu-val> when the stream has been read from or canceled
   </tr>
   <tr>
     <td>\[[reader]]
@@ -395,7 +398,7 @@ Instances of {{ReadableStream}} are created with the internal slots described in
   <tr>
     <td>\[[state]]
     <td>A string containing the stream's current state, used internally; one of <code>"readable"</code>,
-      <code>"closed"</code>, or <code>"errored"</code>.
+      <code>"closed"</code>, or <code>"errored"</code>
   </tr>
   <tr>
     <td>\[[storedError]]
@@ -2399,11 +2402,8 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
 <h2 id="ws">Writable Streams</h2>
 
 <div class="warning" id="ws-not-ready-yet">
-  Although readable streams have been significantly evolved recently due to implementation progress providing feedback,
-  writable streams have not yet caught up to all the discoveries in that space. As such, while the following spec will
-  be the basis for a final API, it is expected to change in several important ways before being ready to ship. Please
-  follow along on the <a href="https://github.com/whatwg/streams/labels/writable%20streams">writable streams issues
-  label</a> for details.
+  The writable stream spec is still stabilizing, although it has recently improved a lot and is more aligned with our
+  vision. Still, it is not quite yet ready to ship.
 </div>
 
 <h3 id="ws-intro">Using Writable Streams</h3>
@@ -2422,15 +2422,17 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
 </div>
 
 <div class="example">
-  You can also write directly to writable streams using their {{WritableStream/write()}} and {{WritableStream/close()}}
-  methods. Since writable streams queue any incoming writes, and take care internally to forward them to the
-  <a>underlying sink</a> in sequence, you can indiscriminately write to a writable stream without much ceremony:
+  You can also write directly to writable streams by acquiring a <a lt="writable stream writer">writer</a> and using its
+  {{WritableStreamDefaultWriter/write()}} and {{WritableStreamDefaultWriter/close()}} methods. Since writable streams
+  queue any incoming writes, and take care internally to forward them to the <a>underlying sink</a> in sequence, you can
+  indiscriminately write to a writable stream without much ceremony:
 
   <pre><code class="lang-javascript">
     function writeArrayToStream(array, writableStream) {
-      array.forEach(chunk => writableStream.write(chunk));
+      const writer = writableStream.getWriter();
+      array.forEach(chunk => writer.write(chunk));
 
-      return writableStream.close();
+      return writer.close();
     }
 
     writeArrayToStream([1, 2, 3, 4, 5], writableStream)
@@ -2441,15 +2443,16 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
 
 <div class="example">
   In the previous example we only paid attention to the success or failure of the entire stream, by looking at the
-  promise returned by its {{WritableStream/close()}} method. That promise (which can also be accessed using the
-  {{WritableStream/closed}} getter) will reject if anything goes wrong with the stream—initializing it, writing to it,
-  or closing it. And it will fulfill once the stream is successfully closed. Often this is all you care about.
+  promise returned by its {{WritableStreamDefaultWriter/close()}} method. That promise (which can also be accessed using
+  the {{WritableStreamDefaultWriter/closed}} getter) will reject if anything goes wrong with the stream—initializing it,
+  writing to it, or closing it. And it will fulfill once the stream is successfully closed. Often this is all you care
+  about.
 
   However, if you care about the success of writing a specific <a>chunk</a>, you can use the promise returned by the
-  stream's {{WritableStream/write()}} method:
+  stream's {{WritableStreamDefaultWriter/write()}} method:
 
   <pre><code class="lang-javascript">
-    writableStream.write("i am a chunk of data")
+    writer.write("i am a chunk of data")
       .then(() => console.log("chunk successfully written!"))
       .catch(e => console.error(e));
   </code></pre>
@@ -2470,15 +2473,12 @@ like
 
 <pre><code class="lang-javascript">
   class WritableStream {
-    constructor(underlyingSink = {}, { size, highWaterMark = 0 } = {})
+    constructor(underlyingSink = {}, { size, highWaterMark = 1 } = {})
 
-    get closed()
-    get ready()
-    get state()
+    get locked()
 
     abort(reason)
-    close()
-    write(chunk)
+    getWriter()
   }
 </code></pre>
 
@@ -2494,26 +2494,9 @@ Instances of {{WritableStream}} are created with the internal slots described in
     </tr>
   </thead>
   <tr>
-    <td>\[[closedPromise]]
-    <td>A promise that becomes fulfilled when the stream becomes <code>"closed"</code>; returned by the
-      {{WritableStream/closed}} getter
-  </tr>
-  <tr>
-    <td>\[[queue]]
-    <td>A List representing the stream's internal queue of pending writes
-  </tr>
-  <tr>
-    <td>\[[started]]
-    <td>A boolean flag indicating whether the <a>underlying sink</a> has finished starting
-  </tr>
-  <tr>
-    <td>\[[startedPromise]]
-    <td>A promise storing the result of starting the <a>underlying sink</a>, used to delay actions until that is
-      complete
-  </tr>
-  <tr>
     <td>\[[state]]
-    <td>A string containing the stream's current state; returned by the {{WritableStream/state}} getter
+    <td>A string containing the stream's current state, used internally; one of <code>"writable"</code>,
+    <code>"closing"</code>, <code>"closed"</code>, or <code>"errored"</code>
   </tr>
   <tr>
     <td>\[[storedError]]
@@ -2521,40 +2504,30 @@ Instances of {{WritableStream}} are created with the internal slots described in
       on the stream while in the <code>"errored"</code> state
   </tr>
   <tr>
-    <td>\[[strategySize]]
-    <td>A function supplied to the constructor as part of the stream's <a>queuing strategy</a>, designed to calculate
-      the size of <a>chunks</a> written; can be <emu-val>undefined</emu-val> for the default behavior.
+    <td>\[[writableStreamController]]
+    <td>A {{WritableStreamDefaultController}} created with the ability to control the state and queue of this stream;
+    also used for the IsWritableStream brand check
   </tr>
   <tr>
-    <td>\[[strategyHWM]]
-    <td>A number supplied to the constructor as part of the stream's <a>queuing strategy</a>, indicating the point at
-      which the stream will apply <a>backpressure</a> to any <a>producers</a>.
+    <td>\[[writer]]
+    <td>A {{WritableStreamDefaultWriter}} instance, if the stream is <a>locked to a writer</a>, or
+    <emu-val>undefined</emu-val> if it is not
   </tr>
   <tr>
-    <td>\[[readyPromise]]
-    <td>A promise returned by the {{WritableStream/ready}} getter
-  </tr>
-  <tr>
-    <td>\[[underlyingSink]]
-    <td>An object representation of the stream's <a>underlying sink</a>; also used for the
-      <a href="#is-writable-stream">IsWritableStream</a> brand check
-  </tr>
-  <tr>
-    <td>\[[writing]]
-    <td>A boolean flag indicating whether the stream is currently writing to the <a>underlying sink</a>, used to
-      prevent concurrent such writes
+    <td>\[[writeRequests]]
+    <td>A List representing the stream's internal queue of pending writes
   </tr>
 </table>
 
 <h4 id="ws-constructor" constructor for="WritableStream" lt="WritableStream(underlyingSink, queuingStrategy)">new
-WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWaterMark</var> = 0 } = {})</h4>
+WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWaterMark</var> = 1 } = {})</h4>
 
 <div class="note">
   The <code>underlyingSink</code> object passed to the constructor can implement any of the following methods to govern
   how the constructed stream instance behaves:
 
   <ul>
-    <li> <code>start(error)</code> is called immediately, and should perform any actions necessary to acquire
+    <li> <code>start(controller)</code> is called immediately, and should perform any actions necessary to acquire
       access to the <a>underlying sink</a>. If this process is asynchronous, it can return a promise to signal success
       or failure.
     <li> <code>write(chunk)</code> is called when a new <a>chunk</a> of data is ready to be written to the
@@ -2567,18 +2540,20 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
       signal success or failure. The stream implementation guarantees that this method will be called only after all
       queued-up writes have succeeded.
     <li> <code>abort(reason)</code> is called when the producer signals they wish to abruptly close the stream
-      and put it in an <code>"errored"</code> state. It should clean up any held resources, much like
-      <code>close</code>, but perhaps with some custom handling. Unlike <code>close</code>, <code>abort</code> will be
-      called even if writes are queued up; those <a>chunks</a> will be thrown away. If this process is asynchronous, it
-      can return a promise to signal success or failure. If no abort method is passed, by default the
-      <code>close</code> method will be called instead.
+      and put it in an errored state. It should clean up any held resources, much like <code>close</code>, but perhaps
+      with some custom handling. Unlike <code>close</code>, <code>abort</code> will be called even if writes are queued
+      up; those <a>chunks</a> will be thrown away. If this process is asynchronous, it can return a promise to signal
+      success or failure. If no abort method is passed, by default the <code>close</code> method will be called instead.
   </ul>
+
+  The <code>controller</code> object passed to <code>start</code> is an instance of {{WritableStreamDefaultController}},
+  and has the ability to error the stream.
 
   The constructor also accepts a second argument containing the <a>queuing strategy</a> object with
   two properties: a non-negative number <code>highWaterMark</code>, and a function <code>size(chunk)</code>. The
   supplied <code>strategy</code> could be an instance of the built-in {{CountQueuingStrategy}} or
   {{ByteLengthQueuingStrategy}} classes, or it could be custom. If no strategy is supplied, the default
-  behavior will be the same as a {{CountQueuingStrategy}} with a <a>high water mark</a> of 0.
+  behavior will be the same as a {{CountQueuingStrategy}} with a <a>high water mark</a> of 1.
 </div>
 
 <div class="note">

--- a/index.bs
+++ b/index.bs
@@ -2864,6 +2864,65 @@ lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>st
   1. Return ! WritableStreamDefaultWriterWrite(*this*, _chunk_).
 </emu-alg>
 
+<h3 id="rs-writer-abstract-ops">Writable Stream Writer Abstract Operations</h3>
+
+<h4 id="is-writable-stream-default-writer" aoid="IsWritableStreamDefaultWriter" nothrow>IsWritableStreamDefaultWriter (
+<var>x</var> )</h4>
+
+<emu-alg>
+  1. If Type(_x_) is not Object, return *false*.
+  1. If _x_ does not have an [[ownerWritableStream]] internal slot, return *false*.
+  1. Return *true*.
+</emu-alg>
+
+<h4 id="writable-stream-default-writer-abort" aoid="WritableStreamDefaultWriterAbort"
+nothrow>WritableStreamDefaultWriterAbort ( <var>writer</var>, <var>reason</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _writer_.[[ownerWritableStream]].
+  1. Assert: _stream_ is not *undefined*.
+  1. Return ! WritableStreamAbort(_stream_, _reason_).
+</emu-alg>
+
+<h4 id="writable-stream-default-writer-close" aoid="WritableStreamDefaultWriterClose"
+nothrow>WritableStreamDefaultWriterClose ( <var>writer</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _writer_.[[ownerWritableStream]].
+  1. Assert: _stream_ is not *undefined*.
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"close"` or `"errored"`, return a promise rejected with a *TypeError* exception.
+  1. Assert: _state_ is `"writable"`.
+  1. Let _promise_ be ! WritableStreamAddWriteRequest(_stream_).
+  1. If ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, resolve _writer_.[[readyPromise]] with *undefined*.
+  1. Set _stream_.[[state]] to `"closing"`.
+  1. Perform ! WritableStreamDefaultControllerClose(_stream_.[[writableStreamController]]).
+  1. Return _promise_.
+</emu-alg>
+
+<h4 id="writable-stream-default-writer-get-desired-size" aoid="WritableStreamDefaultWriterGetDesiredSize"
+nothrow>WritableStreamDefaultWriterGetDesiredSize ( <var>writer</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _writer_.[[ownerWritableStream]].
+  1. If _stream_.[[state]] is `"errored"`, return *null*.
+  1. Return ! WritableStreamDefaultControllerGetDesiredSize(_stream_.[[writableStreamController]]).
+</emu-alg>
+
+<h4 id="writable-stream-default-writer-write" aoid="WritableStreamDefaultWriterWrite"
+nothrow>WritableStreamDefaultWriterWrite ( <var>writer</var>, <var>chunk</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _writer_.[[ownerWritableStream]].
+  1. Assert: _stream_ is not *undefined*.
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"closed"` or `"errored"`, return a promise rejected with a *TypeError* exception.
+  1. Assert: _state_ is `"writable"`.
+  1. Let _promise_ be ! WritableStreamAddWriteRequest(_stream_).
+  1. Perform ! WritableStreamDefaultControllerWrite(_stream_.[[writableStreamController]], _chunk_).
+  1. Return _promise_.
+</emu-alg>
+
 <h2 id="ts">Transform Streams</h2>
 
 Transform streams have been developed in the testable implementation, but not yet re-encoded in spec language.

--- a/index.bs
+++ b/index.bs
@@ -238,10 +238,10 @@ stream.
 
 A given readable or writable stream only has at most one reader or writer at a time. We say in this case the stream is
 <dfn lt="locked to a reader|locked to a writer">locked</dfn>, and that the reader or writer is <dfn
-lt="active reader|active writer">active</dfn>.
+lt="active|active reader|active writer">active</dfn>.
 
-A reader or writer also has the capability to <dfn lt="release a read lock|release a write lock">release its
-lock</dfn>, which makes it no longer active, and allows further readers or writers to be acquired.
+A reader or writer also has the capability to <dfn lt="release a lock|release a read lock|release a write lock">release
+its lock</dfn>, which makes it no longer active, and allows further readers or writers to be acquired.
 
 A <a>readable byte stream</a> has the ability to vend two types of readers: <dfn>default readers</dfn> and <dfn>BYOB
 readers</dfn>. BYOB ("bring your own buffer") readers allow reading into a developer-supplied buffer, thus minimizing
@@ -3548,12 +3548,9 @@ The attributes of these properties must be { \[[Writable]]: <emu-val>true</emu-v
 \[[Configurable]]: <emu-val>true</emu-val> }.
 
 <div class="note">
-  The {{ReadableStreamDefaultReader}} and {{ReadableStreamBYOBReader}} classes are specifically <em>not</em> exposed,
-  as while they do have a functioning constructor, instances should instead be created through the
-  {{ReadableStream/getReader()}} method of a {{ReadableStream}} instance.
-  Similarly, the supporting classes {{ReadableStreamDefaultController}}, {{ReadableByteStreamController}}, and
-  {{ReadableStreamBYOBRequest}} are not exposed, since they are not independently useful outside of the
-  {{ReadableStream}} implementation.
+  The {{ReadableStreamDefaultReader}}, {{ReadableStreamBYOBReader}}, {{ReadableStreamDefaultController}},
+  {{ReadableByteStreamController}}, {{WritableStreamWriter}}, and {{WritableStreamDefaultController}} classes are
+  specifically not exposed, as they are not independently useful.
 </div>
 
 <h2 id="creating-examples">Examples of Creating Streams</h2>
@@ -3891,11 +3888,12 @@ We can then use this function to create a writable stream for a file, and write 
 
 <pre><code class="lang-javascript">
   const fileStream = makeWritableFileStream("/example/path/on/fs.txt");
+  const writer = fileStream.getWriter();
 
-  fileStream.write("To stream, or not to stream\n");
-  fileStream.write("That is the question\n");
+  writer.write("To stream, or not to stream\n");
+  writer.write("That is the question\n");
 
-  fileStream.close()
+  writer.close()
     .then(() => console.log("chunks written and stream closed successfully!"))
     .catch(e => console.error(e));
 </code></pre>
@@ -3983,23 +3981,19 @@ APIs:
 
 <pre><code class="lang-javascript">
   const streamyWS = streamifyWebSocket("wss://example.com:443/", "protocol");
+  const writer = streamyWS.writable.getWriter();
+  const reader = streamyWS.readable.getReader();
 
-  streamyWS.writable.write("Hello");
-  streamyWS.writable.write("web socket!");
+  writer.write("Hello");
+  writer.write("web socket!");
 
-  streamyWS.readable.read().then(({ value, done }) => {
+  reader.read().then(({ value, done }) => {
     console.log("The web socket says: ", value);
   });
 </code></pre>
 
 Note how in this setup canceling the <code>readable</code> side will implicitly close the <code>writable</code> side,
 and similarly, closing or aborting the <code>writable</code> side will implicitly close the <code>readable</code> side.
-
-<pre><code class="lang-javascript">
-  streamyWS.readable.cancel().then(() => {
-    assert(streamyWS.writable.state === "closed");
-  });
-</code></pre>
 
 <h2 id="conventions" class="no-num">Conventions</h2>
 
@@ -4058,7 +4052,7 @@ and
 平野裕 (Yutaka Hirano) for his help with the readable stream reader design.
 
 This standard is written by <a href="https://domenic.me/">Domenic Denicola</a>
-(<a href="https://google.com">Google</a>, <a href="mailto:d@domenic.me">d@domenic.me</a>) with substantial help from
+(<a href="https://google.com">Google</a>, <a href="mailto:d@domenic.me">d@domenic.me</a>) and
 吉野剛史 (Takeshi Yoshino, <a href="https://google.com">Google</a>,
 <a href="mailto:tyoshino@chromium.org">tyoshino@chromium.org</a>).
 

--- a/index.bs
+++ b/index.bs
@@ -2661,17 +2661,7 @@ writable stream is <a>locked to a writer</a>.
   1. If _state_ is `"errored"`, return a new promise rejected with _stream_.[[storedError]].
   1. Assert: _state_ is either `"writable"` or `"closing"`.
   1. Let _error_ be a new *TypeError* indicating that the stream has been aborted.
-  1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
-    1. Reject _writeRequest_ with _error_.
-  1. Set _stream_.[[writeRequests]] to an empty List.
-  1. Let _writer_ be _stream_.[[writer]].
-  1. If _writer_ is not undefined,
-    1. Reject _writer_.[[closedPromise]] with _error_.
-    1. If _state_ is `"writable"` and !
-    WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, resolve
-    _writer_.[[readyPromise]] with *undefined*.
-  1. Set _stream_.[[state]] to `"errored"`.
-  1. Set _stream_.[[storedError]] to _error_.
+  1. Perform ! WritableStreamError(_stream_, _error_).
   1. Return ! WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
 </emu-alg>
 
@@ -2697,6 +2687,60 @@ visible through the {{WritableStream}}'s public API.
   1. Let _promise_ be a new promise.
   1. Append _promise_ as the last element of _stream_.[[writeRequests]].
   1. Return _promise_.
+</emu-alg>
+
+<h4 id="writable-stream-error" aoid="WritableStreamError" nothrow>WritableStreamError ( <var>stream</var>, <var>e</var>
+)</h4>
+
+<emu-alg>
+  1. Let _state_ be _stream_.[[state]].
+  1. Assert: _state_ is either `"writable"` or `"closing"`.
+  1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
+    1. Reject _writeRequest_ with _e_.
+  1. Set _stream_.[[writeRequests]] to an empty List.
+  1. Let _writer_ be _stream_.[[writer]].
+  1. If _writer_ is not undefined,
+    1. Reject _writer_.[[closedPromise]] with _e_.
+    1. If _state_ is `"writable"` and !
+    WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, resolve
+    _writer_.[[readyPromise]] with *undefined*.
+  1. Set _stream_.[[state]] to `"errored"`.
+  1. Set _stream_.[[storedError]] to _e_.
+</emu-alg>
+
+<h4 id="writable-stream-finish-close" aoid="WritableStreamFinishClose" nothrow>WritableStreamFinishClose (
+<var>stream</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[state]] is `"closing"`.
+  1. Assert: _stream_.[[writer]] is not *undefined*.
+  1. Set _stream_.[[state]] to `"closed"`.
+  1. Resolve _stream_.[[writer]].[[closedPromise]] with *undefined*.
+</emu-alg>
+
+<h4 id="writable-stream-fulfill-write-request" aoid="WritableStreamFulfillWriteRequest"
+nothrow>WritableStreamFulfillWriteRequest ( <var>stream</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[writeRequests]] is not empty.
+  1. Let _writeRequest_ be the first element of _stream_.[[writeRequests]].
+  1. Remove _writeRequest_ from _stream_.[[writeRequests]], shifting all other elements downward (so that the second
+  becomes the first, and so on).
+  1. Resolve _writeRequest_ with *undefined*.
+</emu-alg>
+
+<h4 id="writable-stream-update-backpressure" aoid="WritableStreamUpdateBackpressure"
+nothrow>WritableStreamUpdateBackpressure ( <var>stream</var>, <var>backpressure</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[state]] is `"writable"`.
+  1. Let _writer_ be _stream_.[[writer]].
+  1. If _writer_ is *undefined*, return.
+  1. If _backpressure_ is *true*,
+    1. Set _writer_.[[readyPromise]] to a new promise.
+  1. Otherwise,
+    1. Assert: _backpressure_ is *false*.
+    1. Resolve _writer_.[[readyPromise]] with *undefined*.
 </emu-alg>
 
 <h3 id="default-writer-class" interface lt="WritableStreamDefaultWriter">Class

--- a/index.bs
+++ b/index.bs
@@ -2967,6 +2967,258 @@ nothrow>WritableStreamDefaultWriterWrite ( <var>writer</var>, <var>chunk</var> )
   1. Return _promise_.
 </emu-alg>
 
+<h3 id="ws-default-controller-class" interface lt="WritableStreamDefaultController">Class
+<code>WritableStreamDefaultController</code></h3>
+
+The {{WritableStreamDefaultController}} class has methods that allow control of a {{WritableStream}}'s state. When
+constructing a {{WritableStream}}, the <a>underlyingsink</a> is given a corresponding
+{{WritableStreamDefaultController}} instance to manipulate.
+
+<h4 id="ws-default-controller-class-definition">Class Definition</h4>
+
+<em>This section is non-normative.</em>
+
+If one were to write the {{WritableStreamDefaultController}} class in something close to the syntax of [[!ECMASCRIPT]],
+it would look like
+
+<pre><code class="lang-javascript">
+  class WritableStreamDefaultController {
+    constructor(stream, underlyingSink, size, highWaterMark)
+
+    error(e)
+  }
+</code></pre>
+
+<h4 id="ws-default-controller-internal-slots">Internal Slots</h4>
+
+Instances of {{WritableStreamDefaultController}} are created with the internal slots described in the following table:
+
+<table>
+  <thead>
+    <tr>
+      <th>Internal Slot</th>
+      <th>Description (<em>non-normative</em>)</th>
+    </tr>
+  </thead>
+  <tr>
+    <td>\[[controlledWritableStream]]
+    <td>The {{WritableStream}} instance controlled
+  </tr>
+  <tr>
+    <td>\[[queue]]
+    <td>A List representing the stream's internal queue of <a>chunks</a>
+  </tr>
+  <tr>
+    <td>\[[started]]
+    <td>A boolean flag indicating whether the <a>underlying sink</a> has finished starting
+  </tr>
+  <tr>
+    <td>\[[strategyHWM]]
+    <td>A number supplied to the constructor as part of the stream's <a>queuing strategy</a>, indicating the point at
+      which the stream will apply <a>backpressure</a> to its <a>underlying sink</a>
+  </tr>
+  <tr>
+    <td>\[[strategySize]]
+    <td>A function supplied to the constructor as part of the stream's <a>queuing strategy</a>, designed to calculate
+      the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default behavior
+  </tr>
+  <tr>
+    <td>\[[underlyingSink]]
+    <td>An object representation of the stream's <a>underlying sink</a>; also
+      used for the <a href="#is-writable-stream">IsWritableStream</a> brand check
+  </tr>
+  <tr>
+    <td>\[[writing]]
+    <td>A boolean flag set to <emu-val>true</emu-val> while the <a>underlying sink</a>'s <code>write</code> method is
+      executing and has not yet fulfilled, used to prevent reentrant calls
+  </tr>
+</table>
+
+<h4 id="ws-default-controller-constructor" constructor for="WritableStreamDefaultController"
+lt="WritableStreamDefaultController(stream, underlyingSink, size, highWaterMark)">new
+WritableStreamDefaultController(<var>stream</var>, <var>underlyingSink</var>, <var>size</var>,
+<var>highWaterMark</var>)</h4>
+
+<div class="note">
+  The <code>WritableStreamDefaultController</code> constructor cannot be used directly; it only works on a
+  {{WritableStream}} that is in the middle of being constructed.
+</div>
+
+<emu-alg>
+  1. If ! IsWritableStream(_stream_) is *false*, throw a *TypeError* exception.
+  1. If _stream_.[[writableStreamController]] is not *undefined*, throw a *TypeError* exception.
+  1. Set *this*.[[controlledWritableStream]] to _stream_.
+  1. Set *this*.[[underlyingSink]] to _underlyingSink_.
+  1. Set *this*.[[queue]] to a new empty List.
+  1. Set *this*.[[started]] and *this*.[[writing]] to *false*.
+  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
+  1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to
+     _normalizedStrategy_.[[highWaterMark]].
+  1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(*this*).
+  1. If _backpressure_ is *true*, perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
+  1. Let _controller_ be *this*.
+  1. Let _startResult_ be ? InvokeOrNoop(_underlyingSink_, `"start"`, « *this* »).
+  1. Resolve _startResult_ as a promise:
+    1. Upon fulfillment,
+      1. Set _controller_.[[started]] to *true*.
+      1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
+    1. Upon rejection with reason _r_,
+      1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+</emu-alg>
+
+<h4 id="ws-default-controller-prototype">Properties of the {{WritableStreamDefaultController}} Prototype</h4>
+
+<h5 id="ws-default-controller-error" method for="WritableStreamDefaultController">error(<var>e</var>)</h5>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultController(*this*) is *false*, throw a *TypeError* exception.
+  1. Let _state_ be *this*.[[controlledWritableStream]].[[state]].
+  1. If _state_ is `"closed"` or `"errored"`, throw a *TypeError* exception.
+  1. Perform ! WritableStreamDefaultControllerError(*this*, _e_).
+</emu-alg>
+
+<h3 id="ws-default-controller-abstract-ops">Writable Stream Default Controller Abstract Operations</h3>
+
+<h4 id="is-writable-stream-default-controller" aoid="IsWritableStreamDefaultController"
+nothrow>IsWritableStreamDefaultController ( <var>x</var> )</h4>
+
+<emu-alg>
+  1. If Type(_x_) is not Object, return *false*.
+  1. If _x_ does not have an [[underlyingSink]] internal slot, return *false*.
+  1. Return *true*.
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-abort" aoid="WritableStreamDefaultControllerAbort"
+nothrow>WritableStreamDefaultControllerAbort ( <var>controller</var>, <var>reason</var> )</h4>
+
+<emu-alg>
+  1. Set _controller_.[[queue]] to a new empty List.
+  1. Let _sinkAbortPromise_ be ! PromiseInvokeOrFallbackOrNoop(_controller_.[[underlyingSink]], `"abort"`, « _reason_ », `"close"`, « »).
+  1. Upon fulfillment of _sinkAbortPromise_,
+    1. Return *undefined*.
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-close" aoid="WritableStreamDefaultControllerClose"
+nothrow>WritableStreamDefaultControllerClose ( <var>controller</var> )</h4>
+
+<emu-alg>
+  1. Perform ! EnqueueValueWithSize(_controller_.[[queue]], `"close"`, *0*).
+  1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-get-desired-size" aoid="WritableStreamDefaultControllerGetDesiredSize"
+nothrow>WritableStreamDefaultControllerGetDesiredSize ( <var>controller</var> )</h4>
+
+<emu-alg>
+  1. Let _queueSize_ be ! GetTotalQueueSize(_controller_.[[queue]]).
+  1. Return _controller_.[[strategyHWM]] - _queueSize_.
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-write" aoid="WritableStreamDefaultControllerWrite"
+nothrow>WritableStreamDefaultControllerWrite ( <var>controller</var>, <var>chunk</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _controller_.[[controlledWritableStream]].
+  1. Assert: _stream_.[[state]] is `"writable"`.
+  1. Let _chunkSize_ be *1*.
+  1. If _controller_.[[strategySize]] is not *undefined*,
+    1. Set _chunkSize_ to Call(_controller_.[[strategySize]], *undefined*, « ‍_chunk_ »).
+      1. If _chunkSize_ is an abrupt completion,
+        1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_,‍_chunkSize_.[[Value]]).
+        1. Return a promise rejected with _chunkSize_.[[Value]].
+  1. Let _writeRecord_ be Record {[[chunk]]: _chunk_}.
+  1. Let _lastBackpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
+  1. Let _enqueueResult_ be ! EnqueueValueWithSize(_controller_.[[queue]], _writeRecord_, _chunkSize_).
+  1. If _enqueueResult_ is an abrupt completion,
+    1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_,‍_enqueueResult_.[[Value]]).
+    1. Return a promise rejected with _enqueueResult_.[[Value]].
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"writable"`,
+    1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
+    1. If _lastBackpressure_ is not _backpressure_, perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
+  1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-advance-queue-if-needed" aoid="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
+nothrow>WritableStreamDefaultControllerAdvanceQueueIfNeeded ( <var>controller</var> )</h4>
+
+<emu-alg>
+  1. Let _state_ be _controller_.[[controlledWritableStream]].[[state]].
+  1. If _state_ is `"closed"` or `"errored"`, return.
+  1. If _controller_.[[started]] is *false*, return.
+  1. If _controller_.[[queue]] is emtpy, return.
+  1. If _controller_.[[writing]] is *true*, return.
+  1. Let _writeRecord_ be ! PeekQueueValue(_controller_.[[queue]]).
+  1. If _writeRecord_ is `"close"`, perform WritableStreamDefaultControllerProcessClose(_controller_).
+  1. Otherwise, perform WritableStreamDefaultControllerProcessWrite(_controller_, _writeRecord_.[[chunk]]).
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-error-if-needed" aoid="WritableStreamDefaultControllerErrorIfNeeded"
+nothrow>WritableStreamDefaultControllerErrorIfNeeded ( <var>controller</var>, <var>e</var> )</h4>
+
+<emu-alg>
+  1. Let _state_ be _controller_.[[controlledWritableStream]].[[state]].
+  1. If _state_ is `"writable"` or `"closing"`, perform ! WritableStreamDefaultControllerError(_controller_, _e_).
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-process-close" aoid="WritableStreamDefaultControllerProcessClose"
+nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _controller_.[[controlledWritableStream]].
+  1. Assert: _stream_.[[state]] is `"closing"`.
+  1. Perform ! DequeueValue(_controller_.[[queue]]).
+  1. Assert: _controller_.[[queue]] is empty.
+  1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`).
+  1. Upon fulfillment of _sinkClosePromise_,
+    1. If _stream_.[[state]] is not `"closing"`, return.
+    1. Perform ! WritableStreamFulfillWriteRequest(_stream_).
+    1. Perform ! WritableStreamFinishClose(_stream_).
+  1. Upon rejection of _sinkClosePromise_ with reason _r_,
+    1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-process-write" aoid="WritableStreamDefaultControllerProcessWrite"
+nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <var>chunk</var> )</h4>
+
+<emu-alg>
+  1. Set _controller_.[[writing]] to *true*.
+  1. Let _sinkWritePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"write"`, « ‍_chunk_ »).
+  1. Upon fulfillment of _sinkWritePromise_,
+    1. Let _stream_ be _controller_.[[controlledWritableStream]].
+    1. Let _state_ be _stream_.[[state]].
+    1. If _state_ is `"errored"` or `"closed"`, return.
+    1. Set _controller_.[[writing]] to *false*.
+    1. Perform ! WritableStreamFulfillWriteRequest(_stream_).
+    1. Let _lastBackpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
+    1. Perform ! DequeueValue(_controller_.[[queue]]).
+    1. If _state_ is not `"closing"`,
+      1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
+      1. If _lastBackpressure_ is not _backpressure_, perform ! WritableStreamUpdateBackpressure(_controller_.[[controlledWritableStream]], _backpressure_).
+    1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
+  1. Upon rejection of _sinkWritePromise_ with reason _r_,
+    1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-get-backpressure" aoid="WritableStreamDefaultControllerGetBackpressure"
+nothrow>WritableStreamDefaultControllerGetBackpressure ( <var>controller</var> )</h4>
+
+<emu-alg>
+  1. Let _desiredSize_ be ! WritableStreamDefaultControllerGetDesiredSize(_controller_).
+  1. Return _desiredSize_ <= *0*.
+</emu-alg>
+
+<h4 id="writable-stream-default-controller-error" aoid="WritableStreamDefaultControllerError"
+nothrow>WritableStreamDefaultControllerError ( <var>controller</var>, <var>e</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _controller_.[[controlledWritableStream]].
+  1. Let _state_ be _stream_.[[state]].
+  1. Assert: _state_ is `"writable"` or `"closing"`.
+  1. Perform ! WritableStreamError(_stream_, _e_).
+  1. Set _controller_.[[queue]] to a new empty List.
+</emu-alg>
+
 <h2 id="ts">Transform Streams</h2>
 
 Transform streams have been developed in the testable implementation, but not yet re-encoded in spec language.

--- a/index.bs
+++ b/index.bs
@@ -540,7 +540,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
       return pump();
 
       function pump() {
-        return reader.read().then(({ value, done })=> {
+        return reader.read().then(({ value, done }) => {
           if (done) {
             return chunks;
           }
@@ -2566,169 +2566,58 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
 </div>
 
 <emu-alg>
-  1. Set *this*.[[underlyingSink]] to _underlyingSink_.
-  1. Set *this*.[[closedPromise]] to a new promise.
-  1. Set *this*.[[readyPromise]] to a new promise resolved with *undefined*.
-  1. Set *this*.[[queue]] to a new empty List.
-  1. Set *this*.[[state]] to "writable".
-  1. Set *this*.[[started]] and *this*.[[writing]] to *false*.
-  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
-  1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to _normalizedStrategy_.[[highWaterMark]].
-  1. Perform ! SyncWritableStreamStateWithQueue(*this*).
-  1. Let _error_ be a new <a><code>WritableStream</code> error function</a>.
-  1. Set _error_.[[stream]] to *this*.
-  1. Let _startResult_ be ? InvokeOrNoop(_underlyingSink_, "start", « _error_ »).
-  1. Set *this*.[[startedPromise]] to the result of resolving _startResult_ as a promise.
-    1. Upon fulfillment,
-      1. Set *this*.[[started]] to *true*.
-      1. Set *this*.[[startedPromise]] to *undefined*.
-    1. Upon rejection with reason _r_, perform ! ErrorWritableStream(*this*, _r_).
-</emu-alg>
-
-A <dfn>{{WritableStream}} error function</dfn> is an anonymous built-in function that is used to allow
-<a>underlying sinks</a> to error their associated writable stream. Each {{WritableStream}} error function has
-a \[[stream]] internal slot. When a {{WritableStream}} error function <var>F</var> is called with argument
-<var>e</var>, it performs the following steps:
-
-<emu-alg>
-  1. Let _stream_ be _F_.[[stream]].
-  1. Perform ErrorWritableStream(_stream_, _e_).
-  1. Return *undefined*.
+  1. Set *this*.[[state]] to `"writable"`.
+  1. Set *this*.[[storedError]], *this*.[[writer]], and *this*.[[writableStreamController]] to *undefined*.
+  1. Set *this*.[[writeRequests]] to a new empty List.
+  1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
+  1. If _type_ is not *undefined*, throw a *RangeError* exception. <p class="note">This is to allow us to add new
+     potential types in the future, without backward-compatibility concerns.</p>
+  1. Set *this*.[[writableStreamController]] to ? Construct(`<a idl>WritableStreamDefaultController</a>`, « *this*,
+     _underlyingSink_, _size_, _highWaterMark_ »).
 </emu-alg>
 
 <h4 id="ws-prototype">Properties of the {{WritableStream}} Prototype</h4>
 
-<h5 id="ws-closed" attribute for="WritableStream" lt="closed">get closed</h5>
+<h5 id="ws-locked" attribute for="WritableStream" lt="locked">get locked</h5>
 
 <div class="note">
-  The <code>closed</code> getter returns a promise that will be fulfilled when the stream becomes closed, or rejected
-  if it ever errors.
-</div>
-
-<emu-alg>
-  1. If ! IsWritableStream(*this*) is *false*, return a promise rejected with a *TypeError* exception.
-  1. Return *this*.[[closedPromise]].
-</emu-alg>
-
-<h5 id="ws-ready" attribute for="WritableStream" lt="ready">get ready</h5>
-
-<div class="note">
-  The <code>ready</code> getter returns a promise that will be fulfilled when the stream transitions away from the
-  <code>"waiting"</code> state to any other state. Once the stream transitions back to <code>"waiting"</code>, the
-  getter will return a new promise that stays pending until the next state transition.
-
-  In essence, this promise gives a signal as to when any backpressure has let up (or that the stream has been closed
-  or errored).
-</div>
-
-<emu-alg>
-  1. If ! IsWritableStream(*this*) is *false*, return a promise rejected with a *TypeError* exception.
-  1. Return *this*.[[readyPromise]].
-</emu-alg>
-
-<h5 id="ws-state" attribute for="WritableStream" lt="state">get state</h5>
-
-<div class="note">
-  The <code>state</code> getter returns the state of the stream, which will be one of the following:
-
-  <dl>
-    <dt><code>"waiting"</code>
-    <dd>The stream's internal queue is full; that is, the stream is
-      exerting <a>backpressure</a>. Use {{WritableStream/ready}} to be notified of when the pressure subsides.
-
-    <dt><code>"writable"</code>
-    <dd>The stream's internal queue is not full; call {{WritableStream/write()}} until backpressure is exerted.
-
-    <dt><code>"closing"</code>
-    <dd>The stream's {{WritableStream/close()}} method has been called, and a command to close is in the queue or
-      being processed by the <a>underlying sink</a>; attempts to write will now fail.
-
-    <dt><code>"closed"</code>
-    <dd>The <a>underlying sink</a> has been closed; writing is no longer possible.
-
-    <dt><code>"errored"</code>
-    <dd>An error occurred interacting with the <a>underlying sink</a> or the stream has been aborted, so the stream is
-      now dead.
-  </dl>
+  The <code>locked</code> getter returns whether or not the writable stream is <a>locked to a writer</a>.
 </div>
 
 <emu-alg>
   1. If ! IsWritableStream(*this*) is *false*, throw a *TypeError* exception.
-  1. Return *this*.[[state]].
+  1. Return ! IsWritableStreamLocked(*this*).
 </emu-alg>
 
 <h5 id="ws-abort" method for="WritableStream">abort(<var>reason</var>)</h5>
 
 <div class="note">
-  The <code>abort</code> method signals that the producer can no longer successfully write to the stream and it should
-  be immediately moved to an <code>"errored"</code> state, with any queued-up writes discarded. This will also execute
-  any abort mechanism of the <a>underlying sink</a>.
+  The <code>abort</code> method <a lt="abort a writable stream">aborts</a> the stream, signaling that the producer can
+  no longer successfully write to the stream and it should be immediately moved to an errored state, with any queued-up
+  writes discarded. This will also execute any abort mechanism of the <a>underlying sink</a>.
 </div>
 
 <emu-alg>
   1. If ! IsWritableStream(*this*) is *false*, return a promise rejected with a *TypeError* exception.
-  1. If *this*.[[state]] is "closed", return a promise resolved with *undefined*.
-  1. If *this*.[[state]] is "errored", return a promise rejected with *this*.[[storedError]].
-  1. Perform ! ErrorWritableStream(*this*, _reason_).
-  1. Let _sinkAbortPromise_ be ! PromiseInvokeOrFallbackOrNoop(*this*.[[underlyingSink]], "abort", « _reason_ »,
-     "close", «  »).
-  1. Return the result of transforming _sinkAbortPromise_ by a fulfillment handler that returns *undefined*.
+  1. If ! IsWritableStreamLocked(*this*) is *true*, return a promise rejected with a *TypeError* exception.
+  1. Return ! WritableStreamAbort(*this*, _reason_).
 </emu-alg>
 
-<h5 id="ws-close" method for="WritableStream">close()</h5>
+<h5 id="ws-get-writer" method for="WritableStream">getWriter()</h5>
 
 <div class="note">
-  The <code>close</code> method signals that the producer is done writing chunks to the stream and wishes to move the
-  stream to a <code>"closed"</code> state. This queues an action to close the stream, such that once any currently
-  queued-up writes complete, the close mechanism of the <a>underlying sink</a> will execute, releasing any held
-  resources. In the meantime, the stream will be in a <code>"closing"</code> state.
+  The <code>getWriter</code> method creates a <a lt="writable stream writer">writer</a> (an instance of
+  {{WritableStreamDefaultWriter}}) and <a lt="locked to a writer">locks</a> the stream to the new writer. While the
+  stream is locked, no other writer can be acquired until this one is <a lt="release a write lock">released</a>.
+
+  This functionality is especially useful for creating abstractions that desire the ability to write to a stream without
+  interruption or interleaving. By getting a writer for the stream, you can ensure nobody else can write at the same
+  time, which would cause the resulting written data to be unpredictable and probably useless.
 </div>
 
 <emu-alg>
-  1. If ! IsWritableStream(*this*) is *false*, return a promise rejected with a *TypeError* exception.
-  1. If *this*.[[state]] is "closing" or "closed", return a promise rejected with a *TypeError* exception.
-  1. If *this*.[[state]] is "errored", return a promise rejected with *this*.[[storedError]].
-  1. If *this*.[[state]] is "waiting", resolve *this*.[[readyPromise]] with *undefined*.
-  1. Set *this*.[[state]] to "closing".
-  1. Perform ! EnqueueValueWithSize(*this*.[[queue]], "close", *0*).
-  1. Perform ! CallOrScheduleWritableStreamAdvanceQueue(*this*).
-  1. Return *this*.[[closedPromise]].
-</emu-alg>
-
-<h5 id="ws-write" method for="WritableStream">write(<var>chunk</var>)</h5>
-
-<div class="note">
-  The <code>write</code> method adds a write to the stream's internal queue, instructing the stream to
-  write the given <a>chunk</a> of data to the <a>underlying sink</a> once all other pending writes have finished
-  successfully. It returns a promise that will be fulfilled or rejected depending on the success or failure of writing
-  the chunk to the underlying sink.
-
-  The impact of enqueuing this chunk will be immediately reflected in the stream's {{WritableStream/state}} property; in
-  particular, if the internal queue is now full according to the stream's <a>queuing strategy</a>, the stream will
-  exert backpressure by changing its state to <code>"waiting"</code>.
-</div>
-
-<emu-alg>
-  1. If ! IsWritableStream(*this*) is *false*, return a promise rejected with a *TypeError* exception.
-  1. If *this*.[[state]] is `"closing"` or `"closed"`, return a promise rejected with a *TypeError* exception.
-  1. If *this*.[[state]] is `"errored"`, return a promise rejected with *this*.[[storedError]].
-  1. Assert: *this*.[[state]] is either `"waiting"` or `"writable"`.
-  1. Let _chunkSize_ be *1*.
-  1. If *this*.[[strategySize]] is not *undefined*, then
-    1. Set _chunkSize_ to Call(*this*.[[strategySize]], *undefined*, « ‍_chunk_ »).
-    1. If _chunkSize_ is an abrupt completion,
-      1. Perform ! ErrorWritableStream(*this*, _chunkSize_.[[Value]]).
-      1. Return a new promise rejected with _chunkSize_.[[Value]].
-    1. Set _chunkSize_ to _chunkSize_.[[Value]].
-  1. Let _promise_ be a new promise.
-  1. Let _writeRecord_ be Record {[[promise]]: _promise_, [[chunk]]: _chunk_}.
-  1. Let _enqueueResult_ be EnqueueValueWithSize(*this*.[[queue]], _writeRecord_, _chunkSize_).
-  1. If _enqueueResult_ is an abrupt completion,
-    1. Perform ! ErrorWritableStream(*this*, _enqueueResult_.[[Value]]).
-    1. Return a new promise rejected with _enqueueResult_.[[Value]].
-  1. Perform ! SyncWritableStreamStateWithQueue(*this*).
-  1. Perform ! CallOrScheduleWritableStreamAdvanceQueue(*this*).
-  1. Return _promise_.
+  1. If ! IsWritableStream(*this*) is *false*, throw a *TypeError* exception.
+  1. Return ? AcquireWritableStreamDefaultReader(*this*).
 </emu-alg>
 
 <h3 id="ws-abstract-ops">Writable Stream Abstract Operations</h3>

--- a/index.bs
+++ b/index.bs
@@ -2626,7 +2626,7 @@ The following abstract operations, unlike most in this specification, are meant 
 specifications, instead of just being part of the implementation of this spec's classes.
 
 <h4 id="acquire-writable-stream-default-writer" aoid="AcquireWritableStreamDefaultWriter"
-nothrow>AcquireWritableStreamDefaultWriter ( <var>stream</var> )</h4>
+throws>AcquireWritableStreamDefaultWriter ( <var>stream</var> )</h4>
 
 <emu-alg>
   1. Return ? Construct(`<a idl>WritableStreamDefaultWriter</a>`, « *this* »).
@@ -2659,7 +2659,7 @@ writable stream is <a>locked to a writer</a>.
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"closed"`, return a new promise resolved with *undefined*.
   1. If _state_ is `"errored"`, return a new promise rejected with _stream_.[[storedError]].
-  1. Assert: _state_ is either `"writable"` or `"closing"`.
+  1. Assert: _state_ is `"writable"` or `"closing"`.
   1. Let _error_ be a new *TypeError* indicating that the stream has been aborted.
   1. Perform ! WritableStreamError(_stream_, _error_).
   1. Return ! WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
@@ -2694,7 +2694,7 @@ visible through the {{WritableStream}}'s public API.
 
 <emu-alg>
   1. Let _state_ be _stream_.[[state]].
-  1. Assert: _state_ is either `"writable"` or `"closing"`.
+  1. Assert: _state_ is `"writable"` or `"closing"`.
   1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
     1. Reject _writeRequest_ with _e_.
   1. Set _stream_.[[writeRequests]] to an empty List.
@@ -2812,13 +2812,13 @@ lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>st
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"writable"` or `"closing"`,
     1. Set _writer_.[[closedPromise]] to a new promise.
+  1. Otherwise if _state_ is `"closed"`,
+    1. Set _writer_.[[closedPromise]] to a new promise resolved with *undefined*.
   1. Otherwise,
-    1. If _state_ is `"closed"`,
-      1. Set _writer_.[[closedPromise]] to a new promise resolved with *undefined*.
-    1. Otherwise,
-      1. Assert: _state_ is `"errored"`.
-      1. Set _writer_.[[closedPromise]] to a new promise rejected with _stream_.[[storedError]].
-  1. If _state_ is `"writable"` and ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]] is *true*,
+    1. Assert: _state_ is `"errored"`.
+    1. Set _writer_.[[closedPromise]] to a new promise rejected with _stream_.[[storedError]].
+  1. If _state_ is `"writable"` and !
+     WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*,
     1. Set _writer_.[[readyPromise]] to a new promise.
   1. Otherwise,
     1. Set _writer_.[[readyPromise]] to a new promise resolved with *undefined*.
@@ -2829,8 +2829,8 @@ lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>st
 <h5 id="default-writer-closed" attribute for="WritableStreamDefaultWriter" lt="closed">get closed</h5>
 
 <div class="note">
-  The <code>closed</code> getter returns a promise that will be fulfilled when the stream becomes closed or the
-  writer's lock is <a lt="release a write lock">released</a>, or rejected if the stream ever errors.
+  The <code>closed</code> getter returns a promise that will be fulfilled when the stream becomes closed, or rejected if
+  the stream ever errors or the writer's lock is <a lt="release a write lock">released</a>.
 </div>
 
 <emu-alg>
@@ -2890,9 +2890,12 @@ lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>st
   1. Let _stream_ be *this*.[[ownerWritableStream]].
   1. If _stream_ is *undefined*, return *undefined*.
   1. Assert: _stream_.[[writer]] is not *undefined*.
+  1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"writable"` or `"closing"`, reject _writer_.[[closedPromise]] with a *TypeError* exception.
   1. Otherwise, set _writer_.[[closedPromise]] to a new promise rejected with a *TypeError* exception.
-  1. If _state_ is `"writable"` and ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, reject _writer_.[[readyPromise]] with a *TypeError* exception.
+  1. If _state_ is `"writable"` and !
+     WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, reject
+     _writer_.[[readyPromise]] with a *TypeError* exception.
   1. Otherwise, set _writer_.[[readyPromise]] to a new promise rejected with a *TypeError* exception.
   1. Set _stream_.[[writer]] to *undefined*.
   1. Set *this*.[[ownerReadableStream]] to *undefined*.
@@ -2938,7 +2941,8 @@ nothrow>WritableStreamDefaultWriterClose ( <var>writer</var> )</h4>
   1. If _state_ is `"close"` or `"errored"`, return a promise rejected with a *TypeError* exception.
   1. Assert: _state_ is `"writable"`.
   1. Let _promise_ be ! WritableStreamAddWriteRequest(_stream_).
-  1. If ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, resolve _writer_.[[readyPromise]] with *undefined*.
+  1. If ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, resolve
+     _writer_.[[readyPromise]] with *undefined*.
   1. Set _stream_.[[state]] to `"closing"`.
   1. Perform ! WritableStreamDefaultControllerClose(_stream_.[[writableStreamController]]).
   1. Return _promise_.
@@ -2971,7 +2975,7 @@ nothrow>WritableStreamDefaultWriterWrite ( <var>writer</var>, <var>chunk</var> )
 <code>WritableStreamDefaultController</code></h3>
 
 The {{WritableStreamDefaultController}} class has methods that allow control of a {{WritableStream}}'s state. When
-constructing a {{WritableStream}}, the <a>underlyingsink</a> is given a corresponding
+constructing a {{WritableStream}}, the <a>underlying sink</a> is given a corresponding
 {{WritableStreamDefaultController}} instance to manipulate.
 
 <h4 id="ws-default-controller-class-definition">Class Definition</h4>
@@ -3093,9 +3097,10 @@ nothrow>WritableStreamDefaultControllerAbort ( <var>controller</var>, <var>reaso
 
 <emu-alg>
   1. Set _controller_.[[queue]] to a new empty List.
-  1. Let _sinkAbortPromise_ be ! PromiseInvokeOrFallbackOrNoop(_controller_.[[underlyingSink]], `"abort"`, « _reason_ », `"close"`, « »).
-  1. Upon fulfillment of _sinkAbortPromise_,
-    1. Return *undefined*.
+  1. Let _sinkAbortPromise_ be ! PromiseInvokeOrFallbackOrNoop(_controller_.[[underlyingSink]],
+     `"abort"`, « _reason_ », `"close"`, « »).
+  1. Return the result of transforming _sinkAbortPromise_ by a fulfillment handler that returns
+    *undefined*.
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-close" aoid="WritableStreamDefaultControllerClose"
@@ -3111,7 +3116,7 @@ nothrow>WritableStreamDefaultControllerGetDesiredSize ( <var>controller</var> )<
 
 <emu-alg>
   1. Let _queueSize_ be ! GetTotalQueueSize(_controller_.[[queue]]).
-  1. Return _controller_.[[strategyHWM]] - _queueSize_.
+  1. Return _controller_.[[strategyHWM]] − _queueSize_.
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-write" aoid="WritableStreamDefaultControllerWrite"
@@ -3123,31 +3128,31 @@ nothrow>WritableStreamDefaultControllerWrite ( <var>controller</var>, <var>chunk
   1. Let _chunkSize_ be *1*.
   1. If _controller_.[[strategySize]] is not *undefined*,
     1. Set _chunkSize_ to Call(_controller_.[[strategySize]], *undefined*, « ‍_chunk_ »).
-      1. If _chunkSize_ is an abrupt completion,
-        1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_,‍_chunkSize_.[[Value]]).
-        1. Return a promise rejected with _chunkSize_.[[Value]].
+    1. If _chunkSize_ is an abrupt completion,
+      1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_,‍ _chunkSize_.[[Value]]).
+      1. Return a promise rejected with _chunkSize_.[[Value]].
   1. Let _writeRecord_ be Record {[[chunk]]: _chunk_}.
   1. Let _lastBackpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
   1. Let _enqueueResult_ be ! EnqueueValueWithSize(_controller_.[[queue]], _writeRecord_, _chunkSize_).
   1. If _enqueueResult_ is an abrupt completion,
-    1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_,‍_enqueueResult_.[[Value]]).
+    1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _enqueueResult_.[[Value]]).
     1. Return a promise rejected with _enqueueResult_.[[Value]].
-  1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"writable"`,
+  1. If _stream_.[[state]] is `"writable"`,
     1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
-    1. If _lastBackpressure_ is not _backpressure_, perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
+    1. If _lastBackpressure_ is not _backpressure_, perform ! WritableStreamUpdateBackpressure(_stream_,
+       _backpressure_).
   1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
 </emu-alg>
 
-<h4 id="writable-stream-default-controller-advance-queue-if-needed" aoid="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
-nothrow>WritableStreamDefaultControllerAdvanceQueueIfNeeded ( <var>controller</var> )</h4>
+<h4 id="writable-stream-default-controller-advance-queue-if-needed"
+aoid="WritableStreamDefaultControllerAdvanceQueueIfNeeded" nothrow>WritableStreamDefaultControllerAdvanceQueueIfNeeded (
+<var>controller</var> )</h4>
 
 <emu-alg>
-  1. Let _state_ be _controller_.[[controlledWritableStream]].[[state]].
-  1. If _state_ is `"closed"` or `"errored"`, return.
+  1. If _controller_.[[controlledWritableStream]].[[state]] is `"closed"` or `"errored"`, return.
   1. If _controller_.[[started]] is *false*, return.
-  1. If _controller_.[[queue]] is emtpy, return.
   1. If _controller_.[[writing]] is *true*, return.
+  1. If _controller_.[[queue]] is empty, return.
   1. Let _writeRecord_ be ! PeekQueueValue(_controller_.[[queue]]).
   1. If _writeRecord_ is `"close"`, perform WritableStreamDefaultControllerProcessClose(_controller_).
   1. Otherwise, perform WritableStreamDefaultControllerProcessWrite(_controller_, _writeRecord_.[[chunk]]).
@@ -3157,8 +3162,8 @@ nothrow>WritableStreamDefaultControllerAdvanceQueueIfNeeded ( <var>controller</v
 nothrow>WritableStreamDefaultControllerErrorIfNeeded ( <var>controller</var>, <var>e</var> )</h4>
 
 <emu-alg>
-  1. Let _state_ be _controller_.[[controlledWritableStream]].[[state]].
-  1. If _state_ is `"writable"` or `"closing"`, perform ! WritableStreamDefaultControllerError(_controller_, _e_).
+  1. If _controller_.[[controlledWritableStream]].[[state]] is `"writable"` or `"closing"`, perform !
+     WritableStreamDefaultControllerError(_controller_, _e_).
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-process-close" aoid="WritableStreamDefaultControllerProcessClose"
@@ -3194,7 +3199,8 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
     1. Perform ! DequeueValue(_controller_.[[queue]]).
     1. If _state_ is not `"closing"`,
       1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
-      1. If _lastBackpressure_ is not _backpressure_, perform ! WritableStreamUpdateBackpressure(_controller_.[[controlledWritableStream]], _backpressure_).
+      1. If _lastBackpressure_ is not _backpressure_, perform !
+         WritableStreamUpdateBackpressure(_controller_.[[controlledWritableStream]], _backpressure_).
     1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
   1. Upon rejection of _sinkWritePromise_ with reason _r_,
     1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
@@ -3205,7 +3211,7 @@ nothrow>WritableStreamDefaultControllerGetBackpressure ( <var>controller</var> )
 
 <emu-alg>
   1. Let _desiredSize_ be ! WritableStreamDefaultControllerGetDesiredSize(_controller_).
-  1. Return _desiredSize_ <= *0*.
+  1. Return _desiredSize_ ≤ *0*.
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-error" aoid="WritableStreamDefaultControllerError"
@@ -3213,8 +3219,7 @@ nothrow>WritableStreamDefaultControllerError ( <var>controller</var>, <var>e</va
 
 <emu-alg>
   1. Let _stream_ be _controller_.[[controlledWritableStream]].
-  1. Let _state_ be _stream_.[[state]].
-  1. Assert: _state_ is `"writable"` or `"closing"`.
+  1. Assert: _stream_.[[state]] is `"writable"` or `"closing"`.
   1. Perform ! WritableStreamError(_stream_, _e_).
   1. Set _controller_.[[queue]] to a new empty List.
 </emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -2716,6 +2716,171 @@ nothrow>SyncWritableStreamStateWithQueue ( <var>stream</var> )</h4>
   1. Return *undefined*.
 </emu-alg>
 
+<h3 id="default-writer-class" interface lt="WritableStreamDefaultWriter">Class
+<code>WritableStreamDefaultWriter</code></h3>
+
+The {{WritableStreamDefaultWriter}} class represents a <a>default writer</a> designed to be vended by a
+{{WritableStream}} instance.
+
+<h4 id="default-writer-class-definition">Class Definition</h4>
+
+<em>This section is non-normative.</em>
+
+If one were to write the {{WritableStreamDefaultWriter}} class in something close to the syntax of [[!ECMASCRIPT]], it
+would look like
+
+<pre><code class="lang-javascript">
+  class WritableStreamDefaultWriter {
+    constructor(stream)
+
+    get closed()
+    get desiredSize()
+    get ready()
+
+    abort(reason)
+    close()
+    releaseLock()
+    write(chunk)
+  }
+</code></pre>
+
+<h4 id="default-writer-internal-slots">Internal Slots</h4>
+
+Instances of {{WritableStreamDefaultWriter}} are created with the internal slots described in the following table:
+
+<table>
+  <thead>
+    <tr>
+      <th>Internal Slot</th>
+      <th>Description (<em>non-normative</em>)</th>
+    </tr>
+  </thead>
+  <tr>
+    <td>\[[closedPromise]]
+    <td>A promise returned by the writer's {{WritableStreamDefaultWriter/closed}} getter
+  </tr>
+  <tr>
+    <td>\[[ownerWritableStream]]
+    <td>A {{WritableStream}} instance that owns this writer
+  </tr>
+  <tr>
+    <td>\[[readyPromise]]
+    <td>A promise returned by the writer's {{WritableStreamDefaultWriter/ready}} getter
+  </tr>
+</table>
+
+<h4 id="default-writer-constructor" constructor for="WritableStreamDefaultWriter"
+lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>stream</var>)</h4>
+
+<div class="note">
+  The <code>WritableStreamDefaultWriter</code> constructor is generally not meant to be used directly; instead, a
+  stream's {{WritableStream/getWriter()}} method should be used.
+</div>
+
+<emu-alg>
+  1. If ! IsWritableStream(_stream_) is *false*, throw a *TypeError* exception.
+  1. If ! IsWritableStreamLocked(_stream_) is *true*, throw a *TypeError* exception.
+  1. Set *this*.[[ownerWritableStream]] to _stream_.
+  1. Set _stream_.[[writer]] to *this*.
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"writable"` or `"closing"`,
+    1. Set _writer_.[[closedPromise]] to a new promise.
+  1. Otherwise,
+    1. If _state_ is `"closed"`,
+      1. Set _writer_.[[closedPromise]] to a new promise resolved with *undefined*.
+    1. Otherwise,
+      1. Assert: _state_ is `"errored"`.
+      1. Set _writer_.[[closedPromise]] to a new promise rejected with _stream_.[[storedError]].
+  1. If _state_ is `"writable"` and ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]] is *true*,
+    1. Set _writer_.[[readyPromise]] to a new promise.
+  1. Otherwise,
+    1. Set _writer_.[[readyPromise]] to a new promise resolved with *undefined*.
+</emu-alg>
+
+<h4 id="default-writer-prototype">Properties of the {{WritableStreamDefaultWriter}} Prototype</h4>
+
+<h5 id="default-writer-closed" attribute for="WritableStreamDefaultWriter" lt="closed">get closed</h5>
+
+<div class="note">
+  The <code>closed</code> getter returns a promise that will be fulfilled when the stream becomes closed or the
+  writer's lock is <a lt="release a write lock">released</a>, or rejected if the stream ever errors.
+</div>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultWriter(*this*) is *false*, return a promise rejected with a *TypeError* exception.
+  1. Return *this*.[[closedPromise]].
+</emu-alg>
+
+<h5 id="default-writer-desiredSize" attribute for="WritableStreamDefaultWriter" lt="desiredSize">get desiredSize</h5>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultWriter(*this*) is *false*, throw a *TypeError* exception.
+  1. If *this*.[[ownerWritableStream]] is *undefined*, throw a *TypeError* exception.
+  1. Return ! WritableStreamDefaultWriterGetDesiredSize(*this*).
+</emu-alg>
+
+<h5 id="default-writer-ready" attribute for="WritableStreamDefaultWriter" lt="ready">get ready</h5>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultWriter(*this*) is *false*, return a promise rejected with a *TypeError* exception.
+  1. Return *this*.[[readyPromise]].
+</emu-alg>
+
+<h5 id="default-writer-abort" method for="WritableStreamDefaultWriter">abort(<var>reason</var>)</h5>
+
+<div class="note">
+  If the writer is <a lt="active writer">active</a>, the <code>abort</code> method behaves the same as that for the
+  associated stream.
+</div>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultWriter(*this*) is *false*, return a promise rejected with a *TypeError* exception.
+  1. If *this*.[[ownerWritableStream]] is *undefined*, return a promise rejected with a *TypeError* exception.
+  1. Return ! WritableStreamDefaultWriterAbort(*this*, _reason_).
+</emu-alg>
+
+<h5 id="default-writer-close" method for="WritableStreamDefaultWriter">close()</h5>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultWriter(*this*) is *false*, return a promise rejected with a *TypeError* exception.
+  1. Let _stream_ be *this*.[[ownerWritableStream]].
+  1. If _stream_ is *undefined*, return a promise rejected with a *TypeError* exception.
+  1. If _stream_.[[state]] is `"closing"`, return a promise rejected with a *TypeError* exception.
+  1. Return ! WritableStreamDefaultWriterClose(*this*).
+</emu-alg>
+
+<h5 id="default-writer-release-lock" method for="WritableStreamDefaultWriter">releaseLock()</h5>
+
+<div class="note">
+  The <code>releaseLock</code> method <a lt="release a write lock">releases the writer's lock</a> on the corresponding
+  stream. After the lock is released, the writer is no longer <a lt="active writer">active</a>. If the associated
+  stream is errored when the lock is released, the writer will appear errored in the same way from now on; otherwise,
+  the writer will appear closed.
+</div>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultWriter(*this*) is *false*, throw a *TypeError* exception.
+  1. Let _stream_ be *this*.[[ownerWritableStream]].
+  1. If _stream_ is *undefined*, return *undefined*.
+  1. Assert: _stream_.[[writer]] is not *undefined*.
+  1. If _state_ is `"writable"` or `"closing"`, reject _writer_.[[closedPromise]] with a *TypeError* exception.
+  1. Otherwise, set _writer_.[[closedPromise]] to a new promise rejected with a *TypeError* exception.
+  1. If _state_ is `"writable"` and ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, reject _writer_.[[readyPromise]] with a *TypeError* exception.
+  1. Otherwise, set _writer_.[[readyPromise]] to a new promise rejected with a *TypeError* exception.
+  1. Set _stream_.[[writer]] to *undefined*.
+  1. Set *this*.[[ownerReadableStream]] to *undefined*.
+</emu-alg>
+
+<h5 id="default-writer-write" method for="WritableStreamDefaultWriter">write(<var>chunk</var>)</h5>
+
+<emu-alg>
+  1. If ! IsWritableStreamDefaultWriter(*this*) is *false*, return a promise rejected with a *TypeError* exception.
+  1. Let _stream_ be *this*.[[ownerWritableStream]].
+  1. If _stream_ is *undefined*, return a promise rejected with a *TypeError* exception.
+  1. If _stream_.[[state]] is `"closing"`, return a promise rejected with a *TypeError* exception.
+  1. Return ! WritableStreamDefaultWriterWrite(*this*, _chunk_).
+</emu-alg>
+
 <h2 id="ts">Transform Streams</h2>
 
 Transform streams have been developed in the testable implementation, but not yet re-encoded in spec language.

--- a/index.bs
+++ b/index.bs
@@ -2515,7 +2515,7 @@ Instances of {{WritableStream}} are created with the internal slots described in
   </tr>
   <tr>
     <td>\[[writeRequests]]
-    <td>A List representing the stream's internal queue of pending writes
+    <td>A List of promises representing the stream's internal queue of pending writes
   </tr>
 </table>
 
@@ -2620,106 +2620,89 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
   1. Return ? AcquireWritableStreamDefaultReader(*this*).
 </emu-alg>
 
-<h3 id="ws-abstract-ops">Writable Stream Abstract Operations</h3>
+<h3 id="ws-abstract-ops">General Writable Stream Abstract Operations</h3>
 
-<h4 id="call-or-schedule-writable-stream-advance-queue" aoid="CallOrScheduleWritableStreamAdvanceQueue"
-nothrow>CallOrScheduleWritableStreamAdvanceQueue ( <var>stream</var> )</h4>
+The following abstract operations, unlike most in this specification, are meant to be generally useful by other
+specifications, instead of just being part of the implementation of this spec's classes.
 
-<emu-alg>
-  1. If _stream_.[[started]] is *false*, then
-    1. Upon fulfillment of _stream_.[[startedPromise]], perform !
-       WritableStreamAdvanceQueue(_stream_).
-  1. Otherwise,
-    1. Perform ! WritableStreamAdvanceQueue(_stream_).
-  1. Return *undefined*.
-</emu-alg>
-
-<h4 id="close-writable-stream" aoid="CloseWritableStream" nothrow>CloseWritableStream (
-<var>stream</var> )</h4>
+<h4 id="acquire-writable-stream-default-writer" aoid="AcquireWritableStreamDefaultWriter"
+nothrow>AcquireWritableStreamDefaultWriter ( <var>stream</var> )</h4>
 
 <emu-alg>
-  1. Assert: _stream_.[[state]] is `"closing"`.
-  1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_stream_.[[underlyingSink]], "close").
-    1. Upon fulfillment,
-      1. If _stream_.[[state]] is `"errored"`, return.
-      1. Assert: _stream_.[[state]] is `"closing"`.
-      1. Resolve _stream_.[[closedPromise]] with *undefined*.
-      1. Set _stream_.[[state]] to `"closed"`.
-    1. Upon rejection with reason _r_,
-      1. Perform ! ErrorWritableStream(_stream_, _r_).
-  1. Return *undefined*.
-</emu-alg>
-
-<h4 id="error-writable-stream" aoid="ErrorWritableStream" nothrow>ErrorWritableStream ( <var>stream</var>, <var>e</var>
-)</h4>
-
-<emu-alg>
-  1. If _stream_.[[state]] is "closed" or "errored", return *undefined*.
-  1. Repeat while _stream_.[[queue]] is not empty:
-    1. Let _writeRecord_ be ! DequeueValue(_stream_.[[queue]]).
-    1. If _writeRecord_ is not `"close"`, reject _writeRecord_.[[promise]] with _e_.
-  1. Set _stream_.[[storedError]] to _e_.
-  1. If _stream_.[[state]] is `"waiting"`, resolve _stream_.[[readyPromise]] with *undefined*.
-  1. Reject _stream_.[[closedPromise]] with _e_.
-  1. Set _stream_.[[state]] to "errored".
-  1. Return *undefined*.
+  1. Return ? Construct(`<a idl>WritableStreamDefaultWriter</a>`, « *this* »).
 </emu-alg>
 
 <h4 id="is-writable-stream" aoid="IsWritableStream" nothrow>IsWritableStream ( <var>x</var> )</h4>
 
 <emu-alg>
   1. If Type(_x_) is not Object, return *false*.
-  1. If _x_ does not have a [[underlyingSink]] internal slot, return *false*.
+  1. If _x_ does not have a [[writableStreamController]] internal slot, return *false*.
   1. Return *true*.
 </emu-alg>
 
-<h4 id="sync-writable-stream-state-with-queue" aoid="SyncWritableStreamStateWithQueue"
-nothrow>SyncWritableStreamStateWithQueue ( <var>stream</var> )</h4>
+<h4 id="is-writable-stream-locked" aoid="IsWritableStreamLocked" nothrow>IsWritableStreamLocked ( <var>stream</var>
+)</h4>
+
+This abstract operation is meant to be called from other specifications that may wish to query whether or not a
+writable stream is <a>locked to a writer</a>.
 
 <emu-alg>
-  1. If _stream_.[[state]] is `"closing"`, return *undefined*.
-  1. Assert: _stream_.[[state]] is either `"writable"` or `"waiting"`.
-  1. Let _queueSize_ be ! GetTotalQueueSize(_stream_.[[queue]]).
-  1. Let _shouldApplyBackpressure_ be *true* if _queueSize_ > _stream_.[[strategyHWM]], and *false* otherwise.
-  1. If _shouldApplyBackpressure_ is *true* and _stream_.[[state]] is `"writable"`, then
-    1. Set _stream_.[[state]] to `"waiting"`.
-    1. Set _stream_.[[readyPromise]] to a new promise.
-  1. If _shouldApplyBackpressure_ is *false* and _stream_.[[state]] is `"waiting"`, then
-    1. Set _stream_.[[state]] to `"writable"`.
-    1. Resolve _stream_.[[readyPromise]] with *undefined*.
-  1. Return *undefined*.
+  1. Assert: ! IsWritableStream(_stream_) is *true*.
+  1. If _stream_.[[writer]] is *undefined*, return *false*.
+  1. Return *true*.
 </emu-alg>
 
-<h4 id="writable-stream-advance-queue" aoid="WritableStreamAdvanceQueue" nothrow>WritableStreamAdvanceQueue (
+<h4 id="writable-stream-abort" aoid="WritableStreamAbort" nothrow>WritableStreamAbort ( <var>stream</var>,
+<var>reason</var> )</h4>
+
+<emu-alg>
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"closed"`, return a new promise resolved with *undefined*.
+  1. If _state_ is `"errored"`, return a new promise rejected with _stream_.[[storedError]].
+  1. Assert: _state_ is either `"writable"` or `"closing"`.
+  1. Let _error_ be a new *TypeError* indicating that the stream has been aborted.
+  1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
+    1. Reject _writeRequest_ with _error_.
+  1. Set _stream_.[[writeRequests]] to an empty List.
+  1. Let _writer_ be _stream_.[[writer]].
+  1. If _writer_ is not undefined,
+    1. Reject _writer_.[[closedPromise]] with _error_.
+    1. If _state_ is `"writable"` and !
+    WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, resolve
+    _writer_.[[readyPromise]] with *undefined*.
+  1. Set _stream_.[[state]] to `"errored"`.
+  1. Set _stream_.[[storedError]] to _error_.
+  1. Return ! WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
+</emu-alg>
+
+<h3 id="ws-abstract-ops-used-by-controllers">Writable Stream Abstract Operations Used by Controllers</h3>
+
+To allow future flexibility to add different writable stream behaviors (similar to the distinction between simple
+readable streams and <a>readable byte streams</a>), much of the internal state of a <a>writable stream</a> is
+encapsulated by the {{WritableStreamDefaultController}} class. At this point in time the division of work between the
+stream and its controller may seems somewhat arbitrary, but centralizing much of the logic in the controller is a useful
+structure for the future.
+
+The abstract operations in this section are interfaces that are used by the controller implementation to affect its
+associated {{WritableStream}} object, translating the controller's internal state changes into developer-facing results
+visible through the {{WritableStream}}'s public API.
+
+<h4 id="writable-stream-add-write-request" aoid="WritableStreamAddWriteRequest" nothrow>WritableStreamAddWriteRequest (
 <var>stream</var> )</h4>
 
 <emu-alg>
-  1. If _stream_.[[queue]] is empty, or _stream_.[[writing]] is *true*, return *undefined*.
-  1. Let _writeRecord_ be ! PeekQueueValue(_stream_.[[queue]]).
-  1. If _writeRecord_ is `"close"`, then
-    1. Assert: _stream_.[[state]] is "closing".
-    1. Perform ! DequeueValue(_stream_.[[queue]]).
-    1. Assert: _stream_.[[queue]] is now empty.
-    1. Perform ! CloseWritableStream(_stream_).
-    1. Return *undefined*.
-  1. Set _stream_.[[writing]] to *true*.
-  1. Let _writeResult_ be ! PromiseInvokeOrNoop(_stream_.[[underlyingSink]], `"write"`, « _writeRecord_.[[chunk]] »).
-  1. Upon fulfillment of _writeResult_,
-    1. If _stream_.[[state]] is `"errored"`, return.
-    1. Set _stream_.[[writing]] to *false*.
-    1. Resolve _writeRecord_.[[promise]] with *undefined*.
-    1. Perform ! DequeueValue(_stream_.[[queue]]).
-    1. Perform ! SyncWritableStreamStateWithQueue(_stream_).
-    1. Perform ! WritableStreamAdvanceQueue(_stream_).
-  1. Upon rejection of _writeResult_ with reason _r_,
-    1. Perform ! ErrorWritableStream(_stream_, _r_).
-  1. Return *undefined*.
+  1. Let _writer_ be _stream_.[[writer]].
+  1. Assert: ! IsWritableStreamLocked(_writer_) is *true*.
+  1. Assert: _stream_.[[state]] is `"writable"`.
+  1. Let _promise_ be a new promise.
+  1. Append _promise_ as the last element of _stream_.[[writeRequests]].
+  1. Return _promise_.
 </emu-alg>
 
 <h3 id="default-writer-class" interface lt="WritableStreamDefaultWriter">Class
 <code>WritableStreamDefaultWriter</code></h3>
 
-The {{WritableStreamDefaultWriter}} class represents a <a>default writer</a> designed to be vended by a
+The {{WritableStreamDefaultWriter}} class represents a <a>writable stream writer</a> designed to be vended by a
 {{WritableStream}} instance.
 
 <h4 id="default-writer-class-definition">Class Definition</h4>

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -2,12 +2,12 @@
 const assert = require('assert');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
-const InternalTotalSize = Symbol('[[InternalTotalSize]]');
-
 exports.DequeueValue = queue => {
   assert(queue.length > 0, 'Spec-level failure: should never dequeue from an empty queue.');
   const pair = queue.shift();
-  queue[InternalTotalSize] -= pair.size;
+
+  queue._totalSize -= pair.size;
+
   return pair.value;
 };
 
@@ -19,17 +19,18 @@ exports.EnqueueValueWithSize = (queue, value, size) => {
 
   queue.push({ value: value, size: size });
 
-  if (queue[InternalTotalSize] === undefined) {
-    queue[InternalTotalSize] = 0;
+  if (queue._totalSize === undefined) {
+    queue._totalSize = 0;
   }
-  queue[InternalTotalSize] += size;
+  queue._totalSize += size;
 };
 
+// This implementation is not per-spec. Total size is cached for speed.
 exports.GetTotalQueueSize = queue => {
-  if (queue[InternalTotalSize] === undefined) {
-    queue[InternalTotalSize] = 0;
+  if (queue._totalSize === undefined) {
+    queue._totalSize = 0;
   }
-  return queue[InternalTotalSize];
+  return queue._totalSize;
 };
 
 exports.PeekQueueValue = queue => {

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -2,9 +2,12 @@
 const assert = require('assert');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
+const InternalTotalSize = Symbol('[[InternalTotalSize]]');
+
 exports.DequeueValue = queue => {
   assert(queue.length > 0, 'Spec-level failure: should never dequeue from an empty queue.');
   const pair = queue.shift();
+  queue[InternalTotalSize] -= pair.size;
   return pair.value;
 };
 
@@ -15,19 +18,18 @@ exports.EnqueueValueWithSize = (queue, value, size) => {
   }
 
   queue.push({ value: value, size: size });
+
+  if (queue[InternalTotalSize] === undefined) {
+    queue[InternalTotalSize] = 0;
+  }
+  queue[InternalTotalSize] += size;
 };
 
 exports.GetTotalQueueSize = queue => {
-  let totalSize = 0;
-
-  queue.forEach(pair => {
-    assert(typeof pair.size === 'number' && !Number.isNaN(pair.size) &&
-      pair.size !== +Infinity && pair.size !== -Infinity,
-      'Spec-level failure: should never find an invalid size in the queue.');
-    totalSize += pair.size;
-  });
-
-  return totalSize;
+  if (queue[InternalTotalSize] === undefined) {
+    queue[InternalTotalSize] = 0;
+  }
+  return queue[InternalTotalSize];
 };
 
 exports.PeekQueueValue = queue => {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -86,95 +86,272 @@ class ReadableStream {
   }
 
   pipeTo(dest, { preventClose, preventAbort, preventCancel } = {}) {
+    // brandcheck
+
     preventClose = Boolean(preventClose);
     preventAbort = Boolean(preventAbort);
     preventCancel = Boolean(preventCancel);
 
     const source = this;
 
-    let reader;
-    let lastRead;
-    let lastWrite;
-    let closedPurposefully = false;
-    let resolvePipeToPromise;
-    let rejectPipeToPromise;
+    let _resolvePipeToPromise;
+    let _rejectPipeToPromise;
+
+    let _reader;
+    let _writer;
+
+    let _state = 'piping';
+
+    let _lastRead;
+    let _lastWrite;
+    let _allWrites;
 
     return new Promise((resolve, reject) => {
-      resolvePipeToPromise = resolve;
-      rejectPipeToPromise = reject;
+      _resolvePipeToPromise = resolve;
+      _rejectPipeToPromise = reject;
 
-      reader = source.getReader();
+      _reader = source.getReader();
+      _writer = dest.getWriter();
 
-      reader.closed.catch(abortDest);
-      dest.closed.then(
-        () => {
-          if (!closedPurposefully) {
-            cancelSource(new TypeError('destination is closing or closed and cannot be piped to anymore'));
-          }
-        },
-        cancelSource
+      _reader.closed.catch(handleReaderClosedRejection);
+      _writer.closed.then(
+        handleWriterClosedFulfillment,
+        handleWriterClosedRejection
       );
 
       doPipe();
     });
 
-    function doPipe() {
-      lastRead = reader.read();
-      Promise.all([lastRead, dest.ready]).then(([{ value, done }]) => {
-        if (Boolean(done) === true) {
-          closeDest();
-        } else if (dest.state === 'writable') {
-          lastWrite = dest.write(value);
-          doPipe();
+    function releaseReader() {
+      console.log('pipeTo(): releaseReader()');
+
+      _reader.releaseLock();
+      _reader = undefined;
+    }
+
+    function releaseWriter() {
+      console.log('pipeTo(): releaseWriter()');
+
+      _writer.releaseLock();
+      _writer = undefined;
+    }
+
+    function done() {
+      console.log('pipeTo(): done()');
+
+      assert(_reader === undefined);
+      assert(_writer === undefined);
+
+      _state = 'done';
+
+      _lastRead = undefined;
+      _lastWrite = undefined;
+      _allWrites = undefined;
+    }
+
+    function finishWithFulfillment() {
+      console.log('pipeTo(): finishWithFulfillment()');
+
+      _resolvePipeToPromise(undefined);
+      _resolvePipeToPromise = undefined;
+      _rejectPipeToPromise = undefined;
+
+      done();
+    }
+
+    function finishWithRejection(reason) {
+      console.log('pipeTo(): finishWithRejection()');
+
+      _rejectPipeToPromise(reason);
+      _resolvePipeToPromise = undefined;
+      _rejectPipeToPromise = undefined;
+
+      done();
+    }
+
+    function abortWriterCancelReader(reason, skipAbort, skipCancel) {
+      const promises = [];
+
+      if (skipAbort === false) {
+        _writer.abort(reason);
+
+        releaseWriter();
+      } else if (_lastWrite === undefined) {
+        releaseWriter();
+      } else {
+        promises.push(_lastWrite.then(
+          () => {
+            releaseWriter();
+          },
+          () => {
+            releaseWriter();
+          }
+        ));
+      }
+
+      if (skipCancel === false) {
+        _reader.cancel(reason);
+
+        releaseReader();
+      } else if (_lastRead === undefined) {
+        releaseReader();
+      } else {
+        promises.push(_lastRead.then(
+          () => {
+            releaseReader();
+          },
+          () => {
+            releaseReader();
+          }
+        ));
+      }
+
+      if (promises.length > 0) {
+        Promise.all(promises).then(
+          () => {
+            finishWithRejection(reason);
+          }
+        );
+        _state = 'waitingForLastReadAndOrLastWrite';
+        return;
+      }
+
+      finishWithRejection(reason);
+    }
+
+    function handleWriteRejection(reason) {
+      console.log('pipeTo(): handleWriteRejection()');
+
+      if (_state !== 'piping') {
+        return;
+      }
+
+      abortWriterCancelReader(reason, preventAbort, preventCancel);
+    }
+
+    function handleReadValue(value) {
+      console.log('pipeTo(): handleReadValue()');
+
+      _lastWrite = _writer.write(value);
+      _lastWrite.catch(handleWriteRejection);
+
+      // dest may be already errored. But proceed to write().
+      _allWrites = Promise.all([_allWrites, _lastWrite]);
+
+      doPipe();
+    }
+
+    function handleReadDone() {
+      console.log('pipeTo(): handleReadDone()');
+
+      // Does not need to wait for lastRead since it occurs only on source closed.
+
+      releaseReader();
+
+      if (preventClose === false) {
+        console.log('pipeTo(): Close dest');
+
+        // We don't use writer.closed. We can ensure that the microtask for writer.closed is run before any
+        // writer.close() call so that we can determine whether the closure was caused by the close() or ws was already
+        // closed before pipeTo(). It's possible but fragile.
+        _writer.close().then(
+          () => {
+            return _allWrites;
+          },
+          reason => {
+            releaseWriter();
+            finishWithRejection(reason);
+          }
+        ).then(
+          () => {
+            releaseWriter();
+            finishWithFulfillment();
+          }
+        );
+        _state = 'closingDest';
+
+        return;
+      }
+
+      if (_lastWrite === undefined) {
+        releaseWriter()
+        finishWithFulfillment();
+        return;
+      }
+
+      // We don't use writer.closed. pipeTo() is responsible only for what it has written.
+      _lastWrite.then(
+        () => {
+          releaseWriter();
+          finishWithFulfillment();
+        },
+        reason => {
+          releaseWriter();
+          finishWithRejection(reason)
         }
-      })
+      );
+      _state = 'waitingLastWriteOnReadableClosed';
+    }
+
+    function doPipe() {
+      console.log('pipeTo(): doPipe()');
+
+      _lastRead = _reader.read();
+
+      Promise.all([_lastRead, _writer.ready]).then(
+        ([{ value, done }]) => {
+          if (_state !== 'piping') {
+            return;
+          }
+
+          if (Boolean(done) === false) {
+            handleReadValue(value);
+          } else {
+            handleReadDone();
+          }
+        },
+        () => {
+          // Do nothing
+        }
+      )
       .catch(rethrowAssertionErrorRejection);
 
       // Any failures will be handled by listening to reader.closed and dest.closed above.
       // TODO: handle malicious dest.write/dest.close?
     }
 
-    function cancelSource(reason) {
-      if (preventCancel === false) {
-        reader.cancel(reason);
-        reader.releaseLock();
-        rejectPipeToPromise(reason);
-      } else {
-        // If we don't cancel, we need to wait for lastRead to finish before we're allowed to release.
-        // We don't need to handle lastRead failing because that will trigger abortDest which takes care of
-        // both of these.
-        lastRead.then(() => {
-          reader.releaseLock();
-          rejectPipeToPromise(reason);
-        });
+    function handleReaderClosedRejection(reason) {
+      console.log('pipeTo(): handleReaderClosedRejection()');
+
+      if (_state !== 'piping') {
+        return;
       }
+
+      _lastRead = undefined;
+      abortWriterCancelReader(reason, preventAbort, true);
     }
 
-    function closeDest() {
-      // Does not need to wait for lastRead since it occurs only on source closed.
+    function handleUnexpectedWriterCloseAndError(reason) {
+      console.log('pipeTo(): handleUnexpectedWriterCloseAndError()');
 
-      reader.releaseLock();
-
-      const destState = dest.state;
-      if (preventClose === false && (destState === 'waiting' || destState === 'writable')) {
-        closedPurposefully = true;
-        dest.close().then(resolvePipeToPromise, rejectPipeToPromise);
-      } else if (lastWrite !== undefined) {
-        lastWrite.then(resolvePipeToPromise, rejectPipeToPromise);
-      } else {
-        resolvePipeToPromise();
+      if (_state !== 'piping') {
+        return;
       }
+
+      _lastWrite = undefined;
+      abortWriterCancelReader(reason, true, preventCancel);
     }
 
-    function abortDest(reason) {
-      // Does not need to wait for lastRead since it only occurs on source errored.
+    function handleWriterClosedFulfillment() {
+      console.log('pipeTo(): handleWriterClosedFulfillment()');
 
-      reader.releaseLock();
+      handleUnexpectedWriterCloseAndError(new TypeError('dest closed unexpectedly'));
+    }
 
-      if (preventAbort === false) {
-        dest.abort(reason);
-      }
-      rejectPipeToPromise(reason);
+    function handleWriterClosedRejection(reason) {
+      console.log('pipeTo(): handleWriterClosedRejection()');
+
+      handleUnexpectedWriterCloseAndError(reason);
     }
   }
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -123,21 +123,21 @@ class ReadableStream {
     });
 
     function releaseReader() {
-      console.log('pipeTo(): releaseReader()');
+      //console.log('pipeTo(): releaseReader()');
 
       _reader.releaseLock();
       _reader = undefined;
     }
 
     function releaseWriter() {
-      console.log('pipeTo(): releaseWriter()');
+      //console.log('pipeTo(): releaseWriter()');
 
       _writer.releaseLock();
       _writer = undefined;
     }
 
     function done() {
-      console.log('pipeTo(): done()');
+      //console.log('pipeTo(): done()');
 
       assert(_reader === undefined);
       assert(_writer === undefined);
@@ -150,7 +150,7 @@ class ReadableStream {
     }
 
     function finishWithFulfillment() {
-      console.log('pipeTo(): finishWithFulfillment()');
+      //console.log('pipeTo(): finishWithFulfillment()');
 
       _resolvePipeToPromise(undefined);
       _resolvePipeToPromise = undefined;
@@ -160,7 +160,7 @@ class ReadableStream {
     }
 
     function finishWithRejection(reason) {
-      console.log('pipeTo(): finishWithRejection()');
+      //console.log('pipeTo(): finishWithRejection()');
 
       _rejectPipeToPromise(reason);
       _resolvePipeToPromise = undefined;
@@ -220,7 +220,7 @@ class ReadableStream {
     }
 
     function handleWriteRejection(reason) {
-      console.log('pipeTo(): handleWriteRejection()');
+      //console.log('pipeTo(): handleWriteRejection()');
 
       if (_state !== 'piping') {
         return;
@@ -230,7 +230,7 @@ class ReadableStream {
     }
 
     function handleReadValue(value) {
-      console.log('pipeTo(): handleReadValue()');
+      //console.log('pipeTo(): handleReadValue()');
 
       _lastWrite = _writer.write(value);
       _lastWrite.catch(handleWriteRejection);
@@ -242,14 +242,14 @@ class ReadableStream {
     }
 
     function handleReadDone() {
-      console.log('pipeTo(): handleReadDone()');
+      //console.log('pipeTo(): handleReadDone()');
 
       // Does not need to wait for lastRead since it occurs only on source closed.
 
       releaseReader();
 
       if (preventClose === false) {
-        console.log('pipeTo(): Close dest');
+        //console.log('pipeTo(): Close dest');
 
         // We don't use writer.closed. We can ensure that the microtask for writer.closed is run before any
         // writer.close() call so that we can determine whether the closure was caused by the close() or ws was already
@@ -294,7 +294,7 @@ class ReadableStream {
     }
 
     function doPipe() {
-      console.log('pipeTo(): doPipe()');
+      //console.log('pipeTo(): doPipe()');
 
       _lastRead = _reader.read();
 
@@ -321,7 +321,7 @@ class ReadableStream {
     }
 
     function handleReaderClosedRejection(reason) {
-      console.log('pipeTo(): handleReaderClosedRejection()');
+      //console.log('pipeTo(): handleReaderClosedRejection()');
 
       if (_state !== 'piping') {
         return;
@@ -332,7 +332,7 @@ class ReadableStream {
     }
 
     function handleUnexpectedWriterCloseAndError(reason) {
-      console.log('pipeTo(): handleUnexpectedWriterCloseAndError()');
+      //console.log('pipeTo(): handleUnexpectedWriterCloseAndError()');
 
       if (_state !== 'piping') {
         return;
@@ -343,13 +343,13 @@ class ReadableStream {
     }
 
     function handleWriterClosedFulfillment() {
-      console.log('pipeTo(): handleWriterClosedFulfillment()');
+      //console.log('pipeTo(): handleWriterClosedFulfillment()');
 
       handleUnexpectedWriterCloseAndError(new TypeError('dest closed unexpectedly'));
     }
 
     function handleWriterClosedRejection(reason) {
-      console.log('pipeTo(): handleWriterClosedRejection()');
+      //console.log('pipeTo(): handleWriterClosedRejection()');
 
       handleUnexpectedWriterCloseAndError(reason);
     }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -6,7 +6,7 @@ const { WritableStream } = require('./writable-stream.js');
 // Functions passed to the transformer.start().
 
 function TransformStreamCloseReadable(transformStream) {
-  console.log('TransformStreamCloseReadable()');
+  //console.log('TransformStreamCloseReadable()');
 
   if (transformStream._errored === true) {
     throw new TypeError('TransformStream is already errored');
@@ -81,7 +81,6 @@ function TransformStreamError(transformStream, e) {
 // Functions passed to transformer.transform().
 
 function TransformStreamChunkDone(transformStream) {
-      console.log('sjsjs' + transformStream);
   if (transformStream._errroed === true) {
     throw new TypeError('TransformStream is already errored');
   }
@@ -103,7 +102,7 @@ function TransformStreamChunkDone(transformStream) {
 // Abstract operations.
 
 function TransformStreamErrorInternal(transformStream, e) {
-  console.log('TransformStreamErrorInternal()');
+  //console.log('TransformStreamErrorInternal()');
 
   transformStream._errored = true;
 
@@ -122,7 +121,7 @@ function TransformStreamErrorInternal(transformStream, e) {
 }
 
 function TransformStreamTransformIfNeeded(transformStream) {
-  console.log('TransformStreamTransformIfNeeded()');
+  //console.log('TransformStreamTransformIfNeeded()');
 
   if (transformStream._chunkPending === false) {
     return;
@@ -188,7 +187,7 @@ class TransformStreamSink {
   }
 
   write(chunk) {
-    console.log('TransformStreamSink.write()');
+    //console.log('TransformStreamSink.write()');
 
     const transformStream = this._transformStream;
 
@@ -218,7 +217,7 @@ class TransformStreamSink {
   }
 
   close() {
-    console.log('TransformStreamSink.close()');
+    //console.log('TransformStreamSink.close()');
 
     const transformStream = this._transformStream;
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,74 +1,337 @@
 'use strict';
+const assert = require('assert');
 const { ReadableStream } = require('./readable-stream.js');
 const { WritableStream } = require('./writable-stream.js');
 
+// Functions passed to the transformer.start().
+
+function TransformStreamCloseReadable(transformStream) {
+  console.log('TransformStreamCloseReadable()');
+
+  if (transformStream._errored === true) {
+    throw new TypeError('TransformStream is already errored');
+  }
+
+  if (transformStream._readableClosed === true) {
+    throw new TypeError('Readable side is already closed');
+  }
+
+  try {
+    transformStream._readableController.close();
+  } catch (e) {
+    assert(false);
+  }
+
+  transformStream._readableClosed = true;
+}
+
+function TransformStreamEnqueueToReadable(transformStream, chunk) {
+  if (transformStream._errroed === true) {
+    throw new TypeError('TransformStream is already errored');
+  }
+
+  if (transformStream._readableClosed === true) {
+    throw new TypeError('Readable side is already closed');
+  }
+
+  // We throttle transformer.transform invoation based on the backpressure of the ReadableStream, but we still
+  // accept TrasnformStreamEnqueueToReadable() calls.
+
+  const controller = transformStream._readableController;
+
+  transformStream._readableBackpressure = true;
+
+  try {
+    controller.enqueue(chunk);
+  } catch (e) {
+    if (transformStream._error === false) {
+      // This happens when the given strategy is bad.
+      const reason = new TypeError('Failed to enqueue to readable side');
+      TransformStreamErrorInternal(transformStream, reason);
+    }
+    throw reason;
+  }
+
+  let backpressure;
+  try {
+    backpressure = controller.desiredSize <= 0;
+  } catch (e) {
+    if (transformStream._error === false) {
+      const reason = new TypeError('Failed to calculate backpressure of readable side');
+      TransformStreamError(transformStream, reason);
+    }
+    throw reason;
+  }
+
+  // enqueue() may invoke pull() synchronously when we're not in pull() call.
+  // In such case, _readableBackpressure may be already set to false.
+  if (backpressure) {
+    transformStream._readableBackpressure = false;
+  }
+}
+
+function TransformStreamError(transformStream, e) {
+  if (transformStream._errored === true) {
+    throw new TypeError('TransformStream is already errored');
+  }
+
+  TransformStreamErrorInternal(transformStream, e);
+}
+
+// Functions passed to transformer.transform().
+
+function TransformStreamChunkDone(transformStream) {
+      console.log('sjsjs' + transformStream);
+  if (transformStream._errroed === true) {
+    throw new TypeError('TransformStream is already errored');
+  }
+
+  if (transformStream._transforming === false) {
+    throw new TypeError('No active transform is running');
+  }
+
+  assert(transformStream._resolveWrite !== undefined);
+
+  transformStream._transforming = false;
+
+  transformStream._resolveWrite(undefined);
+  transformStream._resolveWrite = undefined;
+
+  TransformStreamTransformIfNeeded(transformStream);
+}
+
+// Abstract operations.
+
+function TransformStreamErrorInternal(transformStream, e) {
+  console.log('TransformStreamErrorInternal()');
+
+  transformStream._errored = true;
+
+  if (transformStream._writableDone === false) {
+    transformStream._writableController.error(e);
+  }
+  if (transformStream._readableClosed === false) {
+    transformStream._readableController.error(e);
+  }
+
+  transformStream._chunk = undefined;
+
+  if (transformStream._resolveWriter !== undefined) {
+    transformStream._resolveWriter(undefined);
+  }
+}
+
+function TransformStreamTransformIfNeeded(transformStream) {
+  console.log('TransformStreamTransformIfNeeded()');
+
+  if (transformStream._chunkPending === false) {
+    return;
+  }
+
+  assert(transformStream._resolveWrite !== undefined);
+
+  if (transformStream._transforming === true) {
+    return;
+  }
+
+  if (transformStream._readableBackpressure === true) {
+    return;
+  }
+
+  transformStream._transforming = true;
+
+  const chunk = transformStream._chunk;
+  transformStream._chunkPending = false;
+  transformStream._chunk = undefined;
+
+  try {
+    if (transformStream._transformer.transform !== undefined) {
+      transformStream._transformer.transform(
+          chunk,
+          TransformStreamChunkDone.bind(undefined, transformStream),
+          transformStream._enqueueFunction,
+          transformStream._closeFunction,
+          transformStream._errorFunction);
+    }
+  } catch (e) {
+    if (transformStream._errored === false) {
+      TransformStreamErrorInternal(transformStream, e);
+    }
+  }
+}
+
+function TransformStreamStart(transformStream) {
+  if (transformStream._transformer.start === undefined) {
+    return;
+  }
+
+  // Thrown exception will be handled by the constructor of TransformStream.
+  transformStream._transformer.start(
+      transformStream._enqueueFunction,
+      transformStream._closeFunction,
+      transformStream._errorFunction);
+}
+
+class TransformStreamSink {
+  constructor(transformStream) {
+    this._transformStream = transformStream;
+  }
+
+  start(c) {
+    const transformStream = this._transformStream;
+
+    transformStream._writableController = c;
+
+    if (transformStream._readableController !== undefined) {
+      TransformStreamStart(transformStream);
+    }
+  }
+
+  write(chunk) {
+    console.log('TransformStreamSink.write()');
+
+    const transformStream = this._transformStream;
+
+    assert(transformStream._errored === false);
+
+    assert(transformStream._chunkPending === false);
+    assert(transformStream._chunk === undefined);
+
+    assert(transformStream._resolveWrite === undefined);
+
+    transformStream._chunkPending = true;
+    transformStream._chunk = chunk;
+
+    const promise = new Promise(resolve => {
+      transformStream._resolveWrite = resolve;
+    });
+
+    TransformStreamTransformIfNeeded(transformStream);
+
+    return promise;
+  }
+
+  abort(reason) {
+    const transformStream = this._transformStream;
+    transformStream._writableDone = true;
+    TransformStreamErrorInternal(transformStream, new TypeError('Writable side aborted'));
+  }
+
+  close() {
+    console.log('TransformStreamSink.close()');
+
+    const transformStream = this._transformStream;
+
+    assert(transformStream._chunkPending === false);
+    assert(transformStream._chunk === undefined);
+
+    assert(transformStream._resolveWrite === undefined);
+
+    assert(transformStream._transforming === false);
+
+    // No control over the promise returned by writableStreamWriter.close(). Need it?
+
+    transformStream._writableDone = true;
+
+    if (transformStream._transformer.flush === undefined) {
+      TransformStreamCloseReadable(transformStream);
+    } else {
+      try {
+        transformStream._transformer.flush(
+            transformStream._enqueueFunction,
+            transformStream._closeFunction,
+            transformStream._errorFunction);
+      } catch (e) {
+        if (transformStream._errored === false) {
+          TransformStreamErrorInternal(transformStream, e);
+          throw e;
+        }
+      }
+    }
+  }
+}
+
+class TransformStreamSource {
+  constructor(transformStream) {
+    this._transformStream = transformStream;
+  }
+
+  start(c) {
+    const transformStream = this._transformStream;
+
+    transformStream._readableController = c;
+
+    if (transformStream._writableController !== undefined) {
+      TransformStreamStart(transformStream);
+    }
+  }
+
+  pull() {
+    this._transformStream._readableBackpressure = false;
+    TransformStreamTransformIfNeeded(this._transformStream);
+  }
+
+  cancel(reason) {
+    const transformStream = this._transformStream;
+    transformStream._readableClosed = true;
+    TransformStreamErrorInternal(transformStream, new TypeError('Readable side canceled'));
+  }
+}
+
 module.exports = class TransformStream {
   constructor(transformer) {
-    if (transformer.flush === undefined) {
-      transformer.flush = (enqueue, close) => close();
+    if (transformer.start !== undefined && typeof transformer.start !== 'function') {
+      throw new TypeError('start must be a function or undefined');
     }
-
     if (typeof transformer.transform !== 'function') {
       throw new TypeError('transform must be a function');
     }
-
-    let writeChunk, writeDone, errorWritable;
-    let transforming = false;
-    let chunkWrittenButNotYetTransformed = false;
-    this.writable = new WritableStream({
-      start(error) {
-        errorWritable = error;
-      },
-      write(chunk) {
-        writeChunk = chunk;
-        chunkWrittenButNotYetTransformed = true;
-
-        const p = new Promise(resolve => writeDone = resolve);
-        maybeDoTransform();
-        return p;
-      },
-      close() {
-        try {
-          transformer.flush(enqueueInReadable, closeReadable);
-        } catch (e) {
-          errorWritable(e);
-          errorReadable(e);
-        }
-      }
-    }, transformer.writableStrategy);
-
-    let enqueueInReadable, closeReadable, errorReadable;
-    this.readable = new ReadableStream({
-      start(c) {
-        enqueueInReadable = c.enqueue.bind(c);
-        closeReadable = c.close.bind(c);
-        errorReadable = c.error.bind(c);
-      },
-      pull() {
-        if (chunkWrittenButNotYetTransformed === true) {
-          maybeDoTransform();
-        }
-      }
-    }, transformer.readableStrategy);
-
-    function maybeDoTransform() {
-      if (transforming === false) {
-        transforming = true;
-        try {
-          transformer.transform(writeChunk, enqueueInReadable, transformDone);
-          writeChunk = undefined;
-          chunkWrittenButNotYetTransformed = false;
-        } catch (e) {
-          transforming = false;
-          errorWritable(e);
-          errorReadable(e);
-        }
-      }
+    if (transformer.flush !== undefined && typeof transformer.flush !== 'function') {
+      throw new TypeError('flush must be a function or undefined');
     }
 
-    function transformDone() {
-      transforming = false;
-      writeDone();
+    this._transformer = transformer;
+
+    this._transforming = false;
+    this._errored = false;
+
+    this._writableController = undefined;
+    this._readableController = undefined;
+
+    this._writableDone = false;
+    this._readableClosed = false;
+
+    this._resolveWrite = undefined;
+
+    this._chunkPending = false;
+    this._chunk = undefined;
+
+    this._enqueueFunction = TransformStreamEnqueueToReadable.bind(undefined, this);
+    this._closeFunction = TransformStreamCloseReadable.bind(undefined, this);
+    this._errorFunction = TransformStreamError.bind(undefined, this);
+
+    const sink = new TransformStreamSink(this);
+
+    try {
+      this.writable = new WritableStream(sink, transformer.writableStrategy);
+    } catch (e) {
+      if (this._errored === false) {
+        TransformStreamError(this, e);
+        throw e;
+      }
+      return;
+    }
+
+    const source = new TransformStreamSource(this);
+
+    try {
+      this.readable = new ReadableStream(source, transformer.readableStrategy);
+    } catch (e) {
+      this.writable = undefined;
+      if (this._errored === false) {
+        TransformStreamError(this, e);
+        throw e;
+      }
     }
   }
 };

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -342,11 +342,13 @@ class WritableStreamDefaultWriter {
       return Promise.reject(defaultWriterBrandCheckException('write'));
     }
 
-    if (this._ownerWritableStream === undefined) {
+    const stream = this._ownerWritableStream;
+
+    if (stream === undefined) {
       return Promise.reject(defaultWriterLockException('write to'));
     }
 
-    if (this._ownerWritableStream._state === 'closing') {
+    if (stream._state === 'closing') {
       return Promise.reject(new TypeError('Cannot write to an already-closed stream'));
     }
 

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -4,22 +4,565 @@ const { InvokeOrNoop, PromiseInvokeOrNoop, PromiseInvokeOrFallbackOrNoop, Valida
         typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, GetTotalQueueSize, PeekQueueValue } = require('./queue-with-sizes.js');
-const CountQueuingStrategy = require('./count-queuing-strategy.js');
 
 class WritableStream {
-  constructor(underlyingSink = {}, { size, highWaterMark = 0 } = {}) {
+  constructor(underlyingSink = {}, { size, highWaterMark } = {}) {
+    // Temporary value. Never used. To be overwritten by the initializer code of the controller.
+    this._state = 'writable';
+    this._storedError = undefined;
+
+    this._writer = undefined;
+
+    this._writeRequests = [];
+
+    // Initialize to undefined first because the constructor of the controller checks this
+    // variable to validate the caller.
+    this._writableStreamController = undefined;
+
+    const type = underlyingSink.type;
+
+    if (type !== undefined) {
+      throw new RangeError('Invalid type is specified');
+    }
+
+    if (highWaterMark === undefined) {
+      highWaterMark = 1;
+    }
+
+    this._writableStreamController = new WritableStreamDefaultController(this, underlyingSink, size, highWaterMark);
+  }
+
+  get locked() {
+    if (IsWritableStream(this) === false) {
+      throw CreateWritableStreamBrandCheckException('locked');
+    }
+
+    return IsWritableStreamLocked(this);
+  }
+
+  abort(reason) {
+    if (IsWritableStream(this) === false) {
+      return Promise.reject(CreateWritableStreamBrandCheckException('abort'));
+    }
+
+    if (IsWritableStreamLocked(this) === true) {
+      return Promise.reject(new TypeError('Cannot abort a stream that already has a reader'));
+    }
+
+    WritableStreamAbort(this, reason);
+  }
+
+  getWriter() {
+    if (IsWritableStream(this) === false) {
+      throw CreateWritableStreamBrandCheckException('getWriter');
+    }
+
+    return AcquireWritableStreamDefaultWriter(this);
+  }
+}
+
+exports.WritableStream = WritableStream;
+
+// Helper functions for the WritableStream.
+
+function CreateWritableStreamBrandCheckException(name) {
+  return new TypeError('WritableStream.prototype.' + name + ' can only be used on a WritableStream')
+}
+
+// Abstract operations for the WritableStream.
+
+function AcquireWritableStreamDefaultWriter(stream) {
+  return new WritableStreamDefaultWriter(stream);
+}
+
+function IsWritableStream(x) {
+  if (!typeIsObject(x)) {
+    return false;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(x, '_writableStreamController')) {
+    return false;
+  }
+
+  return true;
+}
+
+function IsWritableStreamLocked(stream) {
+  assert(IsWritableStream(stream) === true, 'IsWritableStreamLocked should only be used on known writable streams');
+
+  if (stream._writer === undefined) {
+    return false;
+  }
+
+  return true;
+}
+
+function WritableStreamAbort(stream, reason) {
+  const state = stream._state;
+  if (state === 'closed') {
+    return Promise.resolve(undefined);
+  }
+  if (state === 'errored') {
+    return Promise.reject(stream._storedError);
+  }
+
+  assert(state === 'writable' || state === 'waiting' || state === 'closing');
+
+  const writer = stream._writer;
+
+  const error = new TypeError('Aborted');
+
+  for (const writeRequest of stream._writeRequests) {
+    writeRequest._reject(error);
+  }
+
+  if (writer !== undefined) {
+    WritableStreamDefaultWriterClosedPromiseReject(writer, error);
+
+    if (state === 'waiting') {
+      WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+    }
+  }
+
+  stream._state = 'errored';
+  stream._storedError = error;
+
+  return WritableStreamDefaultControllerAbort(stream._writableStreamController, reason);
+}
+
+// WritableStream API exposed for controllers.
+
+function WritableStreamAddWriteRequest(stream) {
+  const writer = stream._writer;
+  assert(IsWritableStreamDefaultWriter(writer) === true);
+
+  const state = stream._state;
+  assert(state === 'writable' || state === 'waiting');
+
+  const promise = new Promise((resolve, reject) => {
+    const writeRequest = {
+      _resolve: resolve,
+      _reject: reject
+    };
+
+    stream._writeRequests.push(writeRequest);
+  });
+
+  return promise;
+}
+
+function WritableStreamError(stream, e) {
+  const state = stream._state;
+  assert(state === 'writable' || state === 'waiting' || state === 'closing');
+
+  const writeRequests = stream._writeRequests;
+  while (writeRequests.length > 0) {
+    const writeRequest = writeRequests.shift();
+    writeRequest._reject(e);
+  }
+
+  const writer = stream._writer;
+
+  if (writer !== undefined) {
+    WritableStreamDefaultWriterClosedPromiseReject(writer, e);
+
+    if (state === 'waiting') {
+      WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+    }
+  }
+
+  stream._state = 'errored';
+  stream._storedError = e;
+}
+
+function WritableStreamFinishClose(stream) {
+  assert(stream._state === 'closing');
+
+  stream._state = 'closed';
+
+  const writer = stream._writer;
+
+  // writer cannot be released while close() is ongoing. So, we can assert that
+  // there's an active writer.
+  assert(writer !== undefined);
+
+  WritableStreamDefaultWriterClosedPromiseResolve(writer);
+}
+
+function WritableStreamFulfillWriteRequest(stream) {
+  assert(stream._writeRequests.length > 0);
+
+  const writeRequest = stream._writeRequests.shift();
+  writeRequest._resolve(undefined);
+}
+
+function WritableStreamUpdateBackpressure(stream, backpressure) {
+  const state = stream._state;
+  const writer = stream._writer;
+
+  if (state === 'writable') {
+    if (backpressure === false) {
+      return;
+    }
+
+    stream._state = 'waiting';
+
+    if (writer !== undefined) {
+      WritableStreamDefaultWriterReadyPromiseReset(writer);
+    }
+
+    return;
+  }
+
+  assert(state === 'waiting');
+
+  if (backpressure === true) {
+    return;
+  }
+
+  stream._state = 'writable';
+
+  if (writer !== undefined) {
+    WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+  }
+}
+
+class WritableStreamDefaultWriter {
+  constructor(stream) {
+    if (IsWritableStream(stream) === false) {
+      throw new TypeError('WritableStreamDefaultWriter can only be constructed with a WritableStream instance');
+    }
+    if (IsWritableStreamLocked(stream) === true) {
+      throw new TypeError('This stream has already been locked for exclusive writing by another writer');
+    }
+
+    this._ownerWritableStream = stream;
+    stream._writer = this;
+
+    const state = stream._state;
+
+    if (state === 'writable' || state === 'waiting' || state === 'closing') {
+      WritableStreamDefaultWriterClosedPromiseInitialize(this);
+    } else {
+      if (state === 'closed') {
+        WritableStreamDefaultWriterClosedPromiseInitializeAsResolved(this, undefined);
+      } else {
+        assert(state === 'errored', 'state must be errored');
+
+        WritableStreamDefaultWriterClosedPromiseInitializeAsRejected(this, stream._storedError);
+      }
+    }
+
+    if (state === 'waiting') {
+      WritableStreamDefaultWriterReadyPromiseInitialize(this);
+    } else {
+      WritableStreamDefaultWriterReadyPromiseInitializeAsResolved(this, undefined);
+    }
+  }
+
+  get closed() {
+    if (IsWritableStreamDefaultWriter(this) === false) {
+      return Promise.reject(CreateWritableStreamDefaultWriterBrandCheckException('closed'));
+    }
+
+    return this._closedPromise;
+  }
+
+  get desiredSize() {
+    if (IsWritableStreamDefaultWriter(this) === false) {
+      throw CreateWritableStreamDefaultWriterBrandCheckException('desiredSize');
+    }
+
+    if (this._ownerWritableStream === undefined) {
+      throw CreateWritableStreamDefaultWriterLockException('desiredSize');
+    }
+
+    return WritableStreamDefaultWriterGetDesiredSize(this)
+  }
+
+  get ready() {
+    if (IsWritableStreamDefaultWriter(this) === false) {
+      return Promise.reject(CreateWritableStreamDefaultWriterBrandCheckException('ready'));
+    }
+
+    return this._readyPromise;
+  }
+
+  abort(reason) {
+    if (IsWritableStreamDefaultWriter(this) === false) {
+      return Promise.reject(CreateWritableStreamDefaultWriterBrandCheckException('abort'));
+    }
+
+    if (this._ownerWritableStream === undefined) {
+      return Promise.reject(CreateWritableStreamDefaultWriterLockException('abort'));
+    }
+
+    return WritableStreamDefaultWriterAbort(this, reason);
+  }
+
+  close() {
+    if (IsWritableStreamDefaultWriter(this) === false) {
+      return Promise.reject(CreateWritableStreamDefaultWriterBrandCheckException('close'));
+    }
+
+    const stream = this._ownerWritableStream;
+
+    if (stream === undefined) {
+      return Promise.reject(CreateWritableStreamDefaultWriterLockException('close'));
+    }
+
+    if (stream._state === 'closing') {
+      return Promise.reject(new TypeError('cannot close an already-closing stream'));
+    }
+
+    return WritableStreamDefaultWriterClose(this);
+  }
+
+  releaseLock() {
+    if (IsWritableStreamDefaultWriter(this) === false) {
+      throw CreateWritableStreamDefaultWriterBrandCheckException('releaseLock');
+    }
+
+    const stream = this._ownerWritableStream;
+
+    if (stream === undefined) {
+      return undefined;
+    }
+
+    assert(stream._writer !== undefined);
+
+    const state = stream._state;
+
+    const releasedException = new TypeError('Writer was released and can no longer be used to monitor the stream\'s closedness');
+
+    if (state === 'writable' || state === 'waiting' || state === 'closing') {
+      WritableStreamDefaultWriterClosedPromiseReject(this, releasedException);
+    } else {
+      WritableStreamDefaultWriterClosedPromiseResetToRejected(this, releasedException);
+    }
+
+    if (state === 'waiting') {
+      WritableStreamDefaultWriterReadyPromiseReject(this, releasedException);
+    } else {
+      WritableStreamDefaultWriterReadyPromiseResetToRejected(this, releasedException);
+    }
+
+    stream._writer = undefined;
+    this._ownerWritableStream = undefined;
+  }
+
+  write(chunk) {
+    if (IsWritableStreamDefaultWriter(this) === false) {
+      return Promise.reject(CreateWritableStreamDefaultWriterBrandCheckException('write'));
+    }
+
+    if (this._ownerWritableStream === undefined) {
+      return Promise.reject(CreateWritableStreamDefaultWriterLockException('write to'));
+    }
+
+    if (this._ownerWritableStream._state === 'closing') {
+      return Promise.reject(new TypeError('Cannot write to an already-closed stream'));
+    }
+
+    return WritableStreamDefaultWriterWrite(this, chunk);
+  }
+}
+
+// Helper functions for the WritableStreamDefaultWriter.
+
+function CreateWritableStreamDefaultWriterBrandCheckException(name) {
+  return new TypeError('WritableStreamDefaultWriter.prototype.' + name + ' can only be used on a WritableStreamDefaultWriter');
+}
+
+function CreateWritableStreamDefaultWriterLockException(name) {
+  return new TypeError('Cannot ' + name + ' a stream using a released writer');
+}
+
+function WritableStreamDefaultWriterClosedPromiseInitialize(writer) {
+  writer._closedPromise = new Promise((resolve, reject) => {
+    writer._closedPromise_resolve = resolve;
+    writer._closedPromise_reject = reject;
+  });
+}
+
+function WritableStreamDefaultWriterClosedPromiseInitializeAsRejected(writer, reason) {
+  writer._closedPromise = Promise.reject(reason);
+  writer._closedPromise_resolve = undefined;
+  writer._closedPromise_reject = undefined;
+}
+
+function WritableStreamDefaultWriterClosedPromiseInitializeAsResolved(writer, value) {
+  writer._closedPromise = Promise.resolve(value);
+  writer._closedPromise_resolve = undefined;
+  writer._closedPromise_reject = undefined;
+}
+
+function WritableStreamDefaultWriterClosedPromiseReject(writer, reason) {
+  assert(writer._closedPromise_resolve !== undefined);
+  assert(writer._closedPromise_reject !== undefined);
+
+  writer._closedPromise_reject(reason);
+  writer._closedPromise_resolve = undefined;
+  writer._closedPromise_reject = undefined;
+}
+
+function WritableStreamDefaultWriterClosedPromiseResetToRejected(writer, reason) {
+  assert(writer._closedPromise_resolve === undefined);
+  assert(writer._closedPromise_reject === undefined);
+
+  writer._closedPromise = Promise.reject(reason);
+}
+
+function WritableStreamDefaultWriterClosedPromiseResolve(writer) {
+  assert(writer._closedPromise_resolve !== undefined);
+  assert(writer._closedPromise_reject !== undefined);
+
+  writer._closedPromise_resolve(undefined);
+  writer._closedPromise_resolve = undefined;
+  writer._closedPromise_reject = undefined;
+}
+
+function WritableStreamDefaultWriterReadyPromiseInitialize(writer) {
+  writer._readyPromise = new Promise((resolve, reject) => {
+    writer._readyPromise_resolve = resolve;
+    writer._readyPromise_reject = reject;
+  });
+}
+
+function WritableStreamDefaultWriterReadyPromiseInitializeAsResolved(writer) {
+  writer._readyPromise = Promise.resolve(undefined);
+  writer._readyPromise_resolve = undefined;
+  writer._readyPromise_reject = undefined;
+}
+
+function WritableStreamDefaultWriterReadyPromiseReject(writer, reason) {
+  assert(writer._readyPromise_resolve !== undefined);
+  assert(writer._readyPromise_reject !== undefined);
+
+  writer._readyPromise_reject(reason);
+  writer._readyPromise_resolve = undefined;
+  writer._readyPromise_reject = undefined;
+}
+
+function WritableStreamDefaultWriterReadyPromiseReset(writer) {
+  assert(writer._readyPromise_resolve === undefined);
+  assert(writer._readyPromise_reject === undefined);
+
+  writer._readyPromise = new Promise((resolve, reject) => {
+    writer._readyPromise_resolve = resolve;
+    writer._readyPromise_reject = reject;
+  });
+}
+
+function WritableStreamDefaultWriterReadyPromiseResetToRejected(writer, reason) {
+  assert(writer._readyPromise_resolve === undefined);
+  assert(writer._readyPromise_reject === undefined);
+
+  writer._readyPromise = Promise.reject(reason);
+}
+
+function WritableStreamDefaultWriterReadyPromiseResolve(writer, value) {
+  assert(writer._readyPromise_resolve !== undefined);
+  assert(writer._readyPromise_reject !== undefined);
+
+  writer._readyPromise_resolve(value);
+  writer._readyPromise_resolve = undefined;
+  writer._readyPromise_reject = undefined;
+}
+
+// Abstract operations for the WritableStreamDefaultWriter.
+
+function IsWritableStreamDefaultWriter(x) {
+  if (!typeIsObject(x)) {
+    return false;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(x, '_ownerWritableStream')) {
+    return false;
+  }
+
+  return true;
+}
+
+// A client of WritableStreamDefaultWriter may use these functions directly to bypass state check.
+
+function WritableStreamDefaultWriterAbort(writer, reason) {
+  const stream = writer._ownerWritableStream;
+
+  assert(stream !== undefined);
+
+  return WritableStreamAbort(stream, reason);
+}
+
+function WritableStreamDefaultWriterClose(writer) {
+  const stream = writer._ownerWritableStream;
+
+  assert(stream !== undefined);
+
+  const state = stream._state;
+  if (state === 'closed' || state === 'errored') {
+    return Promise.reject(new TypeError(`The stream (in ${state} state) is not in the writable state and cannot be closed`));
+  }
+
+  assert(state === 'writable' || state === 'waiting');
+
+  const promise = WritableStreamAddWriteRequest(stream);
+
+  if (state === 'waiting') {
+    WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+  }
+
+  stream._state = 'closing';
+
+  WritableStreamDefaultControllerClose(stream._writableStreamController);
+
+  return promise;
+}
+
+function WritableStreamDefaultWriterGetDesiredSize(writer) {
+  const stream = writer._ownerWritableStream;
+
+  if (stream._state === 'errored') {
+    return null;
+  }
+
+  return WritableStreamDefaultControllerGetDesiredSize(stream._writableStreamController);
+}
+
+function WritableStreamDefaultWriterWrite(writer, chunk) {
+  const stream = writer._ownerWritableStream;
+
+  assert(stream !== undefined);
+
+  const state = stream._state;
+  if (state === 'closed' || state === 'errored') {
+    return Promise.reject(new TypeError(`The stream (in ${state} state) is not in the writable state and cannot be written to`));
+  }
+
+  assert(state === 'writable' || state === 'waiting');
+
+  const promise = WritableStreamAddWriteRequest(stream);
+
+  WritableStreamDefaultControllerWrite(stream._writableStreamController, chunk);
+
+  return promise;
+}
+
+class WritableStreamDefaultController {
+  constructor(stream, underlyingSink, size, highWaterMark) {
+    if (IsWritableStream(stream) === false) {
+      throw new TypeError('WritableStreamDefaultController can only be constructed with a WritableStream instance');
+    }
+
+    if (stream._writableStreamController !== undefined) {
+      throw new TypeError('WritableStreamDefaultController instances can only be created by the WritableStream constructor');
+    }
+
+    this._controlledWritableStream = stream;
+
     this._underlyingSink = underlyingSink;
 
-    this._closedPromise = new Promise((resolve, reject) => {
-      this._closedPromise_resolve = resolve;
-      this._closedPromise_reject = reject;
-    });
-
-    this._readyPromise = Promise.resolve(undefined);
-    this._readyPromise_resolve = null;
-
     this._queue = [];
-    this._state = 'writable';
     this._started = false;
     this._writing = false;
 
@@ -27,202 +570,95 @@ class WritableStream {
     this._strategySize = normalizedStrategy.size;
     this._strategyHWM = normalizedStrategy.highWaterMark;
 
-    SyncWritableStreamStateWithQueue(this);
+    WritableStreamDefaultControllerUpdateBackpressure(this);
 
-    const error = closure_WritableStreamErrorFunction();
-    error._stream = this;
+    const controller = this;
 
-    const startResult = InvokeOrNoop(underlyingSink, 'start', [error]);
-    this._startedPromise = Promise.resolve(startResult);
-    this._startedPromise.then(() => {
-      this._started = true;
-      this._startedPromise = undefined;
-    });
-    this._startedPromise.catch(r => ErrorWritableStream(this, r)).catch(rethrowAssertionErrorRejection);
-  }
-
-  get closed() {
-    if (!IsWritableStream(this)) {
-      return Promise.reject(new TypeError('WritableStream.prototype.closed can only be used on a WritableStream'));
-    }
-
-    return this._closedPromise;
-  }
-
-  get state() {
-    if (!IsWritableStream(this)) {
-      throw new TypeError('WritableStream.prototype.state can only be used on a WritableStream');
-    }
-
-    return this._state;
-  }
-
-  abort(reason) {
-    if (!IsWritableStream(this)) {
-      return Promise.reject(new TypeError('WritableStream.prototype.abort can only be used on a WritableStream'));
-    }
-
-    if (this._state === 'closed') {
-      return Promise.resolve(undefined);
-    }
-    if (this._state === 'errored') {
-      return Promise.reject(this._storedError);
-    }
-
-    ErrorWritableStream(this, reason);
-    const sinkAbortPromise = PromiseInvokeOrFallbackOrNoop(this._underlyingSink, 'abort', [reason], 'close', []);
-    return sinkAbortPromise.then(() => undefined);
-  }
-
-  close() {
-    if (!IsWritableStream(this)) {
-      return Promise.reject(new TypeError('WritableStream.prototype.close can only be used on a WritableStream'));
-    }
-
-    if (this._state === 'closing') {
-      return Promise.reject(new TypeError('cannot close an already-closing stream'));
-    }
-    if (this._state === 'closed') {
-      return Promise.reject(new TypeError('cannot close an already-closed stream'));
-    }
-    if (this._state === 'errored') {
-      return Promise.reject(this._storedError);
-    }
-    if (this._state === 'waiting') {
-      this._readyPromise_resolve(undefined);
-    }
-
-    this._state = 'closing';
-    EnqueueValueWithSize(this._queue, 'close', 0);
-    CallOrScheduleWritableStreamAdvanceQueue(this);
-
-    return this._closedPromise;
-  }
-
-  get ready() {
-    if (!IsWritableStream(this)) {
-      return Promise.reject(new TypeError('WritableStream.prototype.ready can only be used on a WritableStream'));
-    }
-
-    return this._readyPromise;
-  }
-
-  write(chunk) {
-    if (!IsWritableStream(this)) {
-      return Promise.reject(new TypeError('WritableStream.prototype.write can only be used on a WritableStream'));
-    }
-
-    if (this._state === 'closing') {
-      return Promise.reject(new TypeError('cannot write while stream is closing'));
-    }
-    if (this._state === 'closed') {
-      return Promise.reject(new TypeError('cannot write after stream is closed'));
-    }
-    if (this._state === 'errored') {
-      return Promise.reject(this._storedError);
-    }
-
-    assert(this._state === 'waiting' || this._state === 'writable');
-
-    let chunkSize = 1;
-
-    if (this._strategySize !== undefined) {
-      try {
-        chunkSize = this._strategySize(chunk);
-      } catch (chunkSizeE) {
-        ErrorWritableStream(this, chunkSizeE);
-        return Promise.reject(chunkSizeE);
+    const startResult = InvokeOrNoop(underlyingSink, 'start', [this]);
+    Promise.resolve(startResult).then(
+      () => {
+        controller._started = true;
+        WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
+      },
+      r => {
+        WritableStreamDefaultControllerErrorIfNeeded(controller, r);
       }
-    }
-
-    let resolver, rejecter;
-    const promise = new Promise((resolve, reject) => {
-      resolver = resolve;
-      rejecter = reject;
-    });
-
-    const writeRecord = { promise: promise, chunk: chunk, _resolve: resolver, _reject: rejecter };
-    try {
-      EnqueueValueWithSize(this._queue, writeRecord, chunkSize);
-    } catch (enqueueResultE) {
-      ErrorWritableStream(this, enqueueResultE);
-      return Promise.reject(enqueueResultE);
-    }
-
-    SyncWritableStreamStateWithQueue(this);
-    CallOrScheduleWritableStreamAdvanceQueue(this);
-    return promise;
-  }
-}
-
-exports.WritableStream = WritableStream;
-
-function closure_WritableStreamErrorFunction() {
-  const f = e => ErrorWritableStream(f._stream, e);
-  return f;
-}
-
-
-function CallOrScheduleWritableStreamAdvanceQueue(stream) {
-  if (stream._started === false) {
-    stream._startedPromise.then(() => {
-      WritableStreamAdvanceQueue(stream);
-    })
+    )
     .catch(rethrowAssertionErrorRejection);
-    return undefined;
   }
 
-  if (stream._started === true) {
-    return WritableStreamAdvanceQueue(stream);
+  error(e) {
+    if (IsWritableStreamDefaultController(this) === false) {
+      throw new TypeError('WritableStreamDefaultController.prototype.error can only be used on a WritableStreamDefaultController');
+    }
+
+    const state = this._controlledWritableStream._state;
+    if (state === 'closed' || state === 'errored') {
+      throw new TypeError(`The stream is ${state} and so cannot be errored`);
+    }
+
+    WritableStreamDefaultControllerError(this, e);
   }
 }
 
-function CloseWritableStream(stream) {
-  assert(stream._state === 'closing', 'stream must be in closing state while calling CloseWritableStream');
+// Abstract operations implementing interface required by the WritableStream.
 
-  const sinkClosePromise = PromiseInvokeOrNoop(stream._underlyingSink, 'close');
-  sinkClosePromise.then(
-    () => {
-      if (stream._state === 'errored') {
-        return;
-      }
+function WritableStreamDefaultControllerAbort(controller, reason) {
+  controller._queue = [];
 
-      assert(stream._state === 'closing');
-
-      stream._closedPromise_resolve(undefined);
-      stream._closedPromise_resolve = undefined;
-      stream._closedPromise_reject = undefined;
-      stream._state = 'closed';
-    },
-    r => ErrorWritableStream(stream, r)
-  )
-  .catch(rethrowAssertionErrorRejection);
+  const sinkAbortPromise = PromiseInvokeOrFallbackOrNoop(controller._underlyingSink, 'abort', [reason], 'close', []);
+  return sinkAbortPromise.then(() => undefined);
 }
 
-function ErrorWritableStream(stream, e) {
-  if (stream._state === 'closed' || stream._state === 'errored') {
-    return undefined;
-  }
+function WritableStreamDefaultControllerClose(controller) {
+  EnqueueValueWithSize(controller._queue, 'close', 0);
+  WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
+}
 
-  while (stream._queue.length > 0) {
-    const writeRecord = DequeueValue(stream._queue);
-    if (writeRecord !== 'close') {
-      writeRecord._reject(e);
+function WritableStreamDefaultControllerGetDesiredSize(controller) {
+  const queueSize = GetTotalQueueSize(controller._queue);
+  return controller._strategyHWM - queueSize;
+}
+
+function WritableStreamDefaultControllerWrite(controller, chunk) {
+  const stream = controller._controlledWritableStream;
+
+  assert(stream._state === 'writable' || stream._state === 'waiting');
+
+  let chunkSize = 1;
+
+  if (controller._strategySize !== undefined) {
+    try {
+      chunkSize = controller._strategySize(chunk);
+    } catch (chunkSizeE) {
+      // TODO: Should we notify the sink of this error?
+      WritableStreamDefaultControllerErrorIfNeeded(controller, chunkSizeE);
+      return Promise.reject(chunkSizeE);
     }
   }
 
-  stream._storedError = e;
+  const writeRecord = { chunk: chunk };
 
-  if (stream._state === 'waiting') {
-    stream._readyPromise_resolve(undefined);
+  try {
+    EnqueueValueWithSize(controller._queue, writeRecord, chunkSize);
+  } catch (enqueueE) {
+    WritableStreamDefaultControllerErrorIfNeeded(controller, enqueueE);
+    return Promise.reject(enqueueE);
   }
-  stream._closedPromise_reject(e);
-  stream._closedPromise_resolve = undefined;
-  stream._closedPromise_reject = undefined;
-  stream._state = 'errored';
+
+  const state = stream._state;
+  if (state === 'writable' || state === 'waiting') {
+    WritableStreamDefaultControllerUpdateBackpressure(controller);
+  }
+
+  WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
+
+  return;
 }
 
-function IsWritableStream(x) {
+// Abstract operations for the WritableStreamDefaultController.
+
+function IsWritableStreamDefaultController(x) {
   if (!typeIsObject(x)) {
     return false;
   }
@@ -234,65 +670,109 @@ function IsWritableStream(x) {
   return true;
 }
 
-exports.IsWritableStream = IsWritableStream;
-
-function SyncWritableStreamStateWithQueue(stream) {
-  if (stream._state === 'closing') {
-    return undefined;
+function WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller) {
+  const state = controller._controlledWritableStream._state;
+  if (state === 'closed' || state === 'errored') {
+    return;
   }
 
-  assert(stream._state === 'writable' || stream._state === 'waiting',
-    'stream must be in a writable or waiting state while calling SyncWritableStreamStateWithQueue');
-
-  const queueSize = GetTotalQueueSize(stream._queue);
-  const shouldApplyBackpressure = queueSize > stream._strategyHWM;
-
-  if (shouldApplyBackpressure === true && stream._state === 'writable') {
-    stream._state = 'waiting';
-    stream._readyPromise = new Promise((resolve, reject) => {
-      stream._readyPromise_resolve = resolve;
-    });
+  if (controller._started === false) {
+    return;
   }
 
-  if (shouldApplyBackpressure === false && stream._state === 'waiting') {
-    stream._state = 'writable';
-    stream._readyPromise_resolve(undefined);
+  if (controller._queue.length === 0) {
+    return;
   }
 
-  return undefined;
+  if (controller._writing === true) {
+    return;
+  }
+
+  const writeRecord = PeekQueueValue(controller._queue);
+  if (writeRecord === 'close') {
+    WritableStreamDefaultControllerProcessClose(controller);
+  } else {
+    WritableStreamDefaultControllerProcessWrite(controller, writeRecord.chunk);
+  }
 }
 
-function WritableStreamAdvanceQueue(stream) {
-  if (stream._queue.length === 0 || stream._writing === true) {
-    return undefined;
+function WritableStreamDefaultControllerErrorIfNeeded(controller, e) {
+  const state = controller._controlledWritableStream._state;
+  if (state === 'writable' || state === 'waiting' || state === 'closing') {
+    WritableStreamDefaultControllerError(controller, e);
   }
+}
 
-  const writeRecord = PeekQueueValue(stream._queue);
+function WritableStreamDefaultControllerProcessClose(controller) {
+  const stream = controller._controlledWritableStream;
 
-  if (writeRecord === 'close') {
-    assert(stream._state === 'closing', 'can\'t process final write record unless already closing');
-    DequeueValue(stream._queue);
-    assert(stream._queue.length === 0, 'queue must be empty once the final write record is dequeued');
-    return CloseWritableStream(stream);
-  } else {
-    stream._writing = true;
+  assert(stream._state === 'closing', 'can\'t process final write record unless already closed');
 
-    PromiseInvokeOrNoop(stream._underlyingSink, 'write', [writeRecord.chunk]).then(
-      () => {
-        if (stream._state === 'errored') {
-          return;
-        }
+  DequeueValue(controller._queue);
+  assert(controller._queue.length === 0, 'queue must be empty once the final write record is dequeued');
 
-        stream._writing = false;
+  const sinkClosePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'close');
+  sinkClosePromise.then(
+    () => {
+      if (stream._state !== 'closing') {
+        return;
+      }
 
-        writeRecord._resolve(undefined);
+      WritableStreamFulfillWriteRequest(stream);
+      WritableStreamFinishClose(stream);
+    },
+    r => {
+      WritableStreamDefaultControllerErrorIfNeeded(controller, r);
+    }
+  )
+  .catch(rethrowAssertionErrorRejection);
+}
 
-        DequeueValue(stream._queue);
-        SyncWritableStreamStateWithQueue(stream);
-        WritableStreamAdvanceQueue(stream);
-      },
-      r => ErrorWritableStream(stream, r)
-    )
-    .catch(rethrowAssertionErrorRejection);
-  }
+function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
+  controller._writing = true;
+
+  const sinkWritePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'write', [chunk]);
+  sinkWritePromise.then(
+    () => {
+      const stream = controller._controlledWritableStream;
+      const state = stream._state;
+      if (state === 'errored' || state === 'closed') {
+        return;
+      }
+
+      controller._writing = false;
+
+      WritableStreamFulfillWriteRequest(stream);
+
+      DequeueValue(controller._queue);
+      if (state !== 'closing') {
+        WritableStreamDefaultControllerUpdateBackpressure(controller);
+      }
+
+      WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
+    },
+    r => {
+      WritableStreamDefaultControllerErrorIfNeeded(controller, r);
+    }
+  )
+  .catch(rethrowAssertionErrorRejection);
+}
+
+function WritableStreamDefaultControllerUpdateBackpressure(controller) {
+  const desiredSize = WritableStreamDefaultControllerGetDesiredSize(controller);
+  const backpressure = desiredSize <= 0;
+  WritableStreamUpdateBackpressure(controller._controlledWritableStream, backpressure);
+}
+
+// A client of WritableStreamDefaultController may use these functions directly to bypass state check.
+
+function WritableStreamDefaultControllerError(controller, e) {
+  const stream = controller._controlledWritableStream;
+
+  const state = stream._state;
+  assert(state === 'writable' || state === 'waiting' || state === 'closing');
+
+  controller._queue = [];
+
+  WritableStreamError(stream, e);
 }

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -6,29 +6,24 @@ const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, GetTotalQueueSize, PeekQueueValue } = require('./queue-with-sizes.js');
 
 class WritableStream {
-  constructor(underlyingSink = {}, { size, highWaterMark } = {}) {
-    // Temporary value. Never used. To be overwritten by the initializer code of the controller.
+  constructor(underlyingSink = {}, { size, highWaterMark = 1 } = {}) {
     this._state = 'writable';
     this._storedError = undefined;
 
     this._writer = undefined;
 
-    // This queue is placed here instead of the writer class in order to allow for passing a writer to the next data
-    // producer without waiting for the queued writes to finish.
-    this._writeRequests = [];
-
     // Initialize to undefined first because the constructor of the controller checks this
     // variable to validate the caller.
     this._writableStreamController = undefined;
+
+    // This queue is placed here instead of the writer class in order to allow for passing a writer to the next data
+    // producer without waiting for the queued writes to finish.
+    this._writeRequests = [];
 
     const type = underlyingSink.type;
 
     if (type !== undefined) {
       throw new RangeError('Invalid type is specified');
-    }
-
-    if (highWaterMark === undefined) {
-      highWaterMark = 1;
     }
 
     this._writableStreamController = new WritableStreamDefaultController(this, underlyingSink, size, highWaterMark);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -68,7 +68,7 @@ exports.WritableStream = WritableStream;
 // Helper functions for the WritableStream.
 
 function streamBrandCheckException(name) {
-  return new TypeError('WritableStream.prototype.' + name + ' can only be used on a WritableStream')
+  return new TypeError('WritableStream.prototype.' + name + ' can only be used on a WritableStream');
 }
 
 // Abstract operations for the WritableStream.
@@ -119,10 +119,10 @@ function WritableStreamAbort(stream, reason) {
   }
 
   if (writer !== undefined) {
-    WritableStreamDefaultWriterClosedPromiseReject(writer, error);
+    defaultWriterClosedPromiseReject(writer, error);
 
     if (state === 'waiting') {
-      WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+      defaultWriterReadyPromiseResolve(writer, undefined);
     }
   }
 
@@ -166,10 +166,10 @@ function WritableStreamError(stream, e) {
   const writer = stream._writer;
 
   if (writer !== undefined) {
-    WritableStreamDefaultWriterClosedPromiseReject(writer, e);
+    defaultWriterClosedPromiseReject(writer, e);
 
     if (state === 'waiting') {
-      WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+      defaultWriterReadyPromiseResolve(writer, undefined);
     }
   }
 
@@ -188,7 +188,7 @@ function WritableStreamFinishClose(stream) {
   // there's an active writer.
   assert(writer !== undefined);
 
-  WritableStreamDefaultWriterClosedPromiseResolve(writer);
+  defaultWriterClosedPromiseResolve(writer);
 }
 
 function WritableStreamFulfillWriteRequest(stream) {
@@ -210,7 +210,7 @@ function WritableStreamUpdateBackpressure(stream, backpressure) {
     stream._state = 'waiting';
 
     if (writer !== undefined) {
-      WritableStreamDefaultWriterReadyPromiseReset(writer);
+      defaultWriterReadyPromiseReset(writer);
     }
 
     return;
@@ -225,7 +225,7 @@ function WritableStreamUpdateBackpressure(stream, backpressure) {
   stream._state = 'writable';
 
   if (writer !== undefined) {
-    WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+    defaultWriterReadyPromiseResolve(writer, undefined);
   }
 }
 
@@ -244,21 +244,21 @@ class WritableStreamDefaultWriter {
     const state = stream._state;
 
     if (state === 'writable' || state === 'waiting' || state === 'closing') {
-      WritableStreamDefaultWriterClosedPromiseInitialize(this);
+      defaultWriterClosedPromiseInitialize(this);
     } else {
       if (state === 'closed') {
-        WritableStreamDefaultWriterClosedPromiseInitializeAsResolved(this, undefined);
+        defaultWriterClosedPromiseInitializeAsResolved(this, undefined);
       } else {
         assert(state === 'errored', 'state must be errored');
 
-        WritableStreamDefaultWriterClosedPromiseInitializeAsRejected(this, stream._storedError);
+        defaultWriterClosedPromiseInitializeAsRejected(this, stream._storedError);
       }
     }
 
     if (state === 'waiting') {
-      WritableStreamDefaultWriterReadyPromiseInitialize(this);
+      defaultWriterReadyPromiseInitialize(this);
     } else {
-      WritableStreamDefaultWriterReadyPromiseInitializeAsResolved(this, undefined);
+      defaultWriterReadyPromiseInitializeAsResolved(this, undefined);
     }
   }
 
@@ -338,15 +338,15 @@ class WritableStreamDefaultWriter {
     const releasedException = new TypeError('Writer was released and can no longer be used to monitor the stream\'s closedness');
 
     if (state === 'writable' || state === 'waiting' || state === 'closing') {
-      WritableStreamDefaultWriterClosedPromiseReject(this, releasedException);
+      defaultWriterClosedPromiseReject(this, releasedException);
     } else {
-      WritableStreamDefaultWriterClosedPromiseResetToRejected(this, releasedException);
+      defaultWriterClosedPromiseResetToRejected(this, releasedException);
     }
 
     if (state === 'waiting') {
-      WritableStreamDefaultWriterReadyPromiseReject(this, releasedException);
+      defaultWriterReadyPromiseReject(this, releasedException);
     } else {
-      WritableStreamDefaultWriterReadyPromiseResetToRejected(this, releasedException);
+      defaultWriterReadyPromiseResetToRejected(this, releasedException);
     }
 
     stream._writer = undefined;
@@ -380,26 +380,26 @@ function defaultWriterLockException(name) {
   return new TypeError('Cannot ' + name + ' a stream using a released writer');
 }
 
-function WritableStreamDefaultWriterClosedPromiseInitialize(writer) {
+function defaultWriterClosedPromiseInitialize(writer) {
   writer._closedPromise = new Promise((resolve, reject) => {
     writer._closedPromise_resolve = resolve;
     writer._closedPromise_reject = reject;
   });
 }
 
-function WritableStreamDefaultWriterClosedPromiseInitializeAsRejected(writer, reason) {
+function defaultWriterClosedPromiseInitializeAsRejected(writer, reason) {
   writer._closedPromise = Promise.reject(reason);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
 }
 
-function WritableStreamDefaultWriterClosedPromiseInitializeAsResolved(writer, value) {
+function defaultWriterClosedPromiseInitializeAsResolved(writer, value) {
   writer._closedPromise = Promise.resolve(value);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
 }
 
-function WritableStreamDefaultWriterClosedPromiseReject(writer, reason) {
+function defaultWriterClosedPromiseReject(writer, reason) {
   assert(writer._closedPromise_resolve !== undefined);
   assert(writer._closedPromise_reject !== undefined);
 
@@ -408,14 +408,14 @@ function WritableStreamDefaultWriterClosedPromiseReject(writer, reason) {
   writer._closedPromise_reject = undefined;
 }
 
-function WritableStreamDefaultWriterClosedPromiseResetToRejected(writer, reason) {
+function defaultWriterClosedPromiseResetToRejected(writer, reason) {
   assert(writer._closedPromise_resolve === undefined);
   assert(writer._closedPromise_reject === undefined);
 
   writer._closedPromise = Promise.reject(reason);
 }
 
-function WritableStreamDefaultWriterClosedPromiseResolve(writer) {
+function defaultWriterClosedPromiseResolve(writer) {
   assert(writer._closedPromise_resolve !== undefined);
   assert(writer._closedPromise_reject !== undefined);
 
@@ -424,20 +424,20 @@ function WritableStreamDefaultWriterClosedPromiseResolve(writer) {
   writer._closedPromise_reject = undefined;
 }
 
-function WritableStreamDefaultWriterReadyPromiseInitialize(writer) {
+function defaultWriterReadyPromiseInitialize(writer) {
   writer._readyPromise = new Promise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
     writer._readyPromise_reject = reject;
   });
 }
 
-function WritableStreamDefaultWriterReadyPromiseInitializeAsResolved(writer) {
+function defaultWriterReadyPromiseInitializeAsResolved(writer) {
   writer._readyPromise = Promise.resolve(undefined);
   writer._readyPromise_resolve = undefined;
   writer._readyPromise_reject = undefined;
 }
 
-function WritableStreamDefaultWriterReadyPromiseReject(writer, reason) {
+function defaultWriterReadyPromiseReject(writer, reason) {
   assert(writer._readyPromise_resolve !== undefined);
   assert(writer._readyPromise_reject !== undefined);
 
@@ -446,7 +446,7 @@ function WritableStreamDefaultWriterReadyPromiseReject(writer, reason) {
   writer._readyPromise_reject = undefined;
 }
 
-function WritableStreamDefaultWriterReadyPromiseReset(writer) {
+function defaultWriterReadyPromiseReset(writer) {
   assert(writer._readyPromise_resolve === undefined);
   assert(writer._readyPromise_reject === undefined);
 
@@ -456,14 +456,14 @@ function WritableStreamDefaultWriterReadyPromiseReset(writer) {
   });
 }
 
-function WritableStreamDefaultWriterReadyPromiseResetToRejected(writer, reason) {
+function defaultWriterReadyPromiseResetToRejected(writer, reason) {
   assert(writer._readyPromise_resolve === undefined);
   assert(writer._readyPromise_reject === undefined);
 
   writer._readyPromise = Promise.reject(reason);
 }
 
-function WritableStreamDefaultWriterReadyPromiseResolve(writer, value) {
+function defaultWriterReadyPromiseResolve(writer, value) {
   assert(writer._readyPromise_resolve !== undefined);
   assert(writer._readyPromise_reject !== undefined);
 
@@ -511,7 +511,7 @@ function WritableStreamDefaultWriterClose(writer) {
   const promise = WritableStreamAddWriteRequest(stream);
 
   if (state === 'waiting') {
-    WritableStreamDefaultWriterReadyPromiseResolve(writer, undefined);
+    defaultWriterReadyPromiseResolve(writer, undefined);
   }
 
   stream._state = 'closing';

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -533,7 +533,7 @@ class WritableStreamDefaultController {
     this._strategyHWM = normalizedStrategy.highWaterMark;
 
     const backpressure = WritableStreamDefaultControllerGetBackpressure(this);
-    if (backpressure !== false) {
+    if (backpressure === true) {
       WritableStreamUpdateBackpressure(stream, backpressure);
     }
 

--- a/reference-implementation/test/bad-strategies.js
+++ b/reference-implementation/test/bad-strategies.js
@@ -30,12 +30,13 @@ test('Writable stream: throwing strategy.size method', t => {
     });
   }, 'initial construction should not throw');
 
-  ws.write('a').then(
+  const writer = ws.getWriter();
+  writer.write('a').then(
     () => t.fail('write should not fulfill'),
     r => t.equal(r, theError, 'write should reject with the thrown error')
   );
 
-  ws.closed.then(
+  writer.closed.then(
     () => t.fail('closed should not fulfill'),
     r => t.equal(r, theError, 'closed should reject with the thrown error')
   );
@@ -53,14 +54,15 @@ test('Writable stream: invalid strategy.size return value', t => {
       highWaterMark: 5
     });
 
-    ws.write('a').then(
+    const writer = ws.getWriter();
+    writer.write('a').then(
       () => t.fail('write should not fulfill'),
       r => {
         t.equal(r.constructor, RangeError, `write should reject with a RangeError for ${size}`);
         theError = r;
       });
 
-    ws.closed.catch(e => t.equal(e, theError, `closed should reject with the error for ${size}`));
+    writer.closed.catch(e => t.equal(e, theError, `closed should reject with the error for ${size}`));
   }
 });
 

--- a/reference-implementation/test/bad-underlying-sinks.js
+++ b/reference-implementation/test/bad-underlying-sinks.js
@@ -37,12 +37,14 @@ test('Underlying sink: throwing write getter', t => {
     }
   });
 
-  ws.write('a').then(
+  const writer = ws.getWriter();
+
+  writer.write('a').then(
     () => t.fail('write should not fulfill'),
     r => t.equal(r, theError, 'write should reject with the thrown error')
   );
 
-  ws.closed.then(
+  writer.closed.then(
     () => t.fail('closed should not fulfill'),
     r => t.equal(r, theError, 'closed should reject with the thrown error')
   );
@@ -58,12 +60,14 @@ test('Underlying sink: throwing write method', t => {
     }
   });
 
-  ws.write('a').then(
+  const writer = ws.getWriter();
+
+  writer.write('a').then(
     () => t.fail('write should not fulfill'),
     r => t.equal(r, theError, 'write should reject with the thrown error')
   );
 
-  ws.closed.then(
+  writer.closed.then(
     () => t.fail('closed should not fulfill'),
     r => t.equal(r, theError, 'closed should reject with the thrown error')
   );
@@ -80,14 +84,16 @@ test('Underlying sink: throwing abort getter', t => {
     }
   });
 
-  ws.abort(abortReason).then(
+  const writer = ws.getWriter();
+
+  writer.abort(abortReason).then(
     () => t.fail('abort should not fulfill'),
     r => t.equal(r, theError, 'abort should reject with the abort reason')
   );
 
-  ws.closed.then(
+  writer.closed.then(
     () => t.fail('closed should not fulfill'),
-    r => t.equal(r, abortReason, 'closed should reject with the thrown error')
+    r => t.equal(r.constructor, TypeError, 'closed should reject with a TypeError')
   );
 });
 
@@ -102,14 +108,16 @@ test('Underlying sink: throwing abort method', t => {
     }
   });
 
-  ws.abort(abortReason).then(
+  const writer = ws.getWriter();
+
+  writer.abort(abortReason).then(
     () => t.fail('abort should not fulfill'),
     r => t.equal(r, theError, 'abort should reject with the abort reason')
   );
 
-  ws.closed.then(
+  writer.closed.then(
     () => t.fail('closed should not fulfill'),
-    r => t.equal(r, abortReason, 'closed should reject with the thrown error')
+    r => t.equal(r.constructor, TypeError, 'closed should reject with a TypeError')
   );
 });
 
@@ -123,7 +131,8 @@ test('Underlying sink: throwing close getter', t => {
     }
   });
 
-  ws.close().then(
+  const writer = ws.getWriter();
+  writer.close().then(
     () => t.fail('close should not fulfill'),
     r => t.equal(r, theError, 'close should reject with the thrown error')
   );
@@ -139,7 +148,8 @@ test('Underlying sink: throwing close method', t => {
     }
   });
 
-  ws.close().then(
+  const writer = ws.getWriter();
+  writer.close().then(
     () => t.fail('close should not fulfill'),
     r => t.equal(r, theError, 'close should reject with the thrown error')
   );

--- a/reference-implementation/test/brand-checks.js
+++ b/reference-implementation/test/brand-checks.js
@@ -1,23 +1,20 @@
 'use strict';
 const test = require('tape-catch');
 
-function fakeWritableStream() {
+function fakeWritableStreamDefaultWriter() {
   return {
     get closed() { return Promise.resolve(); },
+    get desiredSize() { return 1; },
     get ready() { return Promise.resolve(); },
-    get state() { return 'closed' },
     abort(reason) { return Promise.resolve(); },
     close() { return Promise.resolve(); },
     write(chunk) { return Promise.resolve(); }
   };
 }
 
-function realWritableStream() {
-  return new WritableStream();
-}
-
-function realReadableStream() {
-  return new ReadableStream();
+function realReadableStreamDefaultWriter() {
+  const rs = new ReadableStream();
+  return rs.getReader();
 }
 
 function fakeByteLengthQueuingStrategy() {
@@ -76,39 +73,42 @@ function methodThrows(t, obj, methodName, target) {
   t.throws(() => method.call(target), /TypeError/, methodName + ' should throw a TypeError');
 }
 
+const ws = new WritableStream();
+const writer = ws.getWriter();
+const WritableStreamDefaultWriter = writer.constructor;
 
-test('WritableStream.prototype.closed enforces a brand check', t => {
+test('WritableStreamDefaultWriter.prototype.closed enforces a brand check', t => {
   t.plan(2);
-  getterRejects(t, WritableStream.prototype, 'closed', fakeWritableStream());
-  getterRejects(t, WritableStream.prototype, 'closed', realReadableStream());
+  getterRejects(t, WritableStreamDefaultWriter.prototype, 'closed', fakeWritableStreamDefaultWriter());
+  getterRejects(t, WritableStreamDefaultWriter.prototype, 'closed', realReadableStreamDefaultWriter());
 });
 
-test('WritableStream.prototype.ready enforces a brand check', t => {
+test('WritableStreamDefaultWriter.prototype.desiredSize enforces a brand check', t => {
   t.plan(2);
-  getterRejects(t, WritableStream.prototype, 'ready', fakeWritableStream());
-  getterRejects(t, WritableStream.prototype, 'ready', realReadableStream());
+  getterThrows(t, WritableStreamDefaultWriter.prototype, 'desiredSize', fakeWritableStreamDefaultWriter());
+  getterThrows(t, WritableStreamDefaultWriter.prototype, 'desiredSize', realReadableStreamDefaultWriter());
 });
 
-test('WritableStream.prototype.state enforces a brand check', t => {
+test('WritableStreamDefaultWriter.prototype.ready enforces a brand check', t => {
   t.plan(2);
-  getterThrows(t, WritableStream.prototype, 'state', fakeWritableStream());
-  getterThrows(t, WritableStream.prototype, 'state', realReadableStream());
+  getterRejects(t, WritableStreamDefaultWriter.prototype, 'ready', fakeWritableStreamDefaultWriter());
+  getterRejects(t, WritableStreamDefaultWriter.prototype, 'ready', realReadableStreamDefaultWriter());
 });
 
-test('WritableStream.prototype.abort enforces a brand check', t => {
+test('WritableStreamDefaultWriter.prototype.abort enforces a brand check', t => {
   t.plan(2);
-  methodRejects(t, WritableStream.prototype, 'abort', fakeWritableStream());
-  methodRejects(t, WritableStream.prototype, 'abort', realReadableStream());
+  methodRejects(t, WritableStreamDefaultWriter.prototype, 'abort', fakeWritableStreamDefaultWriter());
+  methodRejects(t, WritableStreamDefaultWriter.prototype, 'abort', realReadableStreamDefaultWriter());
 });
 
-test('WritableStream.prototype.write enforces a brand check', t => {
+test('WritableStreamDefaultWriter.prototype.write enforces a brand check', t => {
   t.plan(2);
-  methodRejects(t, WritableStream.prototype, 'write', fakeWritableStream());
-  methodRejects(t, WritableStream.prototype, 'write', realReadableStream());
+  methodRejects(t, WritableStreamDefaultWriter.prototype, 'write', fakeWritableStreamDefaultWriter());
+  methodRejects(t, WritableStreamDefaultWriter.prototype, 'write', realReadableStreamDefaultWriter());
 });
 
-test('WritableStream.prototype.close enforces a brand check', t => {
+test('WritableStreamDefaultWriter.prototype.close enforces a brand check', t => {
   t.plan(2);
-  methodRejects(t, WritableStream.prototype, 'close', fakeWritableStream());
-  methodRejects(t, WritableStream.prototype, 'close', realReadableStream());
+  methodRejects(t, WritableStreamDefaultWriter.prototype, 'close', fakeWritableStreamDefaultWriter());
+  methodRejects(t, WritableStreamDefaultWriter.prototype, 'close', realReadableStreamDefaultWriter());
 });

--- a/reference-implementation/test/byte-length-queuing-strategy.js
+++ b/reference-implementation/test/byte-length-queuing-strategy.js
@@ -23,6 +23,7 @@ test('Closing a writable stream with in-flight writes below the high water mark 
     new ByteLengthQueuingStrategy({ highWaterMark: 1024 * 16 })
   );
 
-  ws.write({ byteLength: 1024 });
-  ws.close();
+  const writer = ws.getWriter();
+  writer.write({ byteLength: 1024 });
+  writer.close();
 });

--- a/reference-implementation/test/count-queuing-strategy.js
+++ b/reference-implementation/test/count-queuing-strategy.js
@@ -20,28 +20,30 @@ test('Correctly governs the value of a WritableStream\'s state property (HWM = 0
   );
 
   setTimeout(() => {
-    t.equal(ws.state, 'writable', 'After 0 writes, 0 of which finished, state should be \'writable\'');
+    const writer = ws.getWriter();
 
-    const writePromiseA = ws.write('a');
-    t.equal(ws.state, 'waiting', 'After 1 write, 0 of which finished, state should be \'waiting\'');
+    t.equal(writer.desiredSize, 0, 'desiredSize should be initially 0');
 
-    const writePromiseB = ws.write('b');
-    t.equal(ws.state, 'waiting', 'After 2 writes, 0 of which finished, state should be \'waiting\'');
+    const writePromiseA = writer.write('a');
+    t.equal(writer.desiredSize, -1, 'desiredSize should be -1 after 1st write()');
+
+    const writePromiseB = writer.write('b');
+    t.equal(writer.desiredSize, -2, 'desiredSize should be -2 after 2nd write()');
 
     dones.a();
     writePromiseA.then(() => {
-      t.equal(ws.state, 'waiting', 'After 2 writes, 1 of which finished, state should be \'waiting\'');
+      t.equal(writer.desiredSize, -1, 'desiredSize should be -1 after completing 1st write()');
 
       dones.b();
       return writePromiseB.then(() => {
-        t.equal(ws.state, 'writable', 'After 2 writes, 2 of which finished, state should be \'writable\'');
+        t.equal(writer.desiredSize, 0, 'desiredSize should be 0 after completing 2nd write()');
 
-        const writePromiseC = ws.write('c');
-        t.equal(ws.state, 'waiting', 'After 3 writes, 2 of which finished, state should be \'waiting\'');
+        const writePromiseC = writer.write('c');
+        t.equal(writer.desiredSize, -1, 'desiredSize should be -1 after 3rd write()');
 
         dones.c();
         return writePromiseC.then(() => {
-          t.equal(ws.state, 'writable', 'After 3 writes, 3 of which finished, state should be \'writable\'');
+          t.equal(writer.desiredSize, 0, 'desiredSize should be 0 after completing 3rd write()');
 
           t.end();
         });
@@ -64,50 +66,52 @@ test('Correctly governs the value of a WritableStream\'s state property (HWM = 4
   );
 
   setTimeout(() => {
-    t.equal(ws.state, 'writable', 'After 0 writes, 0 of which finished, state should be \'writable\'');
+    const writer = ws.getWriter();
 
-    const writePromiseA = ws.write('a');
-    t.equal(ws.state, 'writable', 'After 1 write, 0 of which finished, state should be \'writable\'');
+    t.equal(writer.desiredSize, 4, 'desiredSize should be initially 4');
 
-    const writePromiseB = ws.write('b');
-    t.equal(ws.state, 'writable', 'After 2 writes, 0 of which finished, state should be \'writable\'');
+    const writePromiseA = writer.write('a');
+    t.equal(writer.desiredSize, 3, 'desiredSize should be 3 after 1st write()');
 
-    const writePromiseC = ws.write('c');
-    t.equal(ws.state, 'writable', 'After 3 writes, 0 of which finished, state should be \'writable\'');
+    const writePromiseB = writer.write('b');
+    t.equal(writer.desiredSize, 2, 'desiredSize should be 2 after 2nd write()');
 
-    const writePromiseD = ws.write('d');
-    t.equal(ws.state, 'writable', 'After 4 writes, 0 of which finished, state should be \'writable\'');
+    const writePromiseC = writer.write('c');
+    t.equal(writer.desiredSize, 1, 'desiredSize should be 1 after 3rd write()');
 
-    ws.write('e');
-    t.equal(ws.state, 'waiting', 'After 5 writes, 0 of which finished, state should be \'waiting\'');
+    const writePromiseD = writer.write('d');
+    t.equal(writer.desiredSize, 0, 'desiredSize should be 0 after 4th write()');
 
-    ws.write('f');
-    t.equal(ws.state, 'waiting', 'After 6 writes, 0 of which finished, state should be \'waiting\'');
+    writer.write('e');
+    t.equal(writer.desiredSize, -1, 'desiredSize should be -1 after 5th write()');
 
-    ws.write('g');
-    t.equal(ws.state, 'waiting', 'After 7 writes, 0 of which finished, state should be \'waiting\'');
+    writer.write('f');
+    t.equal(writer.desiredSize, -2, 'desiredSize should be -2 after 6th write()');
+
+    writer.write('g');
+    t.equal(writer.desiredSize, -3, 'desiredSize should be -3 after 7th write()');
 
     dones.a();
     writePromiseA.then(() => {
-      t.equal(ws.state, 'waiting', 'After 7 writes, 1 of which finished, state should be \'waiting\'');
+      t.equal(writer.desiredSize, -2, 'desiredSize should be -2 after completing 1st write()');
 
       dones.b();
       return writePromiseB.then(() => {
-        t.equal(ws.state, 'waiting', 'After 7 writes, 2 of which finished, state should be \'waiting\'');
+        t.equal(writer.desiredSize, -1, 'desiredSize should be -1 after completing 2nd write()');
 
         dones.c();
         return writePromiseC.then(() => {
-          t.equal(ws.state, 'writable', 'After 7 writes, 3 of which finished, state should be \'writable\'');
+          t.equal(writer.desiredSize, 0, 'desiredSize should be 0 after completing 3rd write()');
 
-          ws.write('h');
-          t.equal(ws.state, 'waiting', 'After 8 writes, 3 of which finished, state should be \'waiting\'');
+          writer.write('h');
+          t.equal(writer.desiredSize, -1, 'desiredSize should be -1 after 8th write()');
 
           dones.d();
           return writePromiseD.then(() => {
-            t.equal(ws.state, 'writable', 'After 8 writes, 4 of which finished, state should be \'writable\'');
+            t.equal(writer.desiredSize, 0, 'desiredSize should be 0 after completing 4th write()');
 
-            ws.write('i');
-            t.equal(ws.state, 'waiting', 'After 9 writes, 4 of which finished, state should be \'waiting\'');
+            writer.write('i');
+            t.equal(writer.desiredSize, -1, 'desiredSize should be -1 after 9th write()');
 
             t.end();
           });

--- a/reference-implementation/test/pipe-through.js
+++ b/reference-implementation/test/pipe-through.js
@@ -14,8 +14,6 @@ test('Piping through a duck-typed pass-through transform stream works', t => {
 });
 
 test('Piping through an identity transform stream will close the destination when the source closes', t => {
-  t.plan(1);
-
   const rs = new ReadableStream({
     start(c) {
       c.enqueue('a');
@@ -25,8 +23,13 @@ test('Piping through an identity transform stream will close the destination whe
     }
   });
 
+  let enqueue;
+
   const ts = new TransformStream({
-    transform(chunk, enqueue, done) {
+    start(e) {
+      enqueue = e;
+    },
+    transform(chunk, done) {
       enqueue(chunk);
       done();
     }
@@ -35,7 +38,7 @@ test('Piping through an identity transform stream will close the destination whe
   const ws = new WritableStream();
 
   rs.pipeThrough(ts).pipeTo(ws).then(() => {
-    t.equal(ws.state, 'closed', 'the writable stream was closed');
+    t.end();
   })
   .catch(e => t.error(e));
 });
@@ -62,8 +65,13 @@ test.skip('Piping through a default transform stream causes backpressure to be e
     }
   });
 
+  let enqueue;
+
   const ts = new TransformStream({
-    transform(chunk, enqueue, done) {
+    start(e) {
+      enqueue = e;
+    },
+    transform(chunk, done) {
       enqueue(chunk);
       done();
     }

--- a/reference-implementation/test/readable-byte-stream.js
+++ b/reference-implementation/test/readable-byte-stream.js
@@ -122,15 +122,7 @@ test('ReadableStream with byte source: Test that closing a stream does not relea
   const reader = stream.getReader();
 
   reader.closed.then(() => {
-    try {
-      stream.getReader();
-    } catch(e) {
-      t.equals(e.constructor, TypeError);
-      t.end();
-      return;
-    }
-
-    t.fail('getReader() must fail');
+    t.throws(() => stream.getReader(), TypeError, 'getReader() must throw');
     t.end();
   }).catch(e => {
     t.fail(e);
@@ -153,15 +145,7 @@ test('ReadableStream with byte source: Test that closing a stream does not relea
   const reader = stream.getReader({mode: 'byob'});
 
   reader.closed.then(() => {
-    try {
-      stream.getReader({mode: 'byob'});
-    } catch(e) {
-      t.equals(e.constructor, TypeError);
-      t.end();
-      return;
-    }
-
-    t.fail('getReader() must fail');
+    t.throws(() => stream.getReader({mode: 'byob'}), TypeError, 'getReader() must throw');
     t.end();
   }).catch(e => {
     t.fail(e);
@@ -191,15 +175,7 @@ test('ReadableStream with byte source: Test that erroring a stream does not rele
   }, e => {
     t.equals(e, passedError);
 
-    try {
-      stream.getReader();
-    } catch(e) {
-      t.equals(e.constructor, TypeError);
-      t.end();
-      return;
-    }
-
-    t.fail('getReader() must fail');
+    t.throws(() => stream.getReader(), TypeError, 'getReader() must throw');
     t.end();
   });
 });
@@ -227,15 +203,7 @@ test('ReadableStream with byte source: Test that erroring a stream does not rele
   }, e => {
     t.equals(e, passedError);
 
-    try {
-      stream.getReader({mode: 'byob'});
-    } catch(e) {
-      t.equals(e.constructor, TypeError);
-      t.end();
-      return;
-    }
-
-    t.fail('getReader() must fail');
+    t.throws(() => stream.getReader({mode: 'byob'}), TypeError, 'getReader() must throw');
     t.end();
   });
 });
@@ -247,17 +215,7 @@ test('ReadableStream with byte source: releaseLock() on ReadableStreamReader wit
 
   const reader = stream.getReader();
   reader.read();
-  try {
-    reader.releaseLock();
-  } catch(e) {
-    t.equals(e.constructor, TypeError);
-
-    t.end();
-
-    return;
-  }
-
-  t.fail('reader.releaseLock() didn\'t throw');
+  t.throws(() => reader.releaseLock(), TypeError, 'reader.releaseLock() must throw');
   t.end();
 });
 
@@ -905,17 +863,9 @@ test('ReadableStream with byte source: read(view), then respond() with too big v
       if (pullCount === 0) {
         t.notEqual(controller.byobRequest, undefined, 'byobRequest is not undefined');
 
-        try {
-          controller.byobRequest.respond(2);
-        } catch(e) {
-          t.equals(e.constructor, RangeError);
-
-          t.end();
-          return;
-        }
-
-        t.fail('respond() didn\'t throw');
+        t.throws(() => controller.byobRequest.respond(2), RangeError, 'respond() must throw');
         t.end();
+        return;
       }
 
       ++pullCount;
@@ -1574,15 +1524,7 @@ test('ReadableStream with byte source: A stream must be errored if close()-d bef
     });
   });
 
-  try {
-    controller.close();
-  } catch(e) {
-    t.equals(e.constructor, TypeError);
-    return;
-  }
-
-  t.fail('controller.close() didn\'t throw');
-  t.end();
+  t.throws(() => controller.close(), TypeError, 'controller.close() must throw');
 });
 
 test('ReadableStream with byte source: Throw if close()-ed more than once', t => {
@@ -1601,15 +1543,7 @@ test('ReadableStream with byte source: Throw if close()-ed more than once', t =>
   controller.enqueue(view);
   controller.close();
 
-  try {
-    controller.close();
-  } catch(e) {
-    t.equals(e.constructor, TypeError);
-    t.end();
-    return;
-  }
-
-  t.fail('controller.close() didn\'t throw');
+  t.throws(() => controller.close(), TypeError, 'controller.close() must throw');
   t.end();
 });
 
@@ -1629,15 +1563,7 @@ test('ReadableStream with byte source: Throw on enqueue() after close()', t => {
   controller.enqueue(view);
   controller.close();
 
-  try {
-    controller.enqueue(view);
-  } catch(e) {
-    t.equals(e.constructor, TypeError);
-    t.end();
-    return;
-  }
-
-  t.fail('controller.close() didn\'t throw');
+  t.throws(() => controller.enqueue(view), TypeError, 'controller.close() must throw');
   t.end();
 });
 

--- a/reference-implementation/test/templated/readable-stream-closed.js
+++ b/reference-implementation/test/templated/readable-stream-closed.js
@@ -7,7 +7,8 @@ module.exports = (label, factory) => {
   }
 
   test('piping to a WritableStream in the writable state should close the writable stream', t => {
-    t.plan(4);
+    t.plan(2);
+
     const rs = factory();
 
     const startPromise = Promise.resolve();
@@ -27,18 +28,16 @@ module.exports = (label, factory) => {
     });
 
     startPromise.then(() => {
-      t.equal(ws.state, 'writable', 'writable stream should start in writable state');
-
       return rs.pipeTo(ws).then(() => {
         t.pass('pipeTo promise should be fulfilled');
-        t.equal(ws.state, 'closed', 'writable stream should become closed');
       });
     })
     .catch(e => t.error(e));
   });
 
   test('piping to a WritableStream in the writable state with { preventClose: true } should do nothing', t => {
-    t.plan(3);
+    t.plan(1);
+
     const rs = factory();
 
     const startPromise = Promise.resolve();
@@ -58,11 +57,8 @@ module.exports = (label, factory) => {
     });
 
     startPromise.then(() => {
-      t.equal(ws.state, 'writable', 'writable stream should start in writable state');
-
       return rs.pipeTo(ws, { preventClose: true }).then(() => {
         t.pass('pipeTo promise should be fulfilled');
-        t.equal(ws.state, 'writable', 'writable stream should still be writable');
       });
     })
     .catch(e => t.error(e));

--- a/reference-implementation/test/templated/readable-stream-errored-async-only.js
+++ b/reference-implementation/test/templated/readable-stream-errored-async-only.js
@@ -7,7 +7,8 @@ module.exports = (label, factory, error) => {
   }
 
   test('piping with no options', t => {
-    t.plan(4);
+    t.plan(3);
+
     const rs = factory();
 
     const ws = new WritableStream({
@@ -17,15 +18,15 @@ module.exports = (label, factory, error) => {
     });
 
     rs.pipeTo(ws).catch(e => {
-      t.equal(ws.state, 'errored', 'destination should be errored');
       t.equal(e, error, 'rejection reason of pipeToPromise should be the source error');
-    });
 
-    ws.closed.catch(e => t.equal(e, error), 'rejection reason of dest closed should be the source error');
+      ws.getWriter().closed.catch(e => t.equal(e.constructor, TypeError), 'rejection reason of dest closed should be a TypeError');
+    });
   });
 
   test('piping with { preventAbort: false }', t => {
-    t.plan(4);
+    t.plan(3);
+
     const rs = factory();
 
     const ws = new WritableStream({
@@ -35,15 +36,15 @@ module.exports = (label, factory, error) => {
     });
 
     rs.pipeTo(ws, { preventAbort: false }).catch(e => {
-      t.equal(ws.state, 'errored', 'destination should be errored');
       t.equal(e, error, 'rejection reason of pipeToPromise should be the source error');
-    });
 
-    ws.closed.catch(e => t.equal(e, error), 'rejection reason of dest closed should be the source error');
+      ws.getWriter().closed.catch(e => t.equal(e.constructor, TypeError), 'rejection reason of dest closed should be a TypeError');
+    });
   });
 
   test('piping with { preventAbort: true }', t => {
-    t.plan(2);
+    t.plan(1);
+
     const rs = factory();
 
     const ws = new WritableStream({
@@ -53,7 +54,6 @@ module.exports = (label, factory, error) => {
     });
 
     rs.pipeTo(ws, { preventAbort: true }).catch(e => {
-      t.equal(ws.state, 'writable', 'destination should remain writable');
       t.equal(e, error, 'rejection reason of pipeToPromise should be the source error');
     });
   });

--- a/reference-implementation/test/templated/readable-stream-errored.js
+++ b/reference-implementation/test/templated/readable-stream-errored.js
@@ -7,7 +7,7 @@ module.exports = (label, factory, error) => {
   }
 
   test('piping to a WritableStream in the writable state should abort the writable stream', t => {
-    t.plan(4);
+    t.plan(2);
 
     const rs = factory();
 
@@ -23,18 +23,15 @@ module.exports = (label, factory, error) => {
         t.fail('Unexpected close call');
       },
       abort(reason) {
-        t.equal(reason, error);
+        t.equal(reason, error, 'abort() of the underlying source should be called with error');
       }
     });
 
     startPromise.then(() => {
-      t.equal(ws.state, 'writable');
-
       rs.pipeTo(ws).then(
         () => t.fail('pipeTo promise should not be fulfilled'),
         e => {
           t.equal(e, error, 'pipeTo promise should be rejected with the passed error');
-          t.equal(ws.state, 'errored', 'writable stream should become errored');
         }
       );
     });

--- a/reference-implementation/test/writable-stream-abort.js
+++ b/reference-implementation/test/writable-stream-abort.js
@@ -21,6 +21,7 @@ test('abort() on a released writer rejects', t => {
     t.end();
   },
   r => {
+    t.equal(r.constructor, TypeError, 'abort() should reject with a TypeError');
     t.end();
   });
 });

--- a/reference-implementation/test/writable-stream-abort.js
+++ b/reference-implementation/test/writable-stream-abort.js
@@ -103,7 +103,7 @@ test('Fulfillment value of ws.abort() call must be undefined even if the underly
   });
 });
 
-test('WritableStream if sink\'s abort throws, the promise returned by ws.abort() rejects', t => {
+test('WritableStream if sink\'s abort throws, the promise returned by writer.abort() rejects', t => {
   const errorInSinkAbort = new Error('Sorry, it just wasn\'t meant to be.');
   const ws = new WritableStream({
     abort() {
@@ -114,6 +114,27 @@ test('WritableStream if sink\'s abort throws, the promise returned by ws.abort()
   const writer = ws.getWriter();
 
   const abortPromise = writer.abort(undefined);
+  abortPromise.then(
+    () => {
+      t.fail('abortPromise is fulfilled unexpectedly');
+      t.end();
+    },
+    r => {
+      t.equal(r, errorInSinkAbort, 'rejection reason of abortPromise must be errorInSinkAbort');
+      t.end();
+    }
+  );
+});
+
+test('WritableStream if sink\'s abort throws, the promise returned by ws.abort() rejects', t => {
+  const errorInSinkAbort = new Error('Sorry, it just wasn\'t meant to be.');
+  const ws = new WritableStream({
+    abort() {
+      throw errorInSinkAbort;
+    }
+  });
+
+  const abortPromise = ws.abort(undefined);
   abortPromise.then(
     () => {
       t.fail('abortPromise is fulfilled unexpectedly');

--- a/reference-implementation/test/writable-stream.js
+++ b/reference-implementation/test/writable-stream.js
@@ -20,15 +20,9 @@ test('desiredSize on a released writer', t => {
   const writer = ws.getWriter();
   writer.releaseLock();
 
-  try {
-    writer.desiredSize;
-  } catch(e) {
-    t.equal(e.constructor, TypeError, 'desiredSize should throw a TypeError');
-    t.end();
-    return;
-  }
+  t.throws(() => writer.desiredSize, TypeError, 'desiredSize should throw a TypeError');
 
-  t.fail('writer.desiredSize did not throw');
+  t.end();
 });
 
 test('ws.getWriter() on a closing WritableStream', t => {


### PR DESCRIPTION
- [x] Add WritableStreamDefaultWriter
- [x] Add WritableStreamDefaultController
- [x] Add lock related methods
- [x] Update reader.pipeTo() to use the new WritableStream classes
- [x] Refine reader.pipeTo()'s error handling
- [x] Update TransformStream to use the new WritableStream classes
- [x] Refine TransformStream's error handling
- [x] Add logging to pipeTo() for easier debugging
- [ ] Document the difference between ReadableStream's locking (releaseLock()) and WritableStream's one
  - WritableStream's reader's releaseLock() doesn't check pending writes
- [ ] Add an example for writer.desiredSize