### PR TITLE
Port constructor tests to web-platform-tests

### DIFF
--- a/reference-implementation/test/writable-stream.js
+++ b/reference-implementation/test/writable-stream.js
@@ -15,42 +15,6 @@ function writeArrayToStream(array, writableStreamWriter) {
   return writableStreamWriter.close();
 }
 
-test('Controller argument is given to start method', t => {
-  let controller;
-  const ws = new WritableStream({
-    start(c) {
-      controller = c;
-    }
-  });
-
-  // Now error the stream after its construction.
-  const passedError = new Error('horrible things');
-  controller.error(passedError);
-
-  const writer = ws.getWriter();
-
-  t.equal(writer.desiredSize, null, 'desiredSize should be null');
-  writer.closed.catch(r => {
-    t.equal(r, passedError, 'ws should be errored by passedError');
-    t.end();
-  });
-});
-
-test('highWaterMark', t => {
-  const ws = new WritableStream({}, {
-    highWaterMark: 1000,
-    size() { return 1; }
-  });
-
-  const writer = ws.getWriter();
-
-  t.equal(writer.desiredSize, 1000, 'desiredSize should be 1000');
-  writer.ready.then(v => {
-    t.equal(v, undefined, 'ready promise should fulfill with undefined');
-    t.end();
-  });
-});
-
 test('Underlying sink\'s write won\'t be called until start finishes', t => {
   let expectWriteCall = false;
 
@@ -192,30 +156,6 @@ test('Underlying sink\'s write or close are never invoked if the promise returne
   }, 100);
 });
 
-test('WritableStream can be constructed with no arguments', t => {
-  t.plan(1);
-  t.doesNotThrow(() => new WritableStream(), 'WritableStream constructed with no errors');
-});
-
-test('WritableStream instances have the correct methods and properties', t => {
-  t.plan(8);
-
-  const ws = new WritableStream();
-
-  const writer = ws.getWriter();
-
-  t.equal(typeof writer.write, 'function', 'has a write method');
-  t.equal(typeof writer.abort, 'function', 'has an abort method');
-  t.equal(typeof writer.close, 'function', 'has a close method');
-
-  t.equal(writer.desiredSize, 1, 'desiredSize starts out 1');
-
-  t.ok(writer.ready, 'has a ready property');
-  t.ok(writer.ready.then, 'ready property is a thenable');
-  t.ok(writer.closed, 'has a closed property');
-  t.ok(writer.closed.then, 'closed property is thenable');
-});
-
 test('WritableStream with simple input, processed asynchronously', t => {
   t.plan(1);
 
@@ -269,22 +209,6 @@ test('WritableStream with simple input, processed synchronously', t => {
     () => t.deepEqual(storage, input, 'correct data was relayed to underlying sink'),
     r => t.fail(r)
   );
-});
-
-test('WritableStream is writable and ready fulfills immediately if the strategy does not apply backpressure', t => {
-  const ws = new WritableStream({}, {
-    highWaterMark: Infinity,
-    size() { return 0; }
-  });
-
-  const writer = ws.getWriter();
-
-  t.equal(writer.desiredSize, Infinity, 'desiredSize should be Infinity');
-
-  writer.ready.then(() => {
-    t.pass('ready promise was fulfilled');
-    t.end();
-  });
 });
 
 test('Fulfillment value of ws.write() call must be undefined even if the underlying sink returns a non-undefined ' +

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.https.html
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+<script src="../resources/test-initializer.js"></script>
+
+<script src="constructor.js"></script>
+<script>
+'use strict';
+worker_test('constructor.js');
+</script>

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -1,0 +1,73 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+promise_test(() => {
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+
+  // Now error the stream after its construction.
+  const passedError = new Error('horrible things');
+  controller.error(passedError);
+
+  const writer = ws.getWriter();
+
+  assert_equals(writer.desiredSize, null, 'desiredSize should be null');
+  return writer.closed.catch(r => {
+    assert_equals(r, passedError, 'ws should be errored by passedError');
+  });
+}, 'controller argument should be passed to start method');
+
+promise_test(() => {
+  const ws = new WritableStream({}, {
+    highWaterMark: 1000,
+    size() { return 1; }
+  });
+
+  const writer = ws.getWriter();
+
+  assert_equals(writer.desiredSize, 1000, 'desiredSize should be 1000');
+  return writer.ready.then(v => {
+    assert_equals(v, undefined, 'ready promise should fulfill with undefined');
+  });
+}, 'highWaterMark should be copied to desiredSize');
+
+promise_test(() => {
+  const ws = new WritableStream({}, {
+    highWaterMark: Infinity,
+    size() { return 0; }
+  });
+
+  const writer = ws.getWriter();
+
+  assert_equals(writer.desiredSize, Infinity, 'desiredSize should be Infinity');
+
+  return writer.ready;
+}, 'WritableStream should be writable and ready should fulfill immediately if the strategy does not apply backpressure');
+
+test(() => {
+  const ws = new WritableStream();
+}, 'WritableStream should be constructible with no arguments');
+
+test(() => {
+  const ws = new WritableStream({});
+
+  const writer = ws.getWriter();
+
+  assert_equals(typeof writer.write, 'function', 'writer should have a write method');
+  assert_equals(typeof writer.abort, 'function', 'writer should have an abort method');
+  assert_equals(typeof writer.close, 'function', 'writer should have a close method');
+
+  assert_equals(writer.desiredSize, 1, 'desiredSize should start at 1');
+
+  assert_idl_attribute(writer, 'ready', 'writer should have a ready attribute');
+  assert_equals(typeof writer.ready.then, 'function', 'ready attribute should be thenable');
+  assert_idl_attribute(writer, 'closed', 'writer should have a closed attribute');
+  assert_equals(typeof writer.closed.then, 'function', 'closed attribute should be thenable');
+}, 'WritableStream instances should have standard methods and properties');

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -36,7 +36,7 @@ promise_test(() => {
   return writer.ready.then(v => {
     assert_equals(v, undefined, 'ready promise should fulfill with undefined');
   });
-}, 'highWaterMark should be copied to desiredSize');
+}, 'highWaterMark should be reflected to desiredSize');
 
 promise_test(() => {
   const ws = new WritableStream({}, {
@@ -66,8 +66,8 @@ test(() => {
 
   assert_equals(writer.desiredSize, 1, 'desiredSize should start at 1');
 
-  assert_idl_attribute(writer, 'ready', 'writer should have a ready attribute');
-  assert_equals(typeof writer.ready.then, 'function', 'ready attribute should be thenable');
-  assert_idl_attribute(writer, 'closed', 'writer should have a closed attribute');
-  assert_equals(typeof writer.closed.then, 'function', 'closed attribute should be thenable');
+  assert_not_equals(typeof writer.ready, 'undefined', 'writer should have a ready property');
+  assert_equals(typeof writer.ready.then, 'function', 'ready property should be thenable');
+  assert_not_equals(typeof writer.closed, 'undefined', 'writer should have a closed property');
+  assert_equals(typeof writer.closed.then, 'function', 'closed property should be thenable');
 }, 'WritableStream instances should have standard methods and properties');


### PR DESCRIPTION
Move tests relating to the WritableStream constructor and
newly-constructed objects to the testharness.js framework.

Only syntactic and style changes have been made in this CL. There are no
semantic changes, except that some property existence checks have been
changed to use assert_idl_attribute(), which is stricter. Also where the
original test verified that a promise resolved, the ported version just
returns the promise and lets the test harness check it.