### PR TITLE
sync spec and implementation of autoAllocateChunkSize

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1860,8 +1860,7 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
   1. Set *this*.[[strategyHWM]] to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
   1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
   1. If _autoAllocateChunkSize_ is not *undefined*,
-    1. Set _autoAllocateChunkSize_ to ? ToInteger(_autoAllocateChunkSize_).
-    1. If _autoAllocateChunkSize_ ≤ *0*, or if _autoAllocateChunkSize_ is *+∞* or *−∞*, throw a *RangeError* exception.
+    1. If ! IsInteger(_autoAllocateChunkSize_) is *false*, or if _autoAllocateChunkSize_ ≤ *0*, throw a *RangeError* exception.
   1. Set *this*.[[autoAllocateChunkSize]] to _autoAllocateChunkSize_.
   1. Set *this*.[[pendingPullIntos]] to a new empty List.
   1. Let _controller_ be *this*.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1171,7 +1171,7 @@ class ReadableByteStreamController {
 
     const autoAllocateChunkSize = underlyingByteSource.autoAllocateChunkSize;
     if (autoAllocateChunkSize !== undefined) {
-      if (Number.isInteger(autoAllocateChunkSize) === false || autoAllocateChunkSize < 0) {
+      if (Number.isInteger(autoAllocateChunkSize) === false || autoAllocateChunkSize <= 0) {
         throw new RangeError('autoAllocateChunkSize must be a non negative integer');
       }
     }


### PR DESCRIPTION
autoAllocateChunkSize was added in #430 as commit e601d69f3ba40e6f4b5506e4bb1fbe3f3eabf393.

The spec was out of sync with the reference implementation: it tried to round
non-integers into integers instead of rejecting them.

The reference implementation was out of sync with the spec: it was allowing
an autoAllocateChunkSize of 0 through instead of throwing a RangeError.