### PR TITLE
Invoking methods should not call .apply()

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -45,8 +45,8 @@ exports.IsFiniteNonNegativeNumber = v => {
 };
 
 function Call(F, V, args) {
-  if (typeof method !== 'function') {
-    throw new TypeError(`${P} is not a function`);
+  if (typeof F !== 'function') {
+    throw new TypeError('Argument is not a function');
   }
 
   return Function.prototype.apply.call(F, V, args);

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -45,6 +45,10 @@ exports.IsFiniteNonNegativeNumber = v => {
 };
 
 function Call(F, V, args) {
+  if (typeof method !== 'function') {
+    throw new TypeError(`${P} is not a function`);
+  }
+
   return Function.prototype.apply.call(F, V, args);
 }
 
@@ -56,10 +60,6 @@ exports.InvokeOrNoop = (O, P, args) => {
   const method = O[P];
   if (method === undefined) {
     return undefined;
-  }
-
-  if (typeof method !== 'function') {
-    throw new TypeError(`${P} is not a function`);
   }
 
   return Call(method, O, args);
@@ -91,10 +91,6 @@ exports.PromiseInvokeOrPerformFallback = (O, P, args, F, argsF) => {
 
   if (method === undefined) {
     return F(...argsF);
-  }
-
-  if (typeof method !== 'function') {
-    return Promise.reject(new TypeError(`${P} is not a function`));
   }
 
   try {

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -44,6 +44,10 @@ exports.IsFiniteNonNegativeNumber = v => {
   return true;
 };
 
+function Call(F, V, args) {
+  return Function.prototype.apply.call(F, V, args);
+}
+
 exports.InvokeOrNoop = (O, P, args) => {
   assert(O !== undefined);
   assert(IsPropertyKey(P));
@@ -58,7 +62,7 @@ exports.InvokeOrNoop = (O, P, args) => {
     throw new TypeError(`${P} is not a function`);
   }
 
-  return method.apply(O, args);
+  return Call(method, O, args);
 };
 
 exports.PromiseInvokeOrNoop = (O, P, args) => {
@@ -94,7 +98,7 @@ exports.PromiseInvokeOrPerformFallback = (O, P, args, F, argsF) => {
   }
 
   try {
-    return Promise.resolve(method.apply(O, args));
+    return Promise.resolve(Call(method, O, args));
   } catch (e) {
     return Promise.reject(e);
   }

--- a/reference-implementation/to-upstream-wpts/transform-stream/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/general.js
@@ -284,4 +284,20 @@ promise_test(() => {
   });
 }, 'Transform stream should call transformer methods as methods');
 
+promise_test(() => {
+  function functionWithOverloads() {}
+  functionWithOverloads.apply = () => assert_unreached('apply() should not be called');
+  functionWithOverloads.call = () => assert_unreached('call() should not be called');
+  const ts = new TransformStream({
+    start: functionWithOverloads,
+    transform: functionWithOverloads,
+    flush: functionWithOverloads
+  });
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  return readableStreamToArray(ts.readable);
+}, 'methods should not not have .apply() or .call() called');
+
 done();


### PR DESCRIPTION
The specification documents InvokeOrNoop() and friends as using the
Ecmascript Call() abstract operation. The reference implementation was
calling .apply() on the method instead. Fix it to use
Function.prototype.apply.call() instead.

Also add tests to verify that .apply() and .call() on the underlyingSink
and transformer methods are not called.