### PR TITLE
Add controller arguments to sink write and close

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2549,14 +2549,14 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
     <li> <code>start(controller)</code> is called immediately, and should perform any actions necessary to acquire
       access to the <a>underlying sink</a>. If this process is asynchronous, it can return a promise to signal success
       or failure.
-    <li> <code>write(chunk)</code> is called when a new <a>chunk</a> of data is ready to be written to the
+    <li> <code>write(chunk, controller)</code> is called when a new <a>chunk</a> of data is ready to be written to the
       <a>underlying sink</a>. It can return a promise to signal success or failure of the write operation. The stream
       implementation guarantees that this method will be called only after previous writes have succeeded, and never
       after <code>close</code> or <code>abort</code> is called.
-    <li> <code>close()</code> is called after the producer signals that they are done writing chunks to the stream, and
-      all queued-up writes successfully complete. It should perform any actions necessary to finalize writes to the
-      <a>underlying sink</a>, and release access to it. If this process is asynchronous, it can return a promise to
-      signal success or failure. The stream implementation guarantees that this method will be called only after all
+    <li> <code>close(controller)</code> is called after the producer signals that they are done writing chunks to the
+      stream, and all queued-up writes successfully complete. It should perform any actions necessary to finalize writes
+      to the <a>underlying sink</a>, and release access to it. If this process is asynchronous, it can return a promise
+      to signal success or failure. The stream implementation guarantees that this method will be called only after all
       queued-up writes have succeeded.
     <li> <code>abort(reason)</code> is called when the producer signals they wish to abruptly close the stream
       and put it in an errored state. It should clean up any held resources, much like <code>close</code>, but perhaps
@@ -2565,8 +2565,8 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
       success or failure. If no abort method is passed, by default the <code>close</code> method will be called instead.
   </ul>
 
-  The <code>controller</code> object passed to <code>start</code> is an instance of {{WritableStreamDefaultController}},
-  and has the ability to error the stream.
+  The <code>controller</code> object passed to <code>start</code>, <code>write</code> and <code>close</code> is an
+  instance of {{WritableStreamDefaultController}}, and has the ability to error the stream.
 
   The constructor also accepts a second argument containing the <a>queuing strategy</a> object with
   two properties: a non-negative number <code>highWaterMark</code>, and a function <code>size(chunk)</code>. The
@@ -3181,7 +3181,7 @@ nothrow>WritableStreamDefaultControllerAbort ( <var>controller</var>, <var>reaso
 <emu-alg>
   1. Set _controller_.[[queue]] to a new empty List.
   1. Let _sinkAbortPromise_ be ! PromiseInvokeOrFallbackOrNoop(_controller_.[[underlyingSink]],
-     `"abort"`, « _reason_ », `"close"`, « »).
+     `"abort"`, « _reason_ », `"close"`, « _controller_ »).
   1. Return the result of transforming _sinkAbortPromise_ by a fulfillment handler that returns
     *undefined*.
 </emu-alg>
@@ -3257,7 +3257,7 @@ nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h
   1. Assert: _stream_.[[state]] is `"closing"`.
   1. Perform ! DequeueValue(_controller_.[[queue]]).
   1. Assert: _controller_.[[queue]] is empty.
-  1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`).
+  1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`, « ‍_controller_ »).
   1. Upon fulfillment of _sinkClosePromise_,
     1. If _stream_.[[state]] is not `"closing"`, return.
     1. Perform ! WritableStreamFulfillWriteRequest(_stream_).
@@ -3271,7 +3271,8 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
 
 <emu-alg>
   1. Set _controller_.[[writing]] to *true*.
-  1. Let _sinkWritePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"write"`, « ‍_chunk_ »).
+  1. Let _sinkWritePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"write"`, « ‍_chunk_,
+  _controller_ »).
   1. Upon fulfillment of _sinkWritePromise_,
     1. Let _stream_ be _controller_.[[controlledWritableStream]].
     1. Let _state_ be _stream_.[[state]].

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -483,7 +483,8 @@ class WritableStreamDefaultController {
 function WritableStreamDefaultControllerAbort(controller, reason) {
   controller._queue = [];
 
-  const sinkAbortPromise = PromiseInvokeOrFallbackOrNoop(controller._underlyingSink, 'abort', [reason], 'close', []);
+  const sinkAbortPromise = PromiseInvokeOrFallbackOrNoop(controller._underlyingSink, 'abort', [reason],
+                                                         'close', [controller]);
   return sinkAbortPromise.then(() => undefined);
 }
 
@@ -590,7 +591,7 @@ function WritableStreamDefaultControllerProcessClose(controller) {
   DequeueValue(controller._queue);
   assert(controller._queue.length === 0, 'queue must be empty once the final write record is dequeued');
 
-  const sinkClosePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'close');
+  const sinkClosePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'close', [controller]);
   sinkClosePromise.then(
     () => {
       if (stream._state !== 'closing') {
@@ -610,7 +611,7 @@ function WritableStreamDefaultControllerProcessClose(controller) {
 function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
   controller._writing = true;
 
-  const sinkWritePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'write', [chunk]);
+  const sinkWritePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'write', [chunk, controller]);
   sinkWritePromise.then(
     () => {
       const stream = controller._controlledWritableStream;

--- a/reference-implementation/test/writable-stream-abort.js
+++ b/reference-implementation/test/writable-stream-abort.js
@@ -276,7 +276,7 @@ test('Aborting a WritableStream after it is closed is a no-op', t => {
 test('WritableStream should call underlying sink\'s close if no abort is supplied', t => {
   const ws = new WritableStream({
     close(...args) {
-      t.equal(args.length, 0, 'close() was called (with no arguments)');
+      t.equal(args.length, 1, 'close() was called (with one argument)');
       t.end();
     }
   });

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -23,10 +23,8 @@ promise_test(t => {
   const passedError = new Error('error me');
   let controller;
   const ws = new WritableStream({
-    start(c) {
+    close(c) {
       controller = c;
-    },
-    close() {
       return delay(50);
     }
   });
@@ -45,12 +43,8 @@ promise_test(t => {
 
 promise_test(t => {
   const passedError = new Error('error me');
-  let controller;
   const ws = new WritableStream({
-    start(c) {
-      controller = c;
-    },
-    close() {
+    close(controller) {
       controller.error(passedError);
     }
   });

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -25,6 +25,38 @@ promise_test(() => {
 }, 'controller argument should be passed to start method');
 
 promise_test(() => {
+  const passedError = new Error('tea and scones');
+  const ws = new WritableStream({
+    write(chunk, controller) {
+      controller.error(passedError);
+    }
+  });
+
+  const writer = ws.getWriter();
+  writer.write('a');
+
+  return writer.closed.catch(r => {
+    assert_equals(r, passedError, 'ws should be errored by passedError');
+  });
+}, 'controller argument should be passed to write method');
+
+promise_test(() => {
+  const passedError = new Error('jelly and ice cream');
+  const ws = new WritableStream({
+    close(controller) {
+      controller.error(passedError);
+    }
+  });
+
+  const writer = ws.getWriter();
+  writer.close();
+
+  return writer.closed.catch(r => {
+    assert_equals(r, passedError, 'ws should be errored by passedError');
+  });
+}, 'controller argument should be passed to close method');
+
+promise_test(() => {
   const ws = new WritableStream({}, {
     highWaterMark: 1000,
     size() { return 1; }

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -24,36 +24,30 @@ promise_test(() => {
   });
 }, 'controller argument should be passed to start method');
 
-promise_test(() => {
-  const passedError = new Error('tea and scones');
+promise_test(t => {
   const ws = new WritableStream({
     write(chunk, controller) {
-      controller.error(passedError);
+      controller.error(new Error());
     }
   });
 
   const writer = ws.getWriter();
   writer.write('a');
 
-  return writer.closed.catch(r => {
-    assert_equals(r, passedError, 'ws should be errored by passedError');
-  });
+  return promise_rejects(t, new Error(), writer.closed, 'controller.error() in write() should errored the stream');
 }, 'controller argument should be passed to write method');
 
-promise_test(() => {
-  const passedError = new Error('jelly and ice cream');
+promise_test(t => {
   const ws = new WritableStream({
     close(controller) {
-      controller.error(passedError);
+      controller.error(new Error());
     }
   });
 
   const writer = ws.getWriter();
   writer.close();
 
-  return writer.closed.catch(r => {
-    assert_equals(r, passedError, 'ws should be errored by passedError');
-  });
+  return promise_rejects(t, new Error(), writer.closed, 'controller.error() in close() should error the stream');
 }, 'controller argument should be passed to close method');
 
 promise_test(() => {


### PR DESCRIPTION
Previously the controller was only passed to the start() method of a
WritableStream sink. It can be convenient to omit the start() method if
no processing is needed. Pass the controller argument to the write() and
close() methods so that it can be used without implementing start().