### PR TITLE
always check if methods are callable first

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -66,6 +66,11 @@ exports.InvokeOrNoop = (O, P, args) => {
   if (method === undefined) {
     return undefined;
   }
+
+  if (typeof method !== 'function') {
+    throw new TypeError(`${P} is not a function`);
+  }
+
   return method.apply(O, args);
 };
 
@@ -87,6 +92,10 @@ exports.PromiseInvokeOrPerformFallback = (O, P, args, F, argsF) => {
 
   if (method === undefined) {
     return F(...argsF);
+  }
+
+  if (typeof method !== 'function') {
+    return Promise.reject(new TypeError(`${P} is not a function`));
   }
 
   try {

--- a/reference-implementation/test/bad-underlying-sinks.js
+++ b/reference-implementation/test/bad-underlying-sinks.js
@@ -27,6 +27,24 @@ test('Underlying sink: throwing start method', t => {
   t.end();
 });
 
+test('Underlying sink: non-function start', t => {
+  t.throws(() => {
+    new WritableStream({
+      start: 'not a function or undefined'
+    });
+  }, /TypeError/);
+  t.end();
+});
+
+test('Underlying sink: non-function start with .apply', t => {
+  t.throws(() => {
+    new WritableStream({
+      start: { apply() {} }
+    });
+  }, /TypeError/);
+  t.end();
+});
+
 test('Underlying sink: throwing write getter', t => {
   t.plan(2);
 


### PR DESCRIPTION
InvokeOrNoop invokes [Call](https://tc39.github.io/ecma262/#sec-call), which only takes actual functions, not anything that has `.apply` on it.
