### PR TITLE
check if sink/source methods are callable in constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3592,6 +3592,16 @@ throws>ValidateAndNormalizeQueuingStrategy ( <var>size</var>, <var>highWaterMark
   1. Return Record {[[size]]: _size_, [[highWaterMark]]: _highWaterMark_}.
 </emu-alg>
 
+<h4 id="validate-methods-are-functions" aoid="ValidateMethodsAreFunctions"
+throws>ValidateMethodsAreFunctions ( <var>x</var>, <var>methods</var> )</h4>
+
+<emu-alg>
+  1. Repeat for each _method_ that is an element of _methods_,
+    1. Let _fun_ be ? GetV(_x_, _method_).
+    1. If _fun_ is not *undefined* and ! IsCallable(_fun_) is *false*, throw a *TypeError* exception.
+  1. Return *undefined*.
+</emu-alg>
+
 <h2 id="globals">Global Properties</h2>
 
 The following constructors must be exposed on the global object as data properties of the same name:

--- a/index.bs
+++ b/index.bs
@@ -451,6 +451,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
   1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
   1. Set *this*.[[disturbed]] to *false*.
   1. Set *this*.[[readableStreamController]] to *undefined*.
+  1. Perform ? ValidateMethodsAreFunctions(_underlyingSource_, « `"start"`, `"pull"`, `"cancel"` »).
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _typeString_ be ? ToString(_type_).
   1. If _typeString_ is `"bytes"`,
@@ -2583,6 +2584,7 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
   1. Set *this*.[[state]] to `"writable"`.
   1. Set *this*.[[storedError]], *this*.[[writer]], and *this*.[[writableStreamController]] to *undefined*.
   1. Set *this*.[[writeRequests]] to a new empty List.
+  1. Perform ? ValidateMethodsAreFunctions(_underlyingSink_, « `"start"`, `"write"`, `"abort"` »).
   1. Let _type_ be ? GetV(_underlyingSink_, `"type"`).
   1. If _type_ is not *undefined*, throw a *RangeError* exception. <p class="note">This is to allow us to add new
      potential types in the future, without backward-compatibility concerns.</p>

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -117,3 +117,13 @@ exports.ValidateAndNormalizeQueuingStrategy = (size, highWaterMark) => {
 
   return { size, highWaterMark };
 };
+
+exports.ValidateMethodsAreFunctions = (x, methods) => {
+  for (const method of methods) {
+    const fun = x[method];
+    if (fun !== undefined && typeof fun !== 'function') {
+      throw new TypeError(`${method} must be a function or undefined`);
+    }
+  }
+  return undefined;
+};

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,7 +1,8 @@
 'use strict';
 const assert = require('assert');
 const { ArrayBufferCopy, CreateIterResultObject, IsFiniteNonNegativeNumber, InvokeOrNoop, PromiseInvokeOrNoop,
-        SameRealmTransfer, ValidateAndNormalizeQueuingStrategy, ValidateAndNormalizeHighWaterMark } =
+        SameRealmTransfer, ValidateAndNormalizeQueuingStrategy, ValidateAndNormalizeHighWaterMark,
+        ValidateMethodsAreFunctions } =
       require('./helpers.js');
 const { createArrayFromList, createDataProperty, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
@@ -23,6 +24,9 @@ class ReadableStream {
     // Initialize to undefined first because the constructor of the controller checks this
     // variable to validate the caller.
     this._readableStreamController = undefined;
+
+    ValidateMethodsAreFunctions(underlyingSource, ['start', 'pull', 'cancel']);
+
     const type = underlyingSource.type;
     const typeString = String(type);
     if (typeString === 'bytes') {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('assert');
 const { InvokeOrNoop, PromiseInvokeOrNoop, PromiseInvokeOrFallbackOrNoop, ValidateAndNormalizeQueuingStrategy,
-        typeIsObject } = require('./helpers.js');
+        ValidateMethodsAreFunctions, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, GetTotalQueueSize, PeekQueueValue } = require('./queue-with-sizes.js');
 
@@ -19,6 +19,8 @@ class WritableStream {
     // This queue is placed here instead of the writer class in order to allow for passing a writer to the next data
     // producer without waiting for the queued writes to finish.
     this._writeRequests = [];
+
+    ValidateMethodsAreFunctions(underlyingSink, ['start', 'write', 'close']);
 
     const type = underlyingSink.type;
 


### PR DESCRIPTION
Before, it waited until there was a reason to call them, then errored the stream when it couldn't. But this can easily be caught much earlier in the constructor instead the same way strategies are already validated.

It looks like it would've never even been noticeable if `abort` or `cancel` were set to a non-function.