### PR TITLE
Port test that sink methods are called as methods

### DIFF
--- a/reference-implementation/test/writable-stream.js
+++ b/reference-implementation/test/writable-stream.js
@@ -103,39 +103,3 @@ test('If close is called on a WritableStream in waiting state, ready will be ful
     });
   }, 0);
 });
-
-test('WritableStream should call underlying sink methods as methods', t => {
-  t.plan(5);
-
-  class Sink {
-    start() {
-      // Called twice
-      t.equal(this, theSink, 'start() should be called with the correct this');
-    }
-
-    write() {
-      t.equal(this, theSink, 'pull() should be called with the correct this');
-    }
-
-    close() {
-      t.equal(this, theSink, 'close() should be called with the correct this');
-    }
-
-    abort() {
-      t.equal(this, theSink, 'abort() should be called with the correct this');
-    }
-  }
-
-  const theSink = new Sink();
-  theSink.debugName = 'the sink object passed to the constructor';
-  const ws = new WritableStream(theSink);
-
-  const writer = ws.getWriter();
-
-  writer.write('a');
-  writer.close();
-
-  const ws2 = new WritableStream(theSink);
-  const writer2 = ws2.getWriter();
-  writer2.abort();
-});

--- a/reference-implementation/to-upstream-wpts/writable-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/general.js
@@ -106,6 +106,8 @@ promise_test(t => {
   ['start', 'write', 'close', 'abort'].forEach(methodName =>
        promises[methodName] = new Promise(resolve => resolvers[methodName] = resolve));
 
+  // Calls to Sink methods after the first are implicitly ignored. Only the first value that is passed to the resolver
+  // is used.
   class Sink {
     start() {
       // Called twice


### PR DESCRIPTION
Port the test 'WritableStream should call underlying sink methods as
methods' to web-platform-tests. The tape test relied on assertions
working after the test function had completed. The new test creates a
promise for each method, then fulfills it with the value of 'this'. The
main logic then verifies that each promise is fulfilled with the correct
value of 'this'.