### PR TITLE
eslint fixes and standardize exports style

### DIFF
--- a/reference-implementation/.eslintignore
+++ b/reference-implementation/.eslintignore
@@ -1,0 +1,1 @@
+web-platform-tests/

--- a/reference-implementation/.eslintrc.json
+++ b/reference-implementation/.eslintrc.json
@@ -19,7 +19,7 @@
     // Possible errors
     "comma-dangle": ["error", "never"],
     "no-cond-assign": ["error", "except-parens"],
-    "no-console": "off",
+    "no-console": "error",
     "no-constant-condition": "error",
     "no-control-regex": "error",
     "no-debugger": "error",

--- a/reference-implementation/.eslintrc.json
+++ b/reference-implementation/.eslintrc.json
@@ -19,7 +19,7 @@
     // Possible errors
     "comma-dangle": ["error", "never"],
     "no-cond-assign": ["error", "except-parens"],
-    "no-console": "error",
+    "no-console": "off",
     "no-constant-condition": "error",
     "no-control-regex": "error",
     "no-debugger": "error",

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -253,7 +253,7 @@ class ReadableStream {
   }
 }
 
-exports.ReadableStream = ReadableStream;
+module.exports = { ReadableStream, IsReadableStreamDisturbed };
 
 // Abstract operations for the ReadableStream.
 
@@ -282,8 +282,6 @@ function IsReadableStreamDisturbed(stream) {
 
   return stream._disturbed;
 }
-
-exports.IsReadableStreamDisturbed = IsReadableStreamDisturbed;
 
 function IsReadableStreamLocked(stream) {
   assert(IsReadableStream(stream) === true, 'IsReadableStreamLocked should only be used on known readable streams');

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -352,7 +352,7 @@ class TransformStreamDefaultController {
   }
 }
 
-module.exports = class TransformStream {
+class TransformStream {
   constructor(transformer = {}) {
     this._transformer = transformer;
     const { readableStrategy, writableStrategy } = transformer;
@@ -423,7 +423,9 @@ module.exports = class TransformStream {
 
     return this._writable;
   }
-};
+}
+
+module.exports = { TransformStream };
 
 // Helper functions for the TransformStreamDefaultController.
 

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -58,7 +58,7 @@ class WritableStream {
   }
 }
 
-Object.assign(exports, {
+module.exports = {
   AcquireWritableStreamDefaultWriter,
   IsWritableStream,
   IsWritableStreamLocked,
@@ -67,7 +67,7 @@ Object.assign(exports, {
   WritableStreamDefaultWriterCloseWithErrorPropagation,
   WritableStreamDefaultWriterRelease,
   WritableStreamDefaultWriterWrite
-});
+};
 
 // Abstract operations for the WritableStream.
 

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -5,7 +5,7 @@
     "pretest": "bash ./update-web-platform-tests.sh",
     "test": "npm run lint && node --expose_gc run-tests.js | tap-spec && npm run wpt",
     "wpt": "node --expose_gc run-web-platform-tests.js",
-    "lint": "eslint \"{lib,test,to-upstream-wpts}/**/*.js\""
+    "lint": "eslint \"**/*.js\""
   },
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "contributors": [

--- a/reference-implementation/run-tests.js
+++ b/reference-implementation/run-tests.js
@@ -4,9 +4,9 @@ const path = require('path');
 
 const { ReadableStream } = require('./lib/readable-stream.js');
 const { WritableStream } = require('./lib/writable-stream.js');
+const { TransformStream } = require('./lib/transform-stream.js');
 const ByteLengthQueuingStrategy = require('./lib/byte-length-queuing-strategy.js');
 const CountQueuingStrategy = require('./lib/count-queuing-strategy.js');
-const TransformStream = require('./lib/transform-stream.js');
 
 global.ReadableStream = ReadableStream;
 global.WritableStream = WritableStream;

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -24,6 +24,7 @@ wptRunner(toUpstreamTestsPath, { rootURL: 'streams/', setup })
     process.exitCode = totalFailures;
   })
   .catch(e => {
+    /* eslint-disable no-console */
     console.error(e.stack);
     process.exitCode = 1;
   });

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -21,11 +21,11 @@ wptRunner(toUpstreamTestsPath, { rootURL: 'streams/', setup })
   })
   .then(failures => {
     totalFailures += failures;
-    process.exit(totalFailures);
+    process.exitCode = totalFailures;
   })
   .catch(e => {
     console.error(e.stack);
-    process.exit(1);
+    process.exitCode = 1;
   });
 
 function setup(window) {

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -6,7 +6,7 @@ const wptRunner = require('wpt-runner');
 
 const { ReadableStream } = require('./lib/readable-stream.js');
 const { WritableStream } = require('./lib/writable-stream.js');
-const TransformStream = require('./lib/transform-stream.js');
+const { TransformStream } = require('./lib/transform-stream.js');
 const ByteLengthQueuingStrategy = require('./lib/byte-length-queuing-strategy.js');
 const CountQueuingStrategy = require('./lib/count-queuing-strategy.js');
 


### PR DESCRIPTION
Put exports in one place per file and use the same style in each one.

Along the way as I tried editing run-web-platform-tests.js, I found out it had lint errors.
