### PR TITLE
Eliminate usages of async_test

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/close.https.html
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.https.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script src="../resources/test-initializer.js"></script>
+<script src="../resources/test-utils.js"></script>
 
 <script src="close.js"></script>
 <script>

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -1,7 +1,8 @@
 'use strict';
 
 if (self.importScripts) {
-  self.importScripts('/resources/testharness.js', '..resources/test-utils.js');
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
 }
 
 promise_test(t => {

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (self.importScripts) {
-  self.importScripts('/resources/testharness.js');
+  self.importScripts('/resources/testharness.js', '..resources/test-utils.js');
 }
 
 promise_test(t => {
@@ -13,12 +13,12 @@ promise_test(t => {
 
   const writer = ws.getWriter();
 
-  const closePromise = writer.close('a');
+  const closePromise = writer.close();
   return closePromise.then(value => assert_equals(value, undefined, 'fulfillment value must be undefined'));
 }, 'fulfillment value of ws.close() call must be undefined even if the underlying sink returns a non-undefined ' +
     'value');
 
-async_test(t => {
+promise_test(t => {
   const passedError = new Error('error me');
   let controller;
   const ws = new WritableStream({
@@ -26,25 +26,23 @@ async_test(t => {
       controller = c;
     },
     close() {
-      return new Promise(resolve => setTimeout(resolve, 50));
+      return delay(50);
     }
   });
 
   const writer = ws.getWriter();
 
   writer.close();
-  setTimeout(() => controller.error(passedError), 10);
 
-  promise_rejects(
-      t, passedError, writer.closed, 'closed promise should be rejected with the passed error');
-
-  setTimeout(() => {
-    promise_rejects(t, passedError, writer.closed, 'closed should stay rejected');
-    t.done();
-  }, 70);
+  return Promise.all([
+    delay(10).then(() => controller.error(passedError)),
+    promise_rejects(t, passedError, writer.closed,
+                    'closed promise should be rejected with the passed error'),
+    delay(70).then(() => promise_rejects(t, passedError, writer.closed, 'closed should stay rejected'))
+  ]);
 }, 'when sink calls error asynchronously while closing, the stream should become errored');
 
-async_test(t => {
+promise_test(t => {
   const passedError = new Error('error me');
   let controller;
   const ws = new WritableStream({
@@ -58,11 +56,6 @@ async_test(t => {
 
   const writer = ws.getWriter();
 
-  promise_rejects(
-      t, passedError, writer.close(), 'close promise should be rejected with the passed error');
-
-  setTimeout(() => {
-    promise_rejects(t, passedError, writer.closed, 'closed should stay rejected');
-    t.done();
-  }, 0);
+  return promise_rejects(t, passedError, writer.close(), 'close promise should be rejected with the passed error')
+      .then(() => promise_rejects(t, passedError, writer.closed, 'closed should stay rejected'));
 }, 'when sink calls error synchronously while closing, the stream should become errored');

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.https.html
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.https.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script src="../resources/test-initializer.js"></script>
+<script src="../resources/test-utils.js"></script>
 
 <script src="start.js"></script>
 <script>

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.https.html
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.https.html
@@ -5,6 +5,7 @@
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script src="../resources/test-initializer.js"></script>
 <script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
 
 <script src="start.js"></script>
 <script>

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.js
@@ -1,25 +1,20 @@
 'use strict';
 
 if (self.importScripts) {
-  self.importScripts('/resources/testharness.js', '../resources/test-utils.js');
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
+  self.importScripts('../resources/recording-streams.js');
 }
 
 promise_test(t => {
   let expectWriteCall = false;
 
   let resolveStartPromise;
-  const ws = new WritableStream({
+  const ws = recordingWritableStream({
     start() {
       return new Promise(resolve => {
         resolveStartPromise = resolve;
       });
-    },
-    write(chunk) {
-      assert_true(expectWriteCall, 'write should not be called until start promise resolves');
-      assert_equals(chunk, 'a', 'chunk should be the value passed to write');
-    },
-    close() {
-      assert_unreached('close should not be called');
     }
   });
 
@@ -29,40 +24,38 @@ promise_test(t => {
   writer.write('a');
   assert_equals(writer.desiredSize, 0, 'desiredSize should be 0 after writer.write()');
 
-  // Wait and verify that write isn't be called.
-  return delay(100).then(() => {
-    expectWriteCall = true;
-    resolveStartPromise();
-    return writer.ready;
-  });
+  // Wait and verify that write isn't called.
+  return delay(100)
+      .then(() => {
+        expectWriteCall = true;
+        assert_array_equals(ws.events, [], 'write should not be called until start promise resolves');
+        resolveStartPromise();
+        return writer.ready;
+      })
+      .then(() =>  assert_array_equals(ws.events, ['write', 'a'],
+                                       'write should not be called until start promise resolves'));
 }, 'underlying sink\'s write should not be called until start finishes');
 
 promise_test(t => {
   let expectCloseCall = false;
 
   let resolveStartPromise;
-  const ws = new WritableStream({
+  const ws = recordingWritableStream({
     start() {
       return new Promise(resolve => {
         resolveStartPromise = resolve;
       });
     },
-    write() {
-      assert_unreached('write could not be called');
-    },
-    close() {
-      assert_true(expectCloseCall, 'close should not be called until start promise resolves');
-    }
   });
 
   const writer = ws.getWriter();
 
-  writer.close('a');
+  writer.close();
   assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
 
-  // Wait and see that write won't be called.
+  // Wait and verify that write isn't called.
   return delay(100).then(() => {
-    expectCloseCall = true;
+    assert_array_equals(ws.events, [], 'close should not be called until start promise resolves');
     resolveStartPromise();
     return writer.closed;
   });
@@ -71,34 +64,35 @@ promise_test(t => {
 test(t => {
   const passedError = new Error('horrible things');
 
+  let writeCalled = false;
+  let closeCalled = false;
   assert_throws(passedError, () => {
+    // recordingWritableStream cannot be used here because the exception in the
+    // constructor prevents assigning the object to a variable.
     new WritableStream({
       start() {
         throw passedError;
       },
       write() {
-        assert_unreached('write should not be called');
+        writeCalled = true;
       },
       close() {
-        assert_unreached('close should not be called');
+        closeCalled = true;
       }
     });
   }, 'constructor should throw passedError');
+  assert_false(writeCalled, 'write should not be called');
+  assert_false(closeCalled, 'close should not be called');
 }, 'underlying sink\'s write or close should not be called if start throws');
 
 promise_test(t => {
-  new WritableStream({
+  const ws = recordingWritableStream({
     start() {
       return Promise.reject();
     },
-    write() {
-      assert_unreached('write should not be called');
-    },
-    close() {
-      assert_unreached('close should not be called');
-    }
   });
 
-  // Wait and verify that write or close won't be called.
-  return delay(100);
+  // Wait and verify that write or close aren't called.
+  return delay(100)
+      .then(() => assert_array_equals(ws.events, [], 'write and close should not be called'));
 }, 'underlying sink\'s write or close should not be invoked if the promise returned by start is rejected');

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.js
@@ -7,8 +7,6 @@ if (self.importScripts) {
 }
 
 promise_test(t => {
-  let expectWriteCall = false;
-
   let resolveStartPromise;
   const ws = recordingWritableStream({
     start() {
@@ -27,7 +25,6 @@ promise_test(t => {
   // Wait and verify that write isn't called.
   return delay(100)
       .then(() => {
-        expectWriteCall = true;
         assert_array_equals(ws.events, [], 'write should not be called until start promise resolves');
         resolveStartPromise();
         return writer.ready;
@@ -37,8 +34,6 @@ promise_test(t => {
 }, 'underlying sink\'s write should not be called until start finishes');
 
 promise_test(t => {
-  let expectCloseCall = false;
-
   let resolveStartPromise;
   const ws = recordingWritableStream({
     start() {

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.https.html
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.https.html
@@ -5,6 +5,7 @@
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script src="../resources/test-initializer.js"></script>
 <script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
 
 <script src="write.js"></script>
 <script>

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.https.html
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.https.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script src="../resources/test-initializer.js"></script>
+<script src="../resources/test-utils.js"></script>
 
 <script src="write.js"></script>
 <script>

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -195,6 +195,6 @@ promise_test(t => {
 
     return writePromise
         .then(() =>
-        assert_equals(writeCount, numberOfWrites, `should have called sink's write ${numberOfWrites} times`));
+          assert_equals(writeCount, numberOfWrites, `should have called sink's write ${numberOfWrites} times`));
   });
 }, 'a large queue of writes should be processed completely');


### PR DESCRIPTION
Replace all usages of async_test in the wpt writable-streams tests with
promise_test. promise_test is easier to work with than async_test.

Also remove the 'a' from close('a') (it did nothing).