### PR TITLE
Tests for Sink methods returning thenable

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -203,3 +203,19 @@ test(() => {
     assert_array_equals(ws.events, ['close']);
   });
 }, 'WritableStream should call underlying sink\'s close if no abort is supplied');
+
+promise_test(() => {
+  let thenCalled = false;
+  const ws = new WritableStream({
+    abort() {
+      return {
+        then(resolve) {
+          thenCalled = true;
+          resolve();
+        }
+      };
+    }
+  });
+  const writer = ws.getWriter();
+  return writer.abort().then(() => assert_true(thenCalled, 'then() should be called'));
+}, 'returning a thenable from abort() should work');

--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -209,9 +209,9 @@ promise_test(() => {
   const ws = new WritableStream({
     abort() {
       return {
-        then(resolve) {
+        then(onFulfilled) {
           thenCalled = true;
-          resolve();
+          onFulfilled();
         }
       };
     }

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -133,7 +133,7 @@ promise_test(t => {
   const ws = new WritableStream({
     close() {
       return {
-        then(resolve, reject) { reject(rejection); }
+        then(onFulfilled, onRejected) { onRejected(rejection); }
       };
     }
   });

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -127,3 +127,15 @@ promise_test(() => {
   });
 }, 'when close is called on a WritableStream in waiting state, ready should be fulfilled immediately even if close ' +
     'takes a long time');
+
+promise_test(t => {
+  const rejection = { name: 'letter' };
+  const ws = new WritableStream({
+    close() {
+      return {
+        then(resolve, reject) { reject(rejection); }
+      };
+    }
+  });
+  return promise_rejects(t, rejection, ws.getWriter().close(), 'close() should return a rejection');
+}, 'returning a thenable from close() should work');

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.js
@@ -97,7 +97,7 @@ promise_test(t => {
   const ws = new WritableStream({
     start() {
       return {
-        then(resolve, reject) { reject(rejection); }
+        then(onFulfilled, onRejected) { onRejected(rejection); }
       };
     }
   });

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.js
@@ -91,3 +91,15 @@ promise_test(() => {
   return delay(100)
       .then(() => assert_array_equals(ws.events, [], 'write and close should not be called'));
 }, 'underlying sink\'s write or close should not be invoked if the promise returned by start is rejected');
+
+promise_test(t => {
+  const rejection = { name: 'this is checked' };
+  const ws = new WritableStream({
+    start() {
+      return {
+        then(resolve, reject) { reject(rejection); }
+      };
+    }
+  });
+  return promise_rejects(t, rejection, ws.getWriter().closed, 'closed promise should be rejected');
+}, 'returning a thenable from start() should work');

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -209,3 +209,18 @@ promise_test(() => {
     assert_array_equals(stream.events, ['write', 'a'], 'write() should be passed to sink');
   });
 }, 'WritableStreamDefaultWriter should work when manually constructed');
+
+promise_test(() => {
+  let thenCalled = false;
+  const ws = new WritableStream({
+    write() {
+      return {
+        then(resolve) {
+          thenCalled = true;
+          resolve();
+        }
+      };
+    }
+  });
+  ws.getWriter().write('a').then(() => assert_true(thenCalled, 'thenCalled should be true'));
+}, 'returning a thenable from write() should work');

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -215,9 +215,9 @@ promise_test(() => {
   const ws = new WritableStream({
     write() {
       return {
-        then(resolve) {
+        then(onFulfilled) {
           thenCalled = true;
-          resolve();
+          onFulfilled();
         }
       };
     }


### PR DESCRIPTION
Sink methods that can return a Promise can also return an arbitrary
object that implements a then() method. The then() method should be
called as if it was a Promise object.

Add web platform tests to verify this behaviour.