### PR TITLE
Add code coverage reporting the reference implementation/tests

### DIFF
--- a/reference-implementation/.eslintignore
+++ b/reference-implementation/.eslintignore
@@ -1,1 +1,2 @@
 web-platform-tests/
+coverage/

--- a/reference-implementation/.gitignore
+++ b/reference-implementation/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 npm-debug.log
 
-bench/results/
 web-platform-tests/
 
-browser-tests/bundle.js
+.nyc_output/
+coverage/

--- a/reference-implementation/README.md
+++ b/reference-implementation/README.md
@@ -10,6 +10,8 @@ The reference implementation is meant to be a fairly close transcription of the 
 
 Test coverage is not complete, but we do aim for it to be. Adding tests would be a great way to contribute to this project.
 
+You can check the test coverage at any time by running `npm run coverage` in this folder.
+
 ### Original Tests
 
 The original tests are written using the [tape](https://github.com/substack/tape) framework.

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -5,7 +5,8 @@
     "pretest": "bash ./update-web-platform-tests.sh",
     "test": "npm run lint && node --expose_gc run-tests.js | tap-spec && npm run wpt",
     "wpt": "node --expose_gc run-web-platform-tests.js",
-    "lint": "eslint \"**/*.js\""
+    "lint": "eslint \"**/*.js\"",
+    "coverage": "nyc --reporter=lcov npm test && opener coverage/lcov-report/index.html"
   },
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "contributors": [
@@ -17,9 +18,16 @@
   "devDependencies": {
     "eslint": "^3.2.2",
     "glob": "^7.0.3",
+    "nyc": "^8.4.0",
+    "opener": "^1.4.2",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1",
     "tape-catch": "^1.0.5",
-    "wpt-runner": "^2.1.0"
+    "wpt-runner": "^2.1.1"
+  },
+  "nyc": {
+    "include": [
+      "**/lib/**/*.js"
+    ]
   }
 }


### PR DESCRIPTION
See https://dl.dropboxusercontent.com/u/20140634/streams-spec-coverage/index.html for a preview. The gaps are interesting, although mostly minor, which is great.