### PR TITLE
Minor fixes to writable-stream tests

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/brand-checks.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/brand-checks.js
@@ -75,3 +75,5 @@ promise_test(t => {
   return Promise.all([methodRejects(t, WriterProto, 'close', fakeWritableStreamDefaultWriter()),
     methodRejects(t, WriterProto, 'close', realReadableStreamDefaultWriter())]);
 }, 'WritableStreamDefaultWriter.prototype.close enforces a brand check');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/byte-length-queuing-strategy.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/byte-length-queuing-strategy.js
@@ -29,3 +29,5 @@ promise_test(() => {
 
   return writer.close();
 }, 'Closing a writable stream with in-flight writes below the high water mark delays the close call properly');
+
+done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -126,7 +126,7 @@ test(() => {
 
   assert_throws(new TypeError(), () => new WritableStreamDefaultController(stream),
                 'constructor should throw a TypeError exception');
-}, 'WritableStreamDefaultController constructor should throw when passed an initalised WritableStream');
+}, 'WritableStreamDefaultController constructor should throw when passed an initialised WritableStream');
 
 test(() => {
   const stream = new WritableStream();

--- a/reference-implementation/to-upstream-wpts/writable-streams/count-queuing-strategy.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/count-queuing-strategy.js
@@ -125,3 +125,5 @@ promise_test(() => {
     assert_equals(writer.desiredSize, -1, 'desiredSize should be -1 after 9th write()');
   });
 }, 'Correctly governs the value of a WritableStream\'s state property (HWM = 4)');
+
+done();


### PR DESCRIPTION
* Add final done() startments to brand-checks.js,
  byte-length-queuing-strategy.js and count-queuing-strategy.js.
* Correct the spelling of 'initialised'.