### PR TITLE
fixup Markdown docs

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -12,7 +12,7 @@ Use "let" for introducing new local variables. Use "set" for updating existing v
 
 Mark up definitions [appropriately](https://github.com/tabatkins/bikeshed/blob/master/docs/definitions-autolinks.md#definitions). This is mostly applicable when defining new classes or methods; follow the existing examples in the spec.
 
-Mark up abstract operations with `throw` or `nothrow` attributes in their heading tags, according to whether or not they can ever return an abrupt completion.
+Mark up abstract operations with `throws` or `nothrow` attributes in their heading tags, according to whether or not they can ever return an abrupt completion.
 
 Use cross-reference [autolinking](https://github.com/tabatkins/bikeshed/blob/master/docs/definitions-autolinks.md#autolinking) liberally. This generally amounts to writing references to "definitions" as `<a>term</a>`, and writing references to classes or methods as `{{ClassName}}` or `{{ClassName/methodName()}}`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The streams standard provides APIs for creating, composing, and consuming streams of data. These streams are designed to map efficiently to low-level I/O primitives, and allow easy composition with built-in backpressure and queuing.
 
-The main spec is available at https://streams.spec.whatwg.org/, generated from the `index.bs` file. We are also working on a potential extension in TeeStream.md.
+The main spec is available at https://streams.spec.whatwg.org/, generated from the `index.bs` file.
 
 Snapshots of any given commit or branch are available at specially-crafted URLs:
 

--- a/Requirements.md
+++ b/Requirements.md
@@ -4,9 +4,9 @@ Drawing upon the JavaScript community's extensive experience with streaming prim
 
 ## Background Reading
 
-The most clear and insightful commentary on a streams API has so far been produced by Isaac Schlueter, lead Node.js maintainer. In a series of posts on the public-webapps list, he outlined his thoughts, first [on the general concepts and requirements of a streams API](http://lists.w3.org/Archives/Public/public-webapps/2013JulSep/0275.html), and second [on potential specific API details and considerations](http://lists.w3.org/Archives/Public/public-webapps/2013JulSep/0355.html). This document leans heavily on his conceptual analysis.
+The most clear and insightful commentary on a streams API has so far been produced by Isaac Schlueter, lead Node.js maintainer. In a series of posts on the public-webapps list, he outlined his thoughts, first [on the general concepts and requirements of a streams API](https://lists.w3.org/Archives/Public/public-webapps/2013JulSep/0275.html), and second [on potential specific API details and considerations](https://lists.w3.org/Archives/Public/public-webapps/2013JulSep/0355.html). This document leans heavily on his conceptual analysis.
 
-To understand the importance of backpressure, watch [Thorsten Lorenz's LXJS 2013 talk](https://www.youtube.com/watch?v=9llfAByho98) and perhaps play with his [stream-viz](http://thlorenz.github.io/stream-viz/) demo.
+To understand the importance of backpressure, watch [Thorsten Lorenz's LXJS 2013 talk](https://www.youtube.com/watch?v=9llfAByho98) and perhaps play with his [stream-viz](https://thlorenz.github.io/stream-viz/) demo.
 
 ## Creating Readable Streams
 
@@ -73,7 +73,7 @@ The primary way of consuming streams is to pipe them to each other. This is the 
 fs.createReadStream("source.txt")
     .pipeTo(fs.createWriteStream("dest.txt"));
 
-http.get("http://example.com")
+https.get("https://example.com")
     .pipeTo(fs.createWriteStream("dest.txt"));
 ```
 
@@ -90,7 +90,7 @@ fs.createReadStream("index.html")
     .pipeThrough(zlib.createGzipCompressor(options))
     .pipeTo(httpServerResponse);
 
-http.get("http://example.com/video.mp4")
+https.get("https://example.com/video.mp4")
     .pipeThrough(videoProcessingWebWorker)
     .pipeTo(document.query("video"));
 


### PR DESCRIPTION
It still mentioned TeeStream.md which got removed in #563.