### PR TITLE
add "bytes" readableType to TransformStream transformer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2181,6 +2181,8 @@ nothrow>ReadableByteStreamControllerEnqueue ( <var>controller</var>, <var>chunk<
   1. Let _stream_ be _controller_.[[controlledReadableStream]].
   1. Assert: _controller_.[[closeRequested]] is *false*.
   1. Assert: _stream_.[[state]] is `"readable"`.
+  1. Assert: Type(_chunk_) is Object.
+  1. Assert: _chunk_ has a [[ViewedArrayBuffer]] internal slot.
   1. Let _buffer_ be _chunk_.[[ViewedArrayBuffer]].
   1. Let _byteOffset_ be _chunk_.[[ByteOffset]].
   1. Let _byteLength_ be _chunk_.[[ByteLength]].

--- a/index.bs
+++ b/index.bs
@@ -1885,13 +1885,7 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
 
 <emu-alg>
   1. If IsReadableByteStreamController(*this*) is *false*, throw a *TypeError* exception.
-  1. If *this*.[[byobRequest]] is *undefined* and *this*.[[pendingPullIntos]] is not empty,
-    1. Let _firstDescriptor_ be the first element of *this*.[[pendingPullIntos]].
-    1. Let _view_ be ! Construct(<a idl>%Uint8Array%</a>, « _firstDescriptor_.[[buffer]],
-       _firstDescriptor_.[[byteOffset]] + _firstDescriptor_.[[bytesFilled]], _firstDescriptor_.[[byteLength]] −
-       _firstDescriptor_.[[bytesFilled]] »).
-    1. Set *this*.[[byobRequest]] to ! Construct(`<a idl>ReadableStreamBYOBRequest</a>`, « *this*, _view_ »).
-  1. Return *this*.[[byobRequest]].
+  1. Return ! ReadableByteStreamControllerGetBYOBRequest(*this*).
 </emu-alg>
 
 <h5 id="rbs-controller-desired-size" attribute for="ReadableByteStreamController" lt="desiredSize">get desiredSize</h5>
@@ -2283,6 +2277,20 @@ nothrow>ReadableByteStreamControllerFillPullIntoDescriptorFromQueue ( <var>contr
     1. Assert: _pullIntoDescriptor_.[[bytesFilled]] > *0*.
     1. Assert: _pullIntoDescriptor_.[[bytesFilled]] < _pullIntoDescriptor_.[[elementSize]].
   1. Return _ready_.
+</emu-alg>
+
+<h4 id="readable-byte-stream-controller-get-byob-request" aoid="ReadableByteStreamControllerGetBYOBRequest"
+nothrow>ReadableByteStreamControllerGetBYOBRequest ( <var>controller</var> )</h4>
+
+<emu-alg>
+  1. If _controller_.[[byobRequest]] is *undefined* and _controller_.[[pendingPullIntos]] is not empty,
+    1. Let _firstDescriptor_ be the first element of _controller_.[[pendingPullIntos]].
+    1. Let _view_ be ! Construct(<a idl>%Uint8Array%</a>, « _firstDescriptor_.[[buffer]],
+       _firstDescriptor_.[[byteOffset]] + _firstDescriptor_.[[bytesFilled]], _firstDescriptor_.[[byteLength]] −
+       _firstDescriptor_.[[bytesFilled]] »).
+    1. Set _controller_.[[byobRequest]] to ! Construct(`<a idl>ReadableStreamBYOBRequest</a>`,
+       « _controller_, _view_ »).
+  1. Return _controller_.[[byobRequest]].
 </emu-alg>
 
 <h4 id="readable-byte-stream-controller-get-desired-size" aoid="ReadableByteStreamControllerGetDesiredSize"

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1212,16 +1212,7 @@ class ReadableByteStreamController {
       throw byteStreamControllerBrandCheckException('byobRequest');
     }
 
-    if (this._byobRequest === undefined && this._pendingPullIntos.length > 0) {
-      const firstDescriptor = this._pendingPullIntos[0];
-      const view = new Uint8Array(firstDescriptor.buffer,
-                                  firstDescriptor.byteOffset + firstDescriptor.bytesFilled,
-                                  firstDescriptor.byteLength - firstDescriptor.bytesFilled);
-
-      this._byobRequest = new ReadableStreamBYOBRequest(this, view);
-    }
-
-    return this._byobRequest;
+    return ReadableByteStreamControllerGetBYOBRequest(this);
   }
 
   get desiredSize() {
@@ -1770,6 +1761,19 @@ function ReadableByteStreamControllerError(controller, e) {
   controller._queue = [];
 
   ReadableStreamError(stream, e);
+}
+
+function ReadableByteStreamControllerGetBYOBRequest(controller) {
+  if (controller._byobRequest === undefined && controller._pendingPullIntos.length > 0) {
+    const firstDescriptor = controller._pendingPullIntos[0];
+    const view = new Uint8Array(firstDescriptor.buffer,
+                                firstDescriptor.byteOffset + firstDescriptor.bytesFilled,
+                                firstDescriptor.byteLength - firstDescriptor.bytesFilled);
+
+    controller._byobRequest = new ReadableStreamBYOBRequest(controller, view);
+  }
+
+  return controller._byobRequest;
 }
 
 function ReadableByteStreamControllerGetDesiredSize(controller) {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -256,6 +256,11 @@ class ReadableStream {
 module.exports = {
   ReadableStream,
   IsReadableStreamDisturbed,
+  ReadableByteStreamControllerClose,
+  ReadableByteStreamControllerEnqueue,
+  ReadableByteStreamControllerError,
+  ReadableByteStreamControllerGetBYOBRequest,
+  ReadableByteStreamControllerGetDesiredSize,
   ReadableStreamDefaultControllerClose,
   ReadableStreamDefaultControllerEnqueue,
   ReadableStreamDefaultControllerError,

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1726,6 +1726,7 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
 
   assert(controller._closeRequested === false);
   assert(stream._state === 'readable');
+  assert(ArrayBuffer.isView(chunk) === true);
 
   const buffer = chunk.buffer;
   const byteOffset = chunk.byteOffset;


### PR DESCRIPTION
Leaves room for writableType as well, which the WritableStream constructor will reject if it's anything other than undefined, at the moment.