### PR TITLE
Port close() tests to web-platform-tests

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/close.https.html
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+<script src="../resources/test-initializer.js"></script>
+
+<script src="close.js"></script>
+<script>
+'use strict';
+worker_test('close.js');
+</script>

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -1,0 +1,87 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+promise_test(t => {
+  const ws = new WritableStream({
+    close() {
+      return 'Hello';
+    }
+  });
+
+  const writer = ws.getWriter();
+
+  const closePromise = writer.close('a');
+  return closePromise.then(value => assert_equals(value, undefined, 'fulfillment value must be undefined'));
+}, 'fulfillment value of ws.close() call must be undefined even if the underlying sink returns a non-undefined ' +
+    'value');
+
+async_test(t => {
+  const thrownError = new Error('throw me');
+  const ws = new WritableStream({
+    close() {
+      throw thrownError;
+    }
+  });
+
+  const writer = ws.getWriter();
+
+  promise_rejects(
+      t, thrownError, writer.close(), 'close promise', 'close promise should be rejected with the thrown error');
+
+  setTimeout(() => {
+    promise_rejects(t, thrownError, writer.closed, 'closed', 'closed should stay rejected');
+    t.done();
+  }, 0);
+}, 'when sink throws an error while closing, the stream should become errored');
+
+async_test(t => {
+  const passedError = new Error('error me');
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    },
+    close() {
+      return new Promise(resolve => setTimeout(resolve, 50));
+    }
+  });
+
+  const writer = ws.getWriter();
+
+  writer.close();
+  setTimeout(() => controller.error(passedError), 10);
+
+  promise_rejects(
+      t, passedError, writer.closed, 'closed promise', 'closed promise should be rejected with the passed error');
+
+  setTimeout(() => {
+    promise_rejects(t, passedError, writer.closed, 'closed', 'closed should stay rejected');
+    t.done();
+  }, 70);
+}, 'when sink calls error asynchronously while closing, the stream should become errored');
+
+async_test(t => {
+  const passedError = new Error('error me');
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    },
+    close() {
+      controller.error(passedError);
+    }
+  });
+
+  const writer = ws.getWriter();
+
+  promise_rejects(
+      t, passedError, writer.close(), 'close promise', 'close promise should be rejected with the passed error');
+
+  setTimeout(() => {
+    promise_rejects(t, passedError, writer.closed, 'closed', 'closed should stay rejected');
+    t.done();
+  }, 0);
+}, 'when sink calls error synchronously while closing, the stream should become errored');

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -29,10 +29,10 @@ async_test(t => {
   const writer = ws.getWriter();
 
   promise_rejects(
-      t, thrownError, writer.close(), 'close promise', 'close promise should be rejected with the thrown error');
+      t, thrownError, writer.close(), 'close promise should be rejected with the thrown error');
 
   setTimeout(() => {
-    promise_rejects(t, thrownError, writer.closed, 'closed', 'closed should stay rejected');
+    promise_rejects(t, thrownError, writer.closed, 'closed should stay rejected');
     t.done();
   }, 0);
 }, 'when sink throws an error while closing, the stream should become errored');
@@ -55,10 +55,10 @@ async_test(t => {
   setTimeout(() => controller.error(passedError), 10);
 
   promise_rejects(
-      t, passedError, writer.closed, 'closed promise', 'closed promise should be rejected with the passed error');
+      t, passedError, writer.closed, 'closed promise should be rejected with the passed error');
 
   setTimeout(() => {
-    promise_rejects(t, passedError, writer.closed, 'closed', 'closed should stay rejected');
+    promise_rejects(t, passedError, writer.closed, 'closed should stay rejected');
     t.done();
   }, 70);
 }, 'when sink calls error asynchronously while closing, the stream should become errored');
@@ -78,10 +78,10 @@ async_test(t => {
   const writer = ws.getWriter();
 
   promise_rejects(
-      t, passedError, writer.close(), 'close promise', 'close promise should be rejected with the passed error');
+      t, passedError, writer.close(), 'close promise should be rejected with the passed error');
 
   setTimeout(() => {
-    promise_rejects(t, passedError, writer.closed, 'closed', 'closed should stay rejected');
+    promise_rejects(t, passedError, writer.closed, 'closed should stay rejected');
     t.done();
   }, 0);
 }, 'when sink calls error synchronously while closing, the stream should become errored');


### PR DESCRIPTION
Move tests relating to the WritableStream sink's close() method to the
testharness.js framework.

To reduce the risk of functional changes, changes to the tests are
intentionally minimal. The only kinds of changes are:

* Use testharness.js syntax
* Match web-platform-tests style

async_test was used where necessary to retain the existing
semantics. It will be changed to promise_test in a separate commit.