### PR TITLE
fix internal slot descriptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1698,7 +1698,7 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
   </thead>
   <tr>
     <td>\[[autoAllocateChunkSize]]
-    <td>A nonnegative integer when, the automatic buffer allocation feature is enabled. In that case, this value
+    <td>A positive integer, when the automatic buffer allocation feature is enabled. In that case, this value
       specifies the size of buffer to allocate. It is <emu-val>undefined</emu-val> otherwise.
   </tr>
   <tr>

--- a/index.bs
+++ b/index.bs
@@ -1400,8 +1400,8 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
   </tr>
   <tr>
     <td>\[[underlyingSource]]
-    <td>An object representation of the stream's <a>underlying source</a>, including its <a>queuing strategy</a>; also
-      used for the <a href="#is-readable-stream">IsReadableStream</a> brand check
+    <td>An object representation of the stream's <a>underlying source</a>; also
+      used for the <a href="#is-readable-stream-default-controller">IsReadableStreamDefaultController</a> brand check
   </tr>
 </table>
 
@@ -1748,8 +1748,8 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
   </tr>
   <tr>
     <td>\[[underlyingByteSource]]
-    <td>An object representation of the stream's <a>underlying byte source</a>, including its <a>queuing strategy</a>;
-      also used for the <a href="#is-readable-stream">IsReadableStream</a> brand check
+    <td>An object representation of the stream's <a>underlying byte source</a>;
+      also used for the <a href="#is-readable-byte-stream-controller">IsReadableByteStreamController</a> brand check
   </tr>
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -3098,7 +3098,7 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
   <tr>
     <td>\[[underlyingSink]]
     <td>An object representation of the stream's <a>underlying sink</a>; also
-      used for the <a href="#is-writable-stream">IsWritableStream</a> brand check
+      used for the <a href="#is-writable-stream-default-controller">IsWritableStreamDefaultController</a> brand check
   </tr>
   <tr>
     <td>\[[writing]]


### PR DESCRIPTION
Some descriptions were outdated, one was never accurate in the first place.