### PR TITLE
Don't mandate transform method in TransformStream

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -77,7 +77,7 @@ exports.PromiseInvokeOrNoop = (O, P, args) => {
   }
 };
 
-exports.PromiseInvokeOrFallbackOrNoop = (O, P1, args1, P2, args2) => {
+exports.PromiseInvokeOrFallback = (O, P1, args1, F, args2) => {
   let method;
   try {
     method = O[P1];
@@ -86,7 +86,7 @@ exports.PromiseInvokeOrFallbackOrNoop = (O, P1, args1, P2, args2) => {
   }
 
   if (method === undefined) {
-    return exports.PromiseInvokeOrNoop(O, P2, args2);
+    return F(args2);
   }
 
   try {
@@ -94,6 +94,10 @@ exports.PromiseInvokeOrFallbackOrNoop = (O, P1, args1, P2, args2) => {
   } catch (e) {
     return Promise.reject(e);
   }
+};
+
+exports.PromiseInvokeOrFallbackOrNoop = (O, P1, args1, P2, args2) => {
+  return exports.PromiseInvokeOrFallback(O, P1, args1, exports.PromiseInvokeOrNoop, [O, P2, args2]);
 };
 
 // Not implemented correctly

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -77,7 +77,7 @@ exports.PromiseInvokeOrNoop = (O, P, args) => {
   }
 };
 
-exports.PromiseInvokeOrFallback = (O, P, args, F, argsF) => {
+exports.PromiseInvokeOrPerformFallback = (O, P, args, F, argsF) => {
   let method;
   try {
     method = O[P];
@@ -97,7 +97,7 @@ exports.PromiseInvokeOrFallback = (O, P, args, F, argsF) => {
 };
 
 exports.PromiseInvokeOrFallbackOrNoop = (O, P1, args1, P2, args2) => {
-  return exports.PromiseInvokeOrFallback(O, P1, args1, exports.PromiseInvokeOrNoop, [O, P2, args2]);
+  return exports.PromiseInvokeOrPerformFallback(O, P1, args1, exports.PromiseInvokeOrNoop, [O, P2, args2]);
 };
 
 // Not implemented correctly

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -86,7 +86,7 @@ exports.PromiseInvokeOrFallback = (O, P1, args1, F, args2) => {
   }
 
   if (method === undefined) {
-    return F(args2);
+    return F(...args2);
   }
 
   try {

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -77,20 +77,20 @@ exports.PromiseInvokeOrNoop = (O, P, args) => {
   }
 };
 
-exports.PromiseInvokeOrFallback = (O, P1, args1, F, args2) => {
+exports.PromiseInvokeOrFallback = (O, P, args, F, argsF) => {
   let method;
   try {
-    method = O[P1];
+    method = O[P];
   } catch (methodE) {
     return Promise.reject(methodE);
   }
 
   if (method === undefined) {
-    return F(...args2);
+    return F(...argsF);
   }
 
   try {
-    return Promise.resolve(method.apply(O, args1));
+    return Promise.resolve(method.apply(O, args));
   } catch (e) {
     return Promise.reject(e);
   }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const { InvokeOrNoop, PromiseInvokeOrFallback, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
+const { InvokeOrNoop, PromiseInvokeOrPerformFallback, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
 const { ReadableStream } = require('./readable-stream.js');
 const { WritableStream } = require('./writable-stream.js');
 
@@ -142,7 +142,7 @@ function TransformStreamTransform(transformStream, chunk) {
   const transformer = transformStream._transformer;
   const controller = transformStream._transformStreamController;
 
-  const transformPromise = PromiseInvokeOrFallback(transformer, 'transform', [chunk, controller],
+  const transformPromise = PromiseInvokeOrPerformFallback(transformer, 'transform', [chunk, controller],
                              TransformStreamDefaultTransform, [chunk, controller]);
 
   return transformPromise.then(

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const { InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
+const { InvokeOrNoop, PromiseInvokeOrFallback, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
 const { ReadableStream } = require('./readable-stream.js');
 const { WritableStream } = require('./writable-stream.js');
 
@@ -141,12 +141,9 @@ function TransformStreamTransform(transformStream, chunk) {
 
   const transformer = transformStream._transformer;
   const controller = transformStream._transformStreamController;
-  let transformPromise;
-  if (transformer.transform === undefined) {
-    transformPromise = TransformStreamDefaultTransform(chunk, controller);
-  } else {
-    transformPromise = PromiseInvokeOrNoop(transformer, 'transform', [chunk, controller]);
-  }
+
+  const transformPromise = PromiseInvokeOrFallback(transformer, 'transform', [chunk, controller],
+                             TransformStreamDefaultTransform, [chunk, controller]);
 
   return transformPromise.then(
     () => {

--- a/reference-implementation/test/transform-stream.js
+++ b/reference-implementation/test/transform-stream.js
@@ -4,18 +4,10 @@ const test = require('tape-catch');
 const readableStreamToArray = require('./utils/readable-stream-to-array.js');
 
 
-test('Pass-through sync TransformStream: can read from readable what is put into writable', t => {
+test('identity TransformStream: can read from readable what is put into writable', t => {
   t.plan(3);
 
-  let c;
-  const ts = new TransformStream({
-    start(controller) {
-      c = controller;
-    },
-    transform(chunk) {
-      c.enqueue(chunk);
-    }
-  });
+  const ts = new TransformStream();
 
   const writer = ts.writable.getWriter();
   writer.write('a');

--- a/reference-implementation/test/transform-stream.js
+++ b/reference-implementation/test/transform-stream.js
@@ -4,7 +4,7 @@ const test = require('tape-catch');
 const readableStreamToArray = require('./utils/readable-stream-to-array.js');
 
 
-test('identity TransformStream: can read from readable what is put into writable', t => {
+test('Identity TransformStream: can read from readable what is put into writable', t => {
   t.plan(3);
 
   const ts = new TransformStream();

--- a/reference-implementation/to-upstream-wpts/transform-stream/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/general.js
@@ -9,11 +9,9 @@ test(() => {
 }, 'TransformStream can be constructed with a transform function');
 
 test(() => {
-  assert_throws(new TypeError(), () => new TransformStream(), 'TransformStream cannot be ' +
-    'constructed with no arguments');
-  assert_throws(new TypeError(), () => new TransformStream({}), 'TransformStream cannot be ' +
-    'constructed with an empty object');
-}, 'TransformStream cannot be constructed with no transform function');
+  new TransformStream();
+  new TransformStream({});
+}, 'TransformStream can be constructed with no transform function');
 
 test(() => {
   const ts = new TransformStream({ transform() { } });


### PR DESCRIPTION
This was bugging me for ages but I assumed the consensus had already settled on that design.

Closes #565.