### PR TITLE
No need to reject writePromise in TransformStreamErrorInternal

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -87,13 +87,11 @@ function TransformStreamResolveWrite(transformStream) {
   assert(transformStream._transforming === true);
 
   assert(transformStream._resolveWrite !== undefined);
-  assert(transformStream._rejectWrite !== undefined);
 
   transformStream._transforming = false;
 
   transformStream._resolveWrite(undefined);
   transformStream._resolveWrite = undefined;
-  transformStream._rejectWrite = undefined;
 
   TransformStreamTransformIfNeeded(transformStream);
 }
@@ -120,10 +118,6 @@ function TransformStreamErrorInternal(transformStream, e) {
   }
 
   transformStream._chunk = undefined;
-
-  if (transformStream._rejectWriter !== undefined) {
-    transformStream._rejectWriter(e);
-  }
 }
 
 function TransformStreamTransformIfNeeded(transformStream) {
@@ -181,14 +175,12 @@ class TransformStreamSink {
     assert(transformStream._chunk === undefined);
 
     assert(transformStream._resolveWrite === undefined);
-    assert(transformStream._rejectWrite === undefined);
 
     transformStream._chunkPending = true;
     transformStream._chunk = chunk;
 
     const promise = new Promise(resolve => {
       transformStream._resolveWrite = resolve;
-      transformStream._rejectWrite = resolve;
     });
 
     TransformStreamTransformIfNeeded(transformStream);
@@ -211,7 +203,6 @@ class TransformStreamSink {
     assert(transformStream._chunk === undefined);
 
     assert(transformStream._resolveWrite === undefined);
-    assert(transformStream._rejectWrite === undefined);
 
     assert(transformStream._transforming === false);
 
@@ -303,7 +294,6 @@ module.exports = class TransformStream {
     this._readableClosed = false;
 
     this._resolveWrite = undefined;
-    this._rejectWrite = undefined;
 
     this._chunkPending = false;
     this._chunk = undefined;


### PR DESCRIPTION
Follow up for #519

As we error the writable stream in TransformStreamErrorInternal, we don't need to take care of the promise returned from the underlying sink write().