### PR TITLE
update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: node
+node_js:
+ - node
+ - 6
 sudo: false
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: stable
+node_js: node
 sudo: false
 
 addons:


### PR DESCRIPTION
'stable' isn't supposed to be used anymore as a version alias, in the post-1.0 world. And optionally, should node 6.x keep being tested against as a baseline rather than exclusively testing the latest version?