### PR TITLE
rework recording-streams helper

### DIFF
--- a/reference-implementation/to-upstream-wpts/piping/flow-control.js
+++ b/reference-implementation/to-upstream-wpts/piping/flow-control.js
@@ -84,12 +84,8 @@ promise_test(() => {
 
   const rs = recordingReadableStream();
 
-  const startPromise = Promise.resolve();
   let resolveWritePromise;
   const ws = recordingWritableStream({
-    start() {
-      return startPromise;
-    },
     write() {
       if (!resolveWritePromise) {
         // first write
@@ -104,7 +100,7 @@ promise_test(() => {
   const writer = ws.getWriter();
   writer.write('a');
 
-  return startPromise.then(() => {
+  return ws.startPromise.then(() => {
     assert_array_equals(ws.events, ['write', 'a']);
     assert_equals(writer.desiredSize, 0, 'after writing the writer\'s desiredSize must be 0');
     writer.releaseLock();

--- a/reference-implementation/to-upstream-wpts/resources/recording-streams.js
+++ b/reference-implementation/to-upstream-wpts/resources/recording-streams.js
@@ -1,93 +1,132 @@
 'use strict';
 
+function IsThenable(x) {
+  return typeof x === 'object' && typeof x.then === 'function';
+}
+
+function InvokeAndRecordEvent(func, args, event1, events) {
+  let result;
+  event1.begun = true;
+  events.push(event1);
+  try {
+    if (func) {
+      result = func(...args);
+    }
+  } catch (resultE) {
+    event1.thrownError = resultE;
+    throw resultE;
+  }
+  event1.fulfilled = !IsThenable(result);
+  if (!event1.fulfilled) {
+    const event2 = Object.assign({}, event1);
+    event2.begun = false;
+    result = result.then(() => {
+      event2.fulfilled = true;
+      events.push(event2);
+    }, e => {
+      event2.fulfilled = false;
+      event2.thrownError = e;
+      events.push(event2);
+      throw e;
+    });
+  }
+
+  return result;
+}
+
 self.recordingReadableStream = (extras = {}, strategy) => {
   let controllerToCopyOver;
+  let startPromise;
   const events = [];
-  const eventsWithoutPulls = [];
   const stream = new ReadableStream({
     start(controller) {
       controllerToCopyOver = controller;
 
-      if (extras.start) {
-        return extras.start(controller);
-      }
-
-      return undefined;
+      const event = { method: 'start' };
+      const result = InvokeAndRecordEvent(extras.start, [controller], event, events);
+      startPromise = Promise.resolve(result);
+      return result;
     },
     pull(controller) {
-      events.push('pull');
-
-      if (extras.pull) {
-        return extras.pull(controller);
-      }
-
-      return undefined;
+      const event = { method: 'pull' };
+      return InvokeAndRecordEvent(extras.pull, [controller], event, events);
     },
     cancel(reason) {
-      events.push('cancel', reason);
-      eventsWithoutPulls.push('cancel', reason);
-
-      if (extras.cancel) {
-        return extras.cancel(reason);
-      }
-
-      return undefined;
+      const event = { method: 'cancel', value: reason };
+      return InvokeAndRecordEvent(extras.cancel, [reason], event, events);
     }
   }, strategy);
 
   stream.controller = controllerToCopyOver;
-  stream.events = events;
-  stream.eventsWithoutPulls = eventsWithoutPulls;
+  Object.defineProperty(stream, 'events', {
+    get() {
+      return events.filter(e => e.begun && e.method !== 'start').reduce((a, e) => {
+        a.push(e.method);
+        if ('value' in e) {
+          a.push(e.value);
+        }
+        return a;
+      }, []);
+    }
+  });
+  Object.defineProperty(stream, 'eventsWithoutPulls', {
+    get() {
+      return events.filter(e => e.begun && e.method !== 'start' && e.method !== 'pull').reduce((a, e) => {
+        a.push(e.method);
+        if ('value' in e) {
+          a.push(e.value);
+        }
+        return a;
+      }, []);
+    }
+  });
+  stream.startPromise = startPromise;
 
   return stream;
 };
 
 self.recordingWritableStream = (extras = {}, strategy) => {
   let controllerToCopyOver;
+  let startPromise;
   const events = [];
   const stream = new WritableStream({
     start(controller) {
       controllerToCopyOver = controller;
 
-      if (extras.start) {
-        return extras.start(controller);
-      }
-
-      return undefined;
+      const event = { method: 'start' };
+      const result = InvokeAndRecordEvent(extras.start, [controller], event, events);
+      startPromise = Promise.resolve(result);
+      return result;
     },
     write(chunk) {
-      events.push('write', chunk);
-
-      if (extras.write) {
-        return extras.write(chunk);
-      }
-
-      return undefined;
+      const event = { method: 'write', value: chunk };
+      return InvokeAndRecordEvent(extras.write, [chunk], event, events);
     },
     close(...args) {
       assert_array_equals(args, [controllerToCopyOver], 'close must always be called with the controller');
 
-      events.push('close');
-
-      if (extras.close) {
-        return extras.close();
-      }
-
-      return undefined;
+      const event = { method: 'close' };
+      return InvokeAndRecordEvent(extras.close, [], event, events);
     },
     abort(e) {
-      events.push('abort', e);
-
-      if (extras.abort) {
-        return extras.abort(e);
-      }
-
-      return undefined;
+      const event = { method: 'abort', value: e };
+      return InvokeAndRecordEvent(extras.abort, [e], event, events);
     }
   }, strategy);
 
   stream.controller = controllerToCopyOver;
-  stream.events = events;
+  Object.defineProperty(stream, 'events', {
+    get() {
+      return events.filter(e => e.begun && e.method !== 'start').reduce((a, e) => {
+        a.push(e.method);
+        if ('value' in e) {
+          a.push(e.value);
+        }
+        return a;
+      }, []);
+    }
+  });
+  stream.startPromise = startPromise;
 
   return stream;
 };

--- a/reference-implementation/to-upstream-wpts/resources/recording-streams.js
+++ b/reference-implementation/to-upstream-wpts/resources/recording-streams.js
@@ -2,6 +2,8 @@
 
 self.recordingReadableStream = (extras = {}, strategy) => {
   let controllerToCopyOver;
+  const events = [];
+  const eventsWithoutPulls = [];
   const stream = new ReadableStream({
     start(controller) {
       controllerToCopyOver = controller;
@@ -13,7 +15,7 @@ self.recordingReadableStream = (extras = {}, strategy) => {
       return undefined;
     },
     pull(controller) {
-      stream.events.push('pull');
+      events.push('pull');
 
       if (extras.pull) {
         return extras.pull(controller);
@@ -22,8 +24,8 @@ self.recordingReadableStream = (extras = {}, strategy) => {
       return undefined;
     },
     cancel(reason) {
-      stream.events.push('cancel', reason);
-      stream.eventsWithoutPulls.push('cancel', reason);
+      events.push('cancel', reason);
+      eventsWithoutPulls.push('cancel', reason);
 
       if (extras.cancel) {
         return extras.cancel(reason);
@@ -34,14 +36,15 @@ self.recordingReadableStream = (extras = {}, strategy) => {
   }, strategy);
 
   stream.controller = controllerToCopyOver;
-  stream.events = [];
-  stream.eventsWithoutPulls = [];
+  stream.events = events;
+  stream.eventsWithoutPulls = eventsWithoutPulls;
 
   return stream;
 };
 
 self.recordingWritableStream = (extras = {}, strategy) => {
   let controllerToCopyOver;
+  const events = [];
   const stream = new WritableStream({
     start(controller) {
       controllerToCopyOver = controller;
@@ -53,7 +56,7 @@ self.recordingWritableStream = (extras = {}, strategy) => {
       return undefined;
     },
     write(chunk) {
-      stream.events.push('write', chunk);
+      events.push('write', chunk);
 
       if (extras.write) {
         return extras.write(chunk);
@@ -64,7 +67,7 @@ self.recordingWritableStream = (extras = {}, strategy) => {
     close(...args) {
       assert_array_equals(args, [controllerToCopyOver], 'close must always be called with the controller');
 
-      stream.events.push('close');
+      events.push('close');
 
       if (extras.close) {
         return extras.close();
@@ -73,7 +76,7 @@ self.recordingWritableStream = (extras = {}, strategy) => {
       return undefined;
     },
     abort(e) {
-      stream.events.push('abort', e);
+      events.push('abort', e);
 
       if (extras.abort) {
         return extras.abort(e);
@@ -84,7 +87,7 @@ self.recordingWritableStream = (extras = {}, strategy) => {
   }, strategy);
 
   stream.controller = controllerToCopyOver;
-  stream.events = [];
+  stream.events = events;
 
   return stream;
 };

--- a/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/bad-underlying-sinks.js
@@ -114,12 +114,8 @@ promise_test(t => {
 
 promise_test(t => {
 
-  const startPromise = Promise.resolve();
   let rejectSinkWritePromise;
   const ws = recordingWritableStream({
-    start() {
-      return startPromise;
-    },
     write() {
       return new Promise((r, reject) => {
         rejectSinkWritePromise = reject;
@@ -127,7 +123,7 @@ promise_test(t => {
     }
   });
 
-  return startPromise.then(() => {
+  return ws.startPromise.then(() => {
     const writer = ws.getWriter();
     const writePromise = writer.write('a');
     rejectSinkWritePromise(error1);


### PR DESCRIPTION
This is the first building block towards being able to record the events of multiple streams in a single array for future backpressure tests.

The old, flattened `events` array is easy to use with `assert_array_equals`, so it's preserved with a few getter properties on top of the more detailed logging.

The next step is creating a 'factory' object that creates recording writable, readable, and transform streams, and records both when the sink/source/transformer methods are invoked, and when their returned promises fulfill, all in one array so you can see the relative ordering of them all to each other without relying on timeouts. `recorderFactory.createReadable()` et al. would take a new `name` argument to label which stream an event came from, etc.