### PR TITLE
Change async test to a promise_test

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/general.js
@@ -63,7 +63,7 @@ test(() => {
   ws.getWriter();
 }, 'ws.getWriter() on an aborted WritableStream');
 
-test(() => {
+promise_test(() => {
   const ws = new WritableStream({
     start(c) {
       c.error();


### PR DESCRIPTION
The test 'ws.getWriter() on an errored WritableStream' was using the
test() function. However, since it is an asynchronous test it needs to
use the promise_test() function. Fix it.