### PR TITLE
test non-function sink.abort

### DIFF
--- a/reference-implementation/test/bad-underlying-sinks.js
+++ b/reference-implementation/test/bad-underlying-sinks.js
@@ -139,27 +139,6 @@ test('Underlying sink: throwing abort method', t => {
   );
 });
 
-test('Underlying sink: non-function abort method with .apply', t => {
-  t.plan(2);
-
-  const abortReason = new Error('reason');
-  const ws = new WritableStream({
-    abort: { apply() {} }
-  });
-
-  const writer = ws.getWriter();
-
-  writer.abort(abortReason).then(
-    () => t.fail('abort should not fulfill'),
-    r => t.equal(r.constructor, TypeError, 'abort should reject with TypeError')
-  );
-
-  writer.closed.then(
-    () => t.fail('closed should not fulfill'),
-    r => t.equal(r.constructor, TypeError, 'closed should reject with a TypeError')
-  );
-});
-
 test('Underlying sink: throwing close getter', t => {
   t.plan(1);
 

--- a/reference-implementation/test/bad-underlying-sinks.js
+++ b/reference-implementation/test/bad-underlying-sinks.js
@@ -139,6 +139,27 @@ test('Underlying sink: throwing abort method', t => {
   );
 });
 
+test('Underlying sink: non-function abort method with .apply', t => {
+  t.plan(2);
+
+  const abortReason = new Error('reason');
+  const ws = new WritableStream({
+    abort: { apply() {} }
+  });
+
+  const writer = ws.getWriter();
+
+  writer.abort(abortReason).then(
+    () => t.fail('abort should not fulfill'),
+    r => t.equal(r.constructor, TypeError, 'abort should reject with TypeError')
+  );
+
+  writer.closed.then(
+    () => t.fail('closed should not fulfill'),
+    r => t.equal(r.constructor, TypeError, 'closed should reject with a TypeError')
+  );
+});
+
 test('Underlying sink: throwing close getter', t => {
   t.plan(1);
 

--- a/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
@@ -109,4 +109,15 @@ promise_test(t => {
 
 }, 'write: returning a rejected promise (second write) should cause writer write() and ready to reject');
 
+promise_test(t => {
+  const ws = new WritableStream({
+    abort: { apply() {} }
+  });
+
+  return promise_rejects(t, new TypeError(), ws.abort(error1), 'abort should reject with TypeError').then(() => {
+    const writer = ws.getWriter();
+    return promise_rejects(t, new TypeError(), writer.closed, 'closed should reject with a TypeError');
+  });
+}, 'abort: non-function abort method with .apply');
+
 done();


### PR DESCRIPTION
This codepath was missing code coverage as revealed in #590.