### PR TITLE
Lint fixes to new web-platform-tests

### DIFF
--- a/reference-implementation/to-upstream-wpts/resources/recording-streams.js
+++ b/reference-implementation/to-upstream-wpts/resources/recording-streams.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 self.recordingReadableStream = (extras = {}, strategy) => {
   let controllerToCopyOver;

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -49,10 +49,11 @@ promise_test(() => {
   assert_equals(writer.desiredSize, Infinity, 'desiredSize should be Infinity');
 
   return writer.ready;
-}, 'WritableStream should be writable and ready should fulfill immediately if the strategy does not apply backpressure');
+}, 'WritableStream should be writable and ready should fulfill immediately if the strategy does not apply ' +
+    'backpressure');
 
 test(() => {
-  const ws = new WritableStream();
+  new WritableStream();
 }, 'WritableStream should be constructible with no arguments');
 
 test(() => {

--- a/reference-implementation/to-upstream-wpts/writable-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/general.js
@@ -9,7 +9,7 @@ test(() => {
   const writer = ws.getWriter();
   writer.releaseLock();
 
-  assert_throws(new TypeError, () => writer.desiredSize, 'desiredSize should throw a TypeError');
+  assert_throws(new TypeError(), () => writer.desiredSize, 'desiredSize should throw a TypeError');
 }, 'desiredSize on a released writer');
 
 test(() => {
@@ -50,7 +50,7 @@ promise_test(() => {
     writer.releaseLock();
 
     ws.getWriter();
-  })
+  });
 }, 'ws.getWriter() on a closed WritableStream');
 
 test(() => {
@@ -101,8 +101,8 @@ promise_test(() => {
 }, 'closed and ready on a released writer');
 
 promise_test(t => {
-  let promises = {};
-  let resolvers = {};
+  const promises = {};
+  const resolvers = {};
   ['start', 'write', 'close', 'abort'].forEach(methodName =>
        promises[methodName] = new Promise(resolve => resolvers[methodName] = resolve));
 

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.js
@@ -29,8 +29,8 @@ promise_test(t => {
         resolveStartPromise();
         return writer.ready;
       })
-      .then(() =>  assert_array_equals(ws.events, ['write', 'a'],
-                                       'write should not be called until start promise resolves'));
+      .then(() => assert_array_equals(ws.events, ['write', 'a'],
+                                      'write should not be called until start promise resolves'));
 }, 'underlying sink\'s write should not be called until start finishes');
 
 promise_test(t => {
@@ -40,7 +40,7 @@ promise_test(t => {
       return new Promise(resolve => {
         resolveStartPromise = resolve;
       });
-    },
+    }
   });
 
   const writer = ws.getWriter();
@@ -84,7 +84,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     start() {
       return Promise.reject();
-    },
+    }
   });
 
   // Wait and verify that write or close aren't called.

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -35,7 +35,6 @@ promise_test(t => {
 }, 'WritableStream should complete asynchronous writes before close resolves');
 
 promise_test(t => {
-  let storage;
   const ws = recordingWritableStream();
 
   const writer = ws.getWriter();


### PR DESCRIPTION
Not all issues reported by eslint have been fixed:
* eslint cannot load scripts from importScripts, so sees all those
  symbols as undefined.
* eslint does not know about 'self'.
* 'Expected to return a value at the end of this method' for sink
  methods in recording-streams.js was harmless so not fixed.
* write(chunk) gives an error "'chunk' is defined but never used". Aids
  readability so not fixed.
* "'t' is defined but never used" is reported for many tests. t
  parameter has been retained for consistency.
* "Arrow function should not return assignment" ignored.