### PR TITLE
Remove trivial non-zero delays in wpts

### DIFF
--- a/reference-implementation/to-upstream-wpts/.eslintrc.json
+++ b/reference-implementation/to-upstream-wpts/.eslintrc.json
@@ -53,6 +53,7 @@
     "add_completion_callback": false,
 
     "delay": true,
+    "flushAsyncEvents": true,
     "methodRejects": true,
     "readableStreamToArray": true,
     "recordingReadableStream": true,

--- a/reference-implementation/to-upstream-wpts/piping/close-propagation-forward.js
+++ b/reference-implementation/to-upstream-wpts/piping/close-propagation-forward.js
@@ -407,7 +407,7 @@ promise_test(() => {
   rs.controller.enqueue('a');
   rs.controller.close();
 
-  // Ensure that within 2 event loops, at least, no shutdown occurs.
+  // Flush async events and verify that no shutdown occurs.
   return flushAsyncEvents().then(() => {
     assert_array_equals(ws.events, ['write', 'a']); // no 'close'
     assert_equals(pipeComplete, false, 'the pipe must not be complete');

--- a/reference-implementation/to-upstream-wpts/piping/close-propagation-forward.js
+++ b/reference-implementation/to-upstream-wpts/piping/close-propagation-forward.js
@@ -407,8 +407,8 @@ promise_test(() => {
   rs.controller.enqueue('a');
   rs.controller.close();
 
-  // Ensure that within 50 ms, at least, no shutdown occurs.
-  return delay(50).then(() => {
+  // Ensure that within 2 event loops, at least, no shutdown occurs.
+  return flushAsyncEvents().then(() => {
     assert_array_equals(ws.events, ['write', 'a']); // no 'close'
     assert_equals(pipeComplete, false, 'the pipe must not be complete');
 

--- a/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
+++ b/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
@@ -286,7 +286,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length > 2) {
-        return delay(10).then(() => {
+        return flushAsyncEvents().then(() => {
           throw error1;
         });
       }
@@ -318,7 +318,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length > 2) {
-        return delay(10).then(() => {
+        return flushAsyncEvents().then(() => {
           throw error1;
         });
       }
@@ -347,7 +347,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length > 2) {
-        return delay(10).then(() => {
+        return flushAsyncEvents().then(() => {
           throw error1;
         });
       }

--- a/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
+++ b/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
@@ -286,7 +286,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length > 2) {
-        return flushAsyncEvents().then(() => {
+        return delay(0).then(() => {
           throw error1;
         });
       }
@@ -318,7 +318,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length > 2) {
-        return flushAsyncEvents().then(() => {
+        return delay(0).then(() => {
           throw error1;
         });
       }
@@ -347,7 +347,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length > 2) {
-        return flushAsyncEvents().then(() => {
+        return delay(0).then(() => {
           throw error1;
         });
       }

--- a/reference-implementation/to-upstream-wpts/piping/error-propagation-forward.js
+++ b/reference-implementation/to-upstream-wpts/piping/error-propagation-forward.js
@@ -410,7 +410,7 @@ promise_test(t => {
   return writeCalledPromise.then(() => {
     rs.controller.error(error1);
 
-    // Ensure that within two event loops, at least, no shutdown occurs.
+    // Flush async events and verify that no shutdown occurs.
     return flushAsyncEvents();
   }).then(() => {
     assert_array_equals(ws.events, ['write', 'a']); // no 'abort'

--- a/reference-implementation/to-upstream-wpts/piping/error-propagation-forward.js
+++ b/reference-implementation/to-upstream-wpts/piping/error-propagation-forward.js
@@ -410,8 +410,8 @@ promise_test(t => {
   return writeCalledPromise.then(() => {
     rs.controller.error(error1);
 
-    // Ensure that within 50 ms, at least, no shutdown occurs.
-    return delay(50);
+    // Ensure that within two event loops, at least, no shutdown occurs.
+    return flushAsyncEvents();
   }).then(() => {
     assert_array_equals(ws.events, ['write', 'a']); // no 'abort'
     assert_equals(pipeComplete, false, 'the pipe must not be complete');

--- a/reference-implementation/to-upstream-wpts/piping/flow-control.js
+++ b/reference-implementation/to-upstream-wpts/piping/flow-control.js
@@ -24,8 +24,8 @@ promise_test(t => {
 
   const pipePromise = rs.pipeTo(ws, { preventCancel: true });
 
-  // Give it some time to make sure it doesn't do any reading for at least 50 ms.
-  return delay(50).then(() => {
+  // Wait and make sure it doesn't do any reading.
+  return flushAsyncEvents().then(() => {
     ws.controller.error(error1);
   })
   .then(() => promise_rejects(t, error1, pipePromise, 'pipeTo must reject with the same error'))
@@ -71,7 +71,7 @@ promise_test(() => {
 
   const pipePromise = rs.pipeTo(ws);
 
-  return delay(10).then(() => resolveWritePromise())
+  return flushAsyncEvents().then(() => resolveWritePromise())
     .then(() => Promise.all([firstWritePromise, pipePromise]))
     .then(() => {
       assert_array_equals(rs.eventsWithoutPulls, []);

--- a/reference-implementation/to-upstream-wpts/resources/test-utils.js
+++ b/reference-implementation/to-upstream-wpts/resources/test-utils.js
@@ -43,3 +43,11 @@ self.garbageCollect = () => {
 };
 
 self.delay = ms => new Promise(resolve => step_timeout(resolve, ms));
+
+// For tests which verify that the implementation doesn't do something it shouldn't, it's better not to use a
+// timeout. Instead, assume that any reasonable implementation is going to finish work after 2 times around the event
+// loop, and use flushAsyncEvents().then(() => assert_array_equals(...));
+// Some tests include promise resolutions which may mean the test code takes a couple of event loop visits itself. So go
+// around an extra 2 times to avoid complicating those tests.
+// TODO(ricea): Upstream this function to w3c repository.
+self.flushAsyncEvents = () => delay(0).then(() => delay(0)).then(() => delay(0)).then(() => delay(0));

--- a/reference-implementation/to-upstream-wpts/transform-stream/flush.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/flush.js
@@ -89,7 +89,7 @@ promise_test(() => {
     flush() {
       c.enqueue('x');
       c.enqueue('y');
-      return flushAsyncEvents();
+      return delay(0);
     }
   });
 

--- a/reference-implementation/to-upstream-wpts/transform-stream/flush.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/flush.js
@@ -89,7 +89,7 @@ promise_test(() => {
     flush() {
       c.enqueue('x');
       c.enqueue('y');
-      return delay(10);
+      return flushAsyncEvents();
     }
   });
 

--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -178,7 +178,7 @@ promise_test(t => {
 
   writer.close();
 
-  return flushAsyncEvents().then(() => {
+  return delay(0).then(() => {
     writer.abort(error1);
   })
   .then(() => promise_rejects(t, new TypeError(), writer.closed, 'closed should reject with a TypeError'));

--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -178,7 +178,7 @@ promise_test(t => {
 
   writer.close();
 
-  return delay(20).then(() => {
+  return flushAsyncEvents().then(() => {
     writer.abort(error1);
   })
   .then(() => promise_rejects(t, new TypeError(), writer.closed, 'closed should reject with a TypeError'));

--- a/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
@@ -83,7 +83,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length === 2) {
-        return flushAsyncEvents();
+        return delay(0);
       }
 
       return Promise.reject(error1);

--- a/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
@@ -83,7 +83,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       if (ws.events.length === 2) {
-        return delay(10);
+        return flushAsyncEvents();
       }
 
       return Promise.reject(error1);

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -95,7 +95,7 @@ promise_test(() => {
         assert_true(calledClose, 'ready should not be fulfilled before writer.close() is called');
         assert_array_equals(ws.events, ['write', 'a'], 'sink abort() should not be called');
       }),
-      delay(100).then(() => {
+      flushAsyncEvents().then(() => {
         writer.close();
         calledClose = true;
       })
@@ -107,7 +107,7 @@ promise_test(() => {
   let asyncCloseFinished = false;
   const ws = recordingWritableStream({
     close() {
-      return delay(50).then(() => {
+      return flushAsyncEvents().then(() => {
         asyncCloseFinished = true;
       });
     }

--- a/reference-implementation/to-upstream-wpts/writable-streams/start.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/start.js
@@ -23,7 +23,7 @@ promise_test(() => {
   assert_equals(writer.desiredSize, 0, 'desiredSize should be 0 after writer.write()');
 
   // Wait and verify that write isn't called.
-  return delay(100)
+  return flushAsyncEvents()
       .then(() => {
         assert_array_equals(ws.events, [], 'write should not be called until start promise resolves');
         resolveStartPromise();
@@ -49,7 +49,7 @@ promise_test(() => {
   assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
 
   // Wait and verify that write isn't called.
-  return delay(100).then(() => {
+  return flushAsyncEvents().then(() => {
     assert_array_equals(ws.events, [], 'close should not be called until start promise resolves');
     resolveStartPromise();
     return writer.closed;
@@ -88,7 +88,7 @@ promise_test(() => {
   });
 
   // Wait and verify that write or close aren't called.
-  return delay(100)
+  return flushAsyncEvents()
       .then(() => assert_array_equals(ws.events, [], 'write and close should not be called'));
 }, 'underlying sink\'s write or close should not be invoked if the promise returned by start is rejected');
 

--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -96,7 +96,7 @@ promise_test(() => {
 
         assert_equals(value, undefined, 'writePromise should be fulfilled with undefined');
       }),
-      delay(100).then(() => {
+      flushAsyncEvents().then(() => {
         resolveSinkWritePromise();
         resolveSinkWritePromise = undefined;
       })
@@ -142,7 +142,7 @@ promise_test(t => {
       promise_rejects(t, passedError, writePromise2, 'writePromise2 should reject with passedError')
           .then(() => assert_equals(sinkWritePromiseRejectors.length, 0,
                                     'sinkWritePromise should reject before writePromise2')),
-      delay(100).then(() => {
+      flushAsyncEvents().then(() => {
         sinkWritePromiseRejectors[0](passedError);
         sinkWritePromiseRejectors = [];
       })


### PR DESCRIPTION
Add a util function flushAsyncEvents() which spins the event loop to
ensure that the implementation doesn't do something it shouldn't
asynchronously.

Use this function to replace trivial uses of delay(100) and similar  to
improve test determinism.

This change relates to #548.

Tests which use multiple delays to express ordering requirements have
not been changed. Those tests require individual analysis.