### PR TITLE
Add done() to the end of w-p-t Javascript files

### DIFF
--- a/reference-implementation/to-upstream-wpts/piping/close-propagation-backward.js
+++ b/reference-implementation/to-upstream-wpts/piping/close-propagation-backward.js
@@ -151,3 +151,5 @@ promise_test(t => {
 
 }, 'Closing must be propagated backward: starts closed; preventCancel = true, preventAbort = true, preventClose ' +
    '= true');
+
+done();

--- a/reference-implementation/to-upstream-wpts/piping/close-propagation-forward.js
+++ b/reference-implementation/to-upstream-wpts/piping/close-propagation-forward.js
@@ -420,3 +420,5 @@ promise_test(() => {
   });
 
 }, 'Closing must be propagated forward: shutdown must not occur until the final write completes');
+
+done();

--- a/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
+++ b/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
@@ -630,3 +630,5 @@ promise_test(t => {
   });
 
 }, 'Errors must be propagated backward: erroring via the controller errors a slow write');
+
+done();

--- a/reference-implementation/to-upstream-wpts/piping/error-propagation-forward.js
+++ b/reference-implementation/to-upstream-wpts/piping/error-propagation-forward.js
@@ -424,3 +424,5 @@ promise_test(t => {
   });
 
 }, 'Errors must be propagated forward: shutdown must not occur until the final write completes');
+
+done();

--- a/reference-implementation/to-upstream-wpts/piping/flow-control.js
+++ b/reference-implementation/to-upstream-wpts/piping/flow-control.js
@@ -222,3 +222,5 @@ promise_test(() => {
     ]);
   });
 }, 'Piping to a WritableStream that does not consume the writes fast enough exerts backpressure on the ReadableStream');
+
+done();

--- a/reference-implementation/to-upstream-wpts/piping/general.js
+++ b/reference-implementation/to-upstream-wpts/piping/general.js
@@ -153,3 +153,5 @@ promise_test(() => {
   return pipePromise;
 
 }, 'Piping from a ReadableStream for which a chunk becomes asynchronously readable after the pipeTo');
+
+done();

--- a/reference-implementation/to-upstream-wpts/piping/multiple-propagation.js
+++ b/reference-implementation/to-upstream-wpts/piping/multiple-propagation.js
@@ -132,3 +132,5 @@ promise_test(() => {
   });
 
 }, 'Piping from a closed readable stream to a closed writable stream');
+
+done();

--- a/reference-implementation/to-upstream-wpts/transform-stream/flush.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/flush.js
@@ -114,3 +114,5 @@ promise_test(() => {
     })
   ]);
 }, 'TransformStream flush gets a chance to enqueue more into the readable, and can then async close');
+
+done();

--- a/reference-implementation/to-upstream-wpts/transform-stream/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/general.js
@@ -40,3 +40,5 @@ test(() => {
   const writer = ts.writable.getWriter();
   assert_equals(writer.desiredSize, 1, 'writer.desiredSize should be 1');
 }, 'TransformStream writable starts in the writable state');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -219,3 +219,5 @@ promise_test(() => {
   const writer = ws.getWriter();
   return writer.abort().then(() => assert_true(thenCalled, 'then() should be called'));
 }, 'returning a thenable from abort() should work');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
@@ -108,3 +108,5 @@ promise_test(t => {
   });
 
 }, 'write: returning a rejected promise (second write) should cause writer write() and ready to reject');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -139,3 +139,5 @@ promise_test(t => {
   });
   return promise_rejects(t, rejection, ws.getWriter().close(), 'close() should return a rejection');
 }, 'returning a thenable from close() should work');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -144,3 +144,5 @@ test(() => {
   assert_throws(new TypeError(), () => new WritableStreamDefaultWriter(stream),
                 'constructor should throw a TypeError exception');
 }, 'WritableStreamDefaultWriter constructor should throw when stream argument is locked');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/general.js
@@ -151,3 +151,5 @@ promise_test(() => {
       .then(() => promises.abort)
       .then(thisValue => assert_equals(thisValue, theSink, 'abort should be called as a method'));
 }, 'WritableStream should call underlying sink methods as methods');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.js
@@ -103,3 +103,5 @@ promise_test(t => {
   });
   return promise_rejects(t, rejection, ws.getWriter().closed, 'closed promise should be rejected');
 }, 'returning a thenable from start() should work');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -194,7 +194,7 @@ promise_test(() => {
 
     return writePromise
         .then(() =>
-          assert_equals(writeCount, numberOfWrites, `should have called sink's write ${numberOfWrites} times`));
+        assert_equals(writeCount, numberOfWrites, `should have called sink's write ${numberOfWrites} times`));
   });
 }, 'a large queue of writes should be processed completely');
 
@@ -224,3 +224,5 @@ promise_test(() => {
   });
   ws.getWriter().write('a').then(() => assert_true(thenCalled, 'thenCalled should be true'));
 }, 'returning a thenable from write() should work');
+
+done();


### PR DESCRIPTION
When running a web-platform-test in a Worker, the Javascript file must
end with a done() statement so that testharness.js knows that parsing is
complete. The extra done() statement is a no-op when running directly in
the page or via the wpt-runner.

Add done() statements to all relevant Javascript files.