### PR TITLE
make TransformStream respect backpressure

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -343,7 +343,7 @@ module.exports = class TransformStream {
     this._readableClosed = false;
 
     this._resolveWrite = undefined;
-
+    this._readableBackpressure = false;
     this._chunkPending = false;
     this._chunk = undefined;
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -266,6 +266,7 @@ class TransformStreamSource {
   }
 
   pull() {
+    // console.log('TransformStreamSource.pull()');
     this._transformStream._readableBackpressure = false;
     TransformStreamTransformIfNeeded(this._transformStream);
   }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -278,6 +278,16 @@ class TransformStreamDefaultController {
     this._controlledTransformStream = transformStream;
   }
 
+  get desiredSize() {
+    if (IsTransformStreamDefaultController(this) === false) {
+      throw defaultControllerBrandCheckException('desiredSize');
+    }
+
+    const transformStream = this._controlledTransformStream;
+
+    return transformStream._readableController.desiredSize;
+  }
+
   enqueue(chunk) {
     if (IsTransformStreamDefaultController(this) === false) {
       throw defaultControllerBrandCheckException('enqueue');

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -52,7 +52,7 @@ function TransformStreamEnqueueToReadable(transformStream, chunk) {
   // enqueue() may invoke pull() synchronously when we're not in pull() call.
   // In such case, _readableBackpressure may be already set to false.
   if (backpressure) {
-    transformStream._readableBackpressure = false;
+    transformStream._readableBackpressure = true;
   }
 }
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -110,6 +110,8 @@ function TransformStreamReadyPromise(transformStream) {
 }
 
 function TransformStreamSetBackpressure(transformStream, backpressure) {
+  // console.log(`TransformStreamSetBackpressure(${backpressure})`);
+
   assert(transformStream._readableBackpressure !== backpressure);
 
   if (transformStream._backpressureChangePromise !== undefined) {

--- a/reference-implementation/test/transform-stream.js
+++ b/reference-implementation/test/transform-stream.js
@@ -200,8 +200,10 @@ test('TransformStream: by default, closing the writable closes the readable afte
   writer.write('a');
   writer.close();
 
+  const readableChunks = readableStreamToArray(ts.readable);
+
   writer.closed.then(() => {
-    return readableStreamToArray(ts.readable).then(chunks => {
+    return readableChunks.then(chunks => {
       t.deepEqual(chunks, ['x', 'y'], 'both enqueued chunks can be read from the readable');
       t.end();
     });
@@ -226,8 +228,10 @@ test('TransformStream: by default, closing the writable closes the readable afte
   writer.write('a');
   writer.close();
 
+  const readableChunks = readableStreamToArray(ts.readable);
+
   writer.closed.then(() => {
-    return readableStreamToArray(ts.readable).then(chunks => {
+    return readableChunks.then(chunks => {
       t.deepEqual(chunks, ['x', 'y'], 'both enqueued chunks can be read from the readable');
       t.end();
     });
@@ -259,8 +263,10 @@ test('Transform stream should call transformer methods as methods', t => {
   writer.write('a');
   writer.close();
 
+  const readableChunks = readableStreamToArray(ts.readable);
+
   writer.closed.then(() => {
-    return readableStreamToArray(ts.readable).then(chunks => {
+    return readableChunks.then(chunks => {
       t.deepEqual(chunks, ['a-suffix', 'flushed-suffix'], 'both enqueued chunks have suffixes');
     });
   }, e => t.error(e));


### PR DESCRIPTION
This should basically fix #330 / make it technically irrelevant, as now transform is only called from one place, technically. But it can now be triggered by pull() indirectly.