### PR TITLE
Add tests for WritableStreamDefaultWriter and Controller constructors

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -143,4 +143,4 @@ test(() => {
   const WritableStreamDefaultWriter = writer.constructor;
   assert_throws(new TypeError(), () => new WritableStreamDefaultWriter(stream),
                 'constructor should throw a TypeError exception');
-}, 'WritableStreamDefaultController constructor should throw when stream argument is locked');
+}, 'WritableStreamDefaultWriter constructor should throw when stream argument is locked');

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -98,3 +98,49 @@ test(() => {
   assert_not_equals(typeof writer.closed, 'undefined', 'writer should have a closed property');
   assert_equals(typeof writer.closed.then, 'function', 'closed property should be thenable');
 }, 'WritableStream instances should have standard methods and properties');
+
+test(() => {
+  ['WritableStreamDefaultWriter', 'WritableStreamDefaultController'].forEach(c =>
+      assert_equals(typeof self[c], 'undefined', `${c} should not be exported`));
+}, 'private constructors should not be exported');
+
+test(() => {
+  let WritableStreamDefaultController;
+  new WritableStream({
+    start(c) {
+      WritableStreamDefaultController = c.constructor;
+    }
+  });
+
+  assert_throws(new TypeError(), () => new WritableStreamDefaultController({}),
+                'constructor should throw a TypeError exception');
+}, 'WritableStreamDefaultController constructor should throw unless passed a WritableStream');
+
+test(() => {
+  let WritableStreamDefaultController;
+  const stream = new WritableStream({
+    start(c) {
+      WritableStreamDefaultController = c.constructor;
+    }
+  });
+
+  assert_throws(new TypeError(), () => new WritableStreamDefaultController(stream),
+                'constructor should throw a TypeError exception');
+}, 'WritableStreamDefaultController constructor should throw when passed an initalised WritableStream');
+
+test(() => {
+  const stream = new WritableStream();
+  const writer = stream.getWriter();
+  const WritableStreamDefaultWriter = writer.constructor;
+  writer.releaseLock();
+  assert_throws(new TypeError(), () => new WritableStreamDefaultWriter({}),
+                'constructor should throw a TypeError exception');
+}, 'WritableStreamDefaultWriter should throw unless passed a WritableStream');
+
+test(() => {
+  const stream = new WritableStream();
+  const writer = stream.getWriter();
+  const WritableStreamDefaultWriter = writer.constructor;
+  assert_throws(new TypeError(), () => new WritableStreamDefaultWriter(stream),
+                'constructor should throw a TypeError exception');
+}, 'WritableStreamDefaultController constructor should throw when stream argument is locked');

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -197,3 +197,15 @@ promise_test(() => {
           assert_equals(writeCount, numberOfWrites, `should have called sink's write ${numberOfWrites} times`));
   });
 }, 'a large queue of writes should be processed completely');
+
+promise_test(() => {
+  const stream = recordingWritableStream();
+  const w = stream.getWriter();
+  const WritableStreamDefaultWriter = w.constructor;
+  w.releaseLock();
+  const writer = new WritableStreamDefaultWriter(stream);
+  return writer.ready.then(() => {
+    writer.write('a');
+    assert_array_equals(stream.events, ['write', 'a'], 'write() should be passed to sink');
+  });
+}, 'WritableStreamDefaultWriter should work when manually constructed');


### PR DESCRIPTION
The WritableStreamDefaultWriter and WritableStreamDefaultController
constructors are not exported. However they can be accessed fron the
"constructor" property of the relevant objects.

The WritableStreamDefaultController constructor should always throw an
exception if used explicitly. Verify that it does.

WritableStreamDefaultWriter can be constructed with an unlocked stream
and should then work just like a writer returned from
getWriter(). Verify that it does.