### PR TITLE
Factor out WritableStreamDefaultWriterRelease

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2953,15 +2953,7 @@ lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>st
   1. Let _stream_ be *this*.[[ownerWritableStream]].
   1. If _stream_ is *undefined*, return *undefined*.
   1. Assert: _stream_.[[writer]] is not *undefined*.
-  1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"writable"` or `"closing"`, reject _writer_.[[closedPromise]] with a *TypeError* exception.
-  1. Otherwise, set _writer_.[[closedPromise]] to a new promise rejected with a *TypeError* exception.
-  1. If _state_ is `"writable"` and !
-     WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, reject
-     _writer_.[[readyPromise]] with a *TypeError* exception.
-  1. Otherwise, set _writer_.[[readyPromise]] to a new promise rejected with a *TypeError* exception.
-  1. Set _stream_.[[writer]] to *undefined*.
-  1. Set *this*.[[ownerReadableStream]] to *undefined*.
+  1. Perform ! WritableStreamDefaultWriterRelease(*this*).
 </emu-alg>
 
 <h5 id="default-writer-write" method for="WritableStreamDefaultWriter">write(<var>chunk</var>)</h5>
@@ -3030,6 +3022,25 @@ nothrow>WritableStreamDefaultWriterGetDesiredSize ( <var>writer</var> )</h4>
   1. If _state_ is `"errored"`, return *null*.
   1. If _state_ is `"closed"`, return *0*.
   1. Return ! WritableStreamDefaultControllerGetDesiredSize(_stream_.[[writableStreamController]]).
+</emu-alg>
+
+<h4 id="writable-stream-default-writer-release" aoid="WritableStreamDefaultWriterRelease"
+nothrow>WritableStreamDefaultWriterRelease ( <var>writer</var> )</h4>
+
+<emu-alg>
+  1. Let _stream_ be _writer_.[[ownerWritableStream]].
+  1. Assert: _stream_ is not *undefined*.
+  1. Assert: _stream_.[[writer]] is _writer_.
+  1. Let _releasedError_ be a new *TypeError*.
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"writable"` or `"closing"`, reject _writer_.[[closedPromise]] with _releasedError_.
+  1. Otherwise, set _writer_.[[closedPromise]] to a new promise rejected with _releasedError_.
+  1. If _state_ is `"writable"` and !
+     WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is
+     *true*, reject _writer_.[[readyPromise]] with _releasedError_.
+  1. Otherwise, set _writer_.[[readyPromise]] to a new promise rejected with _releasedError_.
+  1. Set _stream_.[[writer]] to *undefined*.
+  1. Set _writer_.[[ownerReadableStream]] to *undefined*.
 </emu-alg>
 
 <h4 id="writable-stream-default-writer-write" aoid="WritableStreamDefaultWriterWrite"

--- a/reference-implementation/to-upstream-wpts/writable-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/general.js
@@ -80,3 +80,22 @@ test(() => {
     }
   );
 }, 'ws.getWriter() on an errored WritableStream');
+
+promise_test(() => {
+  const ws = new WritableStream({});
+
+  const writer = ws.getWriter();
+  writer.releaseLock();
+
+  return writer.closed.then(
+    v => assert_unreached('writer.closed fulfilled unexpectedly with: ' + v),
+    closedRejection => {
+      assert_equals(closedRejection.name, 'TypeError', 'closed promise should reject with a TypeError');
+      return writer.ready.then(
+        v => assert_unreached('writer.ready fulfilled unexpectedly with: ' + v),
+        readyRejection => assert_equals(readyRejection, closedRejection,
+          'ready promise should reject with the same error')
+      );
+    }
+  );
+}, 'closed and ready on a released writer');


### PR DESCRIPTION
This will help with specifying pipeTo, as seen in #512. This also aligns the spec, tests, and reference implementation on sharing a single error object across both closed and ready promises; previously this was untested and the reference implementation did so but the spec did not.