### PR TITLE
Refactor TransformStream's backpressure handling

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -123,7 +123,7 @@ function TransformStreamReadableReadyPromise(transformStream) {
 function TransformStreamSetBackpressure(transformStream, backpressure) {
   // console.log(`TransformStreamSetBackpressure(${backpressure})`);
 
-  // Passes also when called for initialization.
+  // Passes also when called during construction.
   assert(transformStream._backpressure !== backpressure,
          'TransformStreamSetBackpressure() should be called only when backpressure is changed');
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -53,9 +53,8 @@ function TransformStreamEnqueueToReadable(transformStream, chunk) {
     // This allows pull() again. When desiredSize is 0, it's possible that a pull() will happen immediately (but
     // asynchronously) after this because of pending read()s and set _backpressure back to false.
     //
-    // We don't have to worry about that such a pull() may happen inside the enqueue() call, and therefore is not
-    // queued at this point. It's guaranteed that there is pending start() or the last pull() kept pending which
-    // prevent such a pull() inside the enqueue() call.
+    // If pull() could be called from inside enqueue(), then this logic would be wrong. This cannot happen
+    // because there is always a promise pending from start() or pull() when _backpressure is false.
     TransformStreamSetBackpressure(transformStream, true);
   }
 }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -263,7 +263,7 @@ class TransformStreamSource {
              '_backpressureChangePromise should have been initialized');
 
       if (transformStream._backpressure === true) {
-        return;
+        return Promise.resolve();
       }
 
       assert(transformStream._backpressure === false, '_backpressure should have been initialized');

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -50,12 +50,12 @@ function TransformStreamEnqueueToReadable(transformStream, chunk) {
   const maybeBackpressure = controller.desiredSize <= 0;
 
   if (maybeBackpressure === true && transformStream._backpressure === false) {
-    // This allows pull() again. When desiredSize is 0, it's possible that a pull() is made immediately (but
-    // asynchronously) after this because of pending read()s and fix _backpressure back to false.
+    // This allows pull() again. When desiredSize is 0, it's possible that a pull() will happen immediately (but
+    // asynchronously) after this because of pending read()s and set _backpressure back to false.
     //
-    // We don't have to worry about that such a pull() may happen synchronously to the enqueue(), and therefore is not
+    // We don't have to worry about that such a pull() may happen inside the enqueue() call, and therefore is not
     // queued at this point. It's guaranteed that there is pending start() or the last pull() kept pending which
-    // prevent such a synchronous pull().
+    // prevent such a pull() inside the enqueue() call.
     TransformStreamSetBackpressure(transformStream, true);
   }
 }
@@ -128,7 +128,7 @@ function TransformStreamSetBackpressure(transformStream, backpressure) {
          'TransformStreamSetBackpressure() should be called only when backpressure is changed');
 
   if (transformStream._backpressureChangePromise !== undefined) {
-    // The fulfillment value is just for the assertion.
+    // The fulfillment value is just for a sanity check.
     transformStream._backpressureChangePromise_resolve(backpressure);
   }
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -278,7 +278,7 @@ class TransformStreamSource {
     const transformStream = this._transformStream;
 
     // Invariant. Enforced by the promises returned by start() and pull().
-    assert(transformStream._backpressure === true, 'pull() is never called while _backpressure is false');
+    assert(transformStream._backpressure === true, 'pull() should be never called while _backpressure is false');
 
     assert(transformStream._backpressureChangePromise !== undefined,
            '_backpressureChangePromise should have been initialized');


### PR DESCRIPTION
Add notes (in the form of assert description where possible) about the new
backpressure controlling logic introduced by isonmad to ease understanding.