### PR TITLE
Aborting a stream should wait for pending writes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2619,7 +2619,7 @@ Instances of {{WritableStream}} are created with the internal slots described in
   </tr>
   <tr>
     <td>\[[pendingCloseRequest]]
-    <td>The promise returned from the writer close method
+    <td>The promise returned from the writer {{WritableStreamDefaultWriter/close()}} method
   </tr>
   <tr>
     <td>\[[pendingAbortRequest]]
@@ -2775,8 +2775,8 @@ writable stream is <a>locked to a writer</a>.
   1. If _controller_.[[writing]] is *true* or _controller_.[[inClose]] is *true*,
     1. Set _stream_.[[pendingAbortRequest]] to <a>a new promise</a>.
     1. If _controller_.[[writing]] is *true*, return the result of transforming _stream_.[[pendingAbortRequest]] by a
-    fulfillment handler that returns
-    ! WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
+    fulfillment handler that returns !
+    WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
     1. Otherwise, return _stream_.[[pendingAbortRequest]].
   1. Return ! WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
 </emu-alg>
@@ -2809,12 +2809,12 @@ visible through the {{WritableStream}}'s public API.
 
 <emu-alg>
   1. Let _oldState_ be _stream_.[[state]].
-  1. Assert: _oldState_ is `"writable"` or `"closing".`
+  1. Assert: _oldState_ is `"writable"` or `"closing"`.
   1. Set _stream_.[[state]] to `"errored"`.
   1. Set _stream_.[[storedError]] to _e_.
   1. Let _controller_ be _stream_.[[writableStreamController]].
   1. If _controller_ is *undefined*, or both _controller_.[[writing]] and _controller_.[[inClose]] are *false*,
-    perform ! WritableStreamRejectUnresolvedPromises(_stream_).
+  perform ! WritableStreamRejectPromisesInReactionToError(_stream_).
   1. Let _writer_ be _stream_.[[writer]].
   1. If _writer_ is not undefined,
     1. If _oldState_ is `"writable"` and !
@@ -2842,8 +2842,8 @@ visible through the {{WritableStream}}'s public API.
     1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
 </emu-alg>
 
-<h4 id="writable-stream-reject-unresolved-promises" aoid="WritableStreamRejectUnresolvedPromises"
-nothrow>WritableStreamRejectUnresolvedPromises ( <var>stream</var> )</h4>
+<h4 id="writable-stream-reject-unresolved-promises" aoid="WritableStreamRejectPromisesInReactionToError"
+nothrow>WritableStreamRejectPromisesInReactionToError ( <var>stream</var> )</h4>
 
 <emu-alg>
   1. Assert: _stream_.[[state]] is `"errored"`.
@@ -2853,7 +2853,7 @@ nothrow>WritableStreamRejectUnresolvedPromises ( <var>stream</var> )</h4>
     1. <a>Reject</a> _writeRequest_ with _storedError_.
   1. Set _stream_.[[writeRequests]] to an empty List.
   1. If _stream_.[[pendingCloseRequest]] is not *undefined*,
-    1. Assert: _stream_.[[writableStreamController]].[[inClose]] is *false*,
+    1. Assert: _stream_.[[writableStreamController]].[[inClose]] is *false*.
     1. <a>Reject</a> _stream_.[[pendingCloseRequest]] with _storedError_.
     1. Set _stream_.[[pendingCloseRequest]] to *undefined*.
   1. Let _writer_ be _stream_.[[writer]].
@@ -3261,7 +3261,7 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
   <tr>
     <td>\[[inClose]]
     <td>A boolean flag set to <emu-val>true</emu-val> while the <a>underlying sink</a>'s <code>close</code> method is
-      executing and has not yet fulfilled, used to prevent the <code>abort</code> method from
+      executing and has not yet fulfilled, used to prevent the {{WritableStreamDefaultWriter/abort()}} method from
       interrupting close
 </table>
 
@@ -3414,7 +3414,7 @@ nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h
   1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`, « ‍_controller_ »).
   1. <a>Upon fulfillment</a> of _sinkClosePromise_,
     1. Assert: _controller_.[[inClose]] is *true*.
-    1. Set  _controller_.[[InClose]] to *false*.
+    1. Set  _controller_.[[inClose]] to *false*.
     1. If _stream_.[[state]] is not `"closing"` or `"errored"`, return.
     1. Assert: _stream_.[[pendingCloseRequest]] is not *undefined*.
     1. <a>Resolve</a> _stream_.[[pendingCloseRequest]] with *undefined*.
@@ -3454,7 +3454,7 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
     1. <a>Resolve</a> _stream_.[[pendingWriteRequest]] with *undefined*.
     1. Set _stream_.[[pendingWriteRequest]] to *undefined*.
     1. If _state_ is `"errored"`,
-      1. Perform ! WritableStreamRejectUnresolvedPromises(_stream_).
+      1. Perform ! WritableStreamRejectPromisesInReactionToError(_stream_).
       1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
         1. <a>Resolve</a>  _stream_.[[pendingAbortRequest]] with *undefined*.
         1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
@@ -3474,7 +3474,7 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
     1. Set _stream_.[[pendingWriteRequest]] to *undefined*.
     1. If _stream_.[[state]] is `"errored"`,
       1. Set _stream_.[[storedError]] to _r_.
-      1. Perform ! WritableStreamRejectUnresolvedPromises(_stream_).
+      1. Perform ! WritableStreamRejectPromisesInReactionToError(_stream_).
     1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
       1. <a>Reject</a>  _stream_.[[pendingAbortRequest]] with _r_.
       1. Set _stream_.[[pendingAbortRequest]] to *undefined*.      

--- a/index.bs
+++ b/index.bs
@@ -2613,6 +2613,18 @@ Instances of {{WritableStream}} are created with the internal slots described in
     <td>\[[writeRequests]]
     <td>A List of promises representing the stream's internal queue of pending writes
   </tr>
+  <tr>
+    <td>\[[pendingWriteRequest]]
+    <td>The promise for the current pending write operation
+  </tr>
+  <tr>
+    <td>\[[pendingCloseRequest]]
+    <td>The promise returned from the writer close method
+  </tr>
+  <tr>
+    <td>\[[pendingAbortRequest]]
+    <td>The promise for a pending abort operation
+  </tr>
 </table>
 
 <h4 id="ws-constructor" constructor for="WritableStream" lt="WritableStream(underlyingSink, queuingStrategy)">new
@@ -2758,6 +2770,14 @@ writable stream is <a>locked to a writer</a>.
   1. Assert: _state_ is `"writable"` or `"closing"`.
   1. Let _error_ be a new *TypeError* indicating that the stream has been aborted.
   1. Perform ! WritableStreamError(_stream_, _error_).
+  1. Let _controller_ be _stream_.[[writableStreamController]].
+  1. Assert: _controller_ is not *undefined*.
+  1. If _controller_.[[writing]] is *true* or _controller_.[[inClose]] is *true*,
+    1. Set _stream_.[[pendingAbortRequest]] to <a>a new promise</a>.
+    1. If _controller_.[[writing]] is *true*, return the result of transforming _stream_.[[pendingAbortRequest]] by a
+    fulfillment handler that returns
+    ! WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
+    1. Otherwise, return _stream_.[[pendingAbortRequest]].
   1. Return ! WritableStreamDefaultControllerAbort(_stream_.[[writableStreamController]], _reason_).
 </emu-alg>
 
@@ -2788,32 +2808,58 @@ visible through the {{WritableStream}}'s public API.
 )</h4>
 
 <emu-alg>
-  1. Let _state_ be _stream_.[[state]].
-  1. Assert: _state_ is `"writable"` or `"closing"`.
-  1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
-    1. <a>Reject</a> _writeRequest_ with _e_.
-  1. Set _stream_.[[writeRequests]] to an empty List.
+  1. Let _oldState_ be _stream_.[[state]].
+  1. Assert: _oldState_ is `"writable"` or `"closing".`
+  1. Set _stream_.[[state]] to `"errored"`.
+  1. Set _stream_.[[storedError]] to _e_.
+  1. Let _controller_ be _stream_.[[writableStreamController]].
+  1. If _controller_ is *undefined*, or both _controller_.[[writing]] and _controller_.[[inClose]] are *false*,
+    perform ! WritableStreamRejectUnresolvedPromises(_stream_).
   1. Let _writer_ be _stream_.[[writer]].
   1. If _writer_ is not undefined,
-    1. <a>Reject</a> _writer_.[[closedPromise]] with _e_.
-    1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
-    1. If _state_ is `"writable"` and !
+    1. If _oldState_ is `"writable"` and !
     WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, <a>reject</a>
     _writer_.[[readyPromise]] with _e_.
     1. Otherwise, set _writer_.[[readyPromise]] to <a>a promise rejected with</a> _e_.
     1. Set _writer_.[[readyPromise]].[[PromiseIsHandled]] to *true*.
-  1. Set _stream_.[[state]] to `"errored"`.
-  1. Set _stream_.[[storedError]] to _e_.
 </emu-alg>
 
 <h4 id="writable-stream-finish-close" aoid="WritableStreamFinishClose" nothrow>WritableStreamFinishClose (
 <var>stream</var> )</h4>
 
 <emu-alg>
-  1. Assert: _stream_.[[state]] is `"closing"`.
+  1. Assert: _stream_.[[state]] is `"closing"` or `"errored"`.
   1. Assert: _stream_.[[writer]] is not *undefined*.
-  1. Set _stream_.[[state]] to `"closed"`.
-  1. <a>Resolve</a> _stream_.[[writer]].[[closedPromise]] with *undefined*.
+  1. If _stream_.[[state]] is `"closing"`,
+    1. <a>Resolve</a> _writer_.[[closedPromise]] with *undefined*.
+    1. Set _stream_.[[state]] to `"closed"`.
+  1. Otherwise,
+    1. Assert: _stream_.[[state]] is `"errored"`.
+    1. <a>Reject</a> _writer_.[[closedPromise]] with _stream_.[[storedError]].
+    1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
+  1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
+    1. <a>Resolve</a> _stream_.[[pendingAbortRequest]] with *undefined*.
+    1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
+</emu-alg>
+
+<h4 id="writable-stream-reject-unresolved-promises" aoid="WritableStreamRejectUnresolvedPromises"
+nothrow>WritableStreamRejectUnresolvedPromises ( <var>stream</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[state]] is `"errored"`.
+  1. Assert: _stream_.[[pendingWriteRequest]] is *undefined*.
+  1. Let _storedError_ be _stream_.[[storedError]].
+  1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
+    1. <a>Reject</a> _writeRequest_ with _storedError_.
+  1. Set _stream_.[[writeRequests]] to an empty List.
+  1. If _stream_.[[pendingCloseRequest]] is not *undefined*,
+    1. Assert: _stream_.[[writableStreamController]].[[inClose]] is *false*,
+    1. <a>Reject</a> _stream_.[[pendingCloseRequest]] with _storedError_.
+    1. Set _stream_.[[pendingCloseRequest]] to *undefined*.
+  1. Let _writer_ be _stream_.[[writer]].
+  1. If _writer_ is not undefined,
+    1. <a>Reject</a> _writer_.[[closedPromise]] with _storedError_.
+    1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
 </emu-alg>
 
 <h4 id="writable-stream-fulfill-write-request" aoid="WritableStreamFulfillWriteRequest"
@@ -3077,12 +3123,12 @@ nothrow>WritableStreamDefaultWriterClose ( <var>writer</var> )</h4>
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"closed"` or `"errored"`, return <a>a promise rejected with</a> a *TypeError* exception.
   1. Assert: _state_ is `"writable"`.
-  1. Let _promise_ be ! WritableStreamAddWriteRequest(_stream_).
+  1. Set _stream_.[[pendingCloseRequest]] to <a>a new promise</a>.
   1. If ! WritableStreamDefaultControllerGetBackpressure(_stream_.[[writableStreamController]]) is *true*, <a>resolve</a>
      _writer_.[[readyPromise]] with *undefined*.
   1. Set _stream_.[[state]] to `"closing"`.
   1. Perform ! WritableStreamDefaultControllerClose(_stream_.[[writableStreamController]]).
-  1. Return _promise_.
+  1. Return _stream_.[[pendingCloseRequest]].
 </emu-alg>
 
 <h4 id="writable-stream-default-writer-close-with-error-propagation" aoid="WritableStreamDefaultWriterCloseWithErrorPropagation"
@@ -3212,6 +3258,11 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
     <td>A boolean flag set to <emu-val>true</emu-val> while the <a>underlying sink</a>'s <code>write</code> method is
       executing and has not yet fulfilled, used to prevent reentrant calls
   </tr>
+  <tr>
+    <td>\[[inClose]]
+    <td>A boolean flag set to <emu-val>true</emu-val> while the <a>underlying sink</a>'s <code>close</code> method is
+      executing and has not yet fulfilled, used to prevent the <code>abort</code> method from
+      interrupting close
 </table>
 
 <h4 id="ws-default-controller-constructor" constructor for="WritableStreamDefaultController"
@@ -3230,7 +3281,7 @@ WritableStreamDefaultController(<var>stream</var>, <var>underlyingSink</var>, <v
   1. Set *this*.[[controlledWritableStream]] to _stream_.
   1. Set *this*.[[underlyingSink]] to _underlyingSink_.
   1. Set *this*.[[queue]] to a new empty List.
-  1. Set *this*.[[started]] and *this*.[[writing]] to *false*.
+  1. Set *this*.[[started]] and *this*.[[writing]] and *this*.[[inClose]] to *false*.
   1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
   1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to
      _normalizedStrategy_.[[highWaterMark]].
@@ -3359,12 +3410,25 @@ nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h
   1. Assert: _stream_.[[state]] is `"closing"`.
   1. Perform ! DequeueValue(_controller_.[[queue]]).
   1. Assert: _controller_.[[queue]] is empty.
+  1. Set _controller_.[[InClose]] to *true*.
   1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`, « ‍_controller_ »).
   1. <a>Upon fulfillment</a> of _sinkClosePromise_,
-    1. If _stream_.[[state]] is not `"closing"`, return.
-    1. Perform ! WritableStreamFulfillWriteRequest(_stream_).
+    1. Assert: _controller_.[[inClose]] is *true*.
+    1. Set  _controller_.[[InClose]] to *false*.
+    1. If _stream_.[[state]] is not `"closing"` or `"errored"`, return.
+    1. Assert: _stream_.[[pendingCloseRequest]] is not *undefined*.
+    1. <a>Resolve</a> _stream_.[[pendingCloseRequest]] with *undefined*.
+    1. Set _stream_.[[pendingCloseRequest]] to *undefined*.
     1. Perform ! WritableStreamFinishClose(_stream_).
   1. <a>Upon rejection</a> of _sinkClosePromise_ with reason _r_,
+    1. Assert: _controller_.[[inClose]] it *true*.
+    1. Set  _controller_.[[InClose]] to *false*.
+    1. Assert: _stream_.[[pendingCloseRequest]] is not *undefined*.
+    1. <a>Reject</a> _stream_.[[pendingCloseRequest]] with _r_.
+    1. Set _stream_.[[pendingCloseRequest]] to *undefined*.
+    1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
+      1. <a>Reject</a> _stream_.[[pendingAbortRequest]] with _r_.
+      1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
     1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
 </emu-alg>
 
@@ -3373,14 +3437,28 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
 
 <emu-alg>
   1. Set _controller_.[[writing]] to *true*.
+  1. Let _stream_ be _controller_.[[controllerWritableStream]].
+  1. Assert: _stream_.[[pendingWriteRequest]] is undefined.
+  1. Assert: _stream_.[[writeRequests]] is not empty.
+  1. Let _writeRequest_ be the first element of _stream_.[[writeRequests]].
+  1. Remove _writeRequest_ from _stream_.[[writeRequests]], shifting all other elements downward (so that the second
+  becomes the first, and so on).
+  1. Set _stream_.[[pendingWriteRequest]] to _writeRequest_.
   1. Let _sinkWritePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"write"`, « ‍_chunk_,
   _controller_ »).
   1. <a>Upon fulfillment</a> of _sinkWritePromise_,
-    1. Let _stream_ be _controller_.[[controlledWritableStream]].
     1. Let _state_ be _stream_.[[state]].
-    1. If _state_ is `"errored"` or `"closed"`, return.
+    1. Assert: _controller_.[[writing]] is *true*.
     1. Set _controller_.[[writing]] to *false*.
-    1. Perform ! WritableStreamFulfillWriteRequest(_stream_).
+    1. Assert: _stream_.[[pendingWriteRequest]] is not *undefined*.
+    1. <a>Resolve</a> _stream_.[[pendingWriteRequest]] with *undefined*.
+    1. Set _stream_.[[pendingWriteRequest]] to *undefined*.
+    1. If _state_ is `"errored"`,
+      1. Perform ! WritableStreamRejectUnresolvedPromises(_stream_).
+      1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
+        1. <a>Resolve</a>  _stream_.[[pendingAbortRequest]] with *undefined*.
+        1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
+      1. Return.
     1. Let _lastBackpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
     1. Perform ! DequeueValue(_controller_.[[queue]]).
     1. If _state_ is not `"closing"`,
@@ -3388,7 +3466,18 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
       1. If _lastBackpressure_ is not _backpressure_, perform !
          WritableStreamUpdateBackpressure(_controller_.[[controlledWritableStream]], _backpressure_).
     1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
-  1. <a>Upon rejection</a> of _sinkWritePromise_ with reason _r_,
+  1. <a>Upon rejection</a> of _sinkWritePromise_ with _r_,
+    1. Assert: _controller_.[[writing]] is *true*.
+    1. Set _controller_.[[writing]] to *false*.
+    1. Assert: _stream_.[[pendingWriteRequest]] is not *undefined*.
+    1. <a>Reject</a> _stream_.[[pendingWriteRequest]] with _r_.
+    1. Set _stream_.[[pendingWriteRequest]] to *undefined*.
+    1. If _stream_.[[state]] is `"errored"`,
+      1. Set _stream_.[[storedError]] to _r_.
+      1. Perform ! WritableStreamRejectUnresolvedPromises(_stream_).
+    1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
+      1. <a>Reject</a>  _stream_.[[pendingAbortRequest]] with _r_.
+      1. Set _stream_.[[pendingAbortRequest]] to *undefined*.      
     1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
 </emu-alg>
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -173,7 +173,10 @@ function TransformStreamTransform(transformStream, chunk) {
 
       return TransformStreamReadableReadyPromise(transformStream);
     },
-    e => TransformStreamErrorIfNeeded(transformStream, e));
+    e => {
+      TransformStreamErrorIfNeeded(transformStream, e);
+      return Promise.reject(e);
+    });
 }
 
 function IsTransformStreamDefaultController(x) {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -172,7 +172,7 @@ function WritableStreamError(stream, e) {
   // This method can be called during the construction of the controller, in which case "controller" will be undefined
   // but the flags are guaranteed to be false anyway.
   if (controller === undefined || controller._writing === false && controller._inClose === false) {
-    WritableStreamRejectUnresolvedPromises(stream);
+    WritableStreamRejectPromisesInReactionToError(stream);
   }
 
   const writer = stream._writer;
@@ -205,7 +205,7 @@ function WritableStreamFinishClose(stream) {
   }
 }
 
-function WritableStreamRejectUnresolvedPromises(stream) {
+function WritableStreamRejectPromisesInReactionToError(stream) {
   assert(stream._state === 'errored');
   assert(stream._pendingWriteRequest === undefined);
 
@@ -735,7 +735,7 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
       stream._pendingWriteRequest = undefined;
 
       if (state === 'errored') {
-        WritableStreamRejectUnresolvedPromises(stream);
+        WritableStreamRejectPromisesInReactionToError(stream);
 
         if (stream._pendingAbortRequest !== undefined) {
           stream._pendingAbortRequest._resolve();
@@ -763,7 +763,7 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
       stream._pendingWriteRequest = undefined;
       if (stream._state === 'errored') {
         stream._storedError = r;
-        WritableStreamRejectUnresolvedPromises(stream);
+        WritableStreamRejectPromisesInReactionToError(stream);
       }
       if (stream._pendingAbortRequest !== undefined) {
         stream._pendingAbortRequest._reject(r);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -681,7 +681,6 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
   const sinkWritePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'write', [chunk, controller]);
   sinkWritePromise.then(
     () => {
-      const stream = controller._controlledWritableStream; // eslint-disable-line no-shadow
       const state = stream._state;
 
       controller._writing = false;

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -676,6 +676,9 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
       stream._pendingWriteRequest._resolve(undefined);
       stream._pendingWriteRequest = undefined;
 
+      if (state === 'errored') {
+        return;
+      }
       const lastBackpressure = WritableStreamDefaultControllerGetBackpressure(controller);
       DequeueValue(controller._queue);
       if (state !== 'closing') {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -707,6 +707,7 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
       stream._pendingWriteRequest._reject(r);
       stream._pendingWriteRequest = undefined;
       if (stream._state === 'errored') {
+        stream._storedError = r;
         WritableStreamRejectUnresolvedPromises(stream);
       }
       WritableStreamDefaultControllerErrorIfNeeded(controller, r);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -216,6 +216,7 @@ function WritableStreamRejectUnresolvedPromises(stream) {
   stream._writeRequests = [];
 
   if (stream._pendingCloseRequest !== undefined) {
+    assert(stream._writableStreamController._inClose === false);
     stream._pendingCloseRequest._reject(storedError);
     stream._pendingCloseRequest = undefined;
   }

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -126,7 +126,7 @@ function WritableStreamAbort(stream, reason) {
 
   const controller = stream._writableStreamController;
   assert(controller !== undefined);
-  if (controller._writing !== false || controller._inClose !== false) {
+  if (controller._writing === true || controller._inClose === true) {
     const promise = new Promise((resolve, reject) => {
       const abortRequest = {
         _resolve: resolve,

--- a/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
+++ b/reference-implementation/to-upstream-wpts/piping/error-propagation-backward.js
@@ -611,8 +611,7 @@ promise_test(t => {
   const ws = recordingWritableStream({
     write() {
       resolveWriteCalled();
-      // never settles, which normally would hang the pipe, except we error via the controller.
-      return new Promise(() => {});
+      return flushAsyncEvents();
     }
   });
 
@@ -629,6 +628,6 @@ promise_test(t => {
     assert_array_equals(ws.events, ['write', 'a']);
   });
 
-}, 'Errors must be propagated backward: erroring via the controller errors a slow write');
+}, 'Errors must be propagated backward: erroring via the controller errors once pending write completes');
 
 done();

--- a/reference-implementation/to-upstream-wpts/transform-stream/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/errors.js
@@ -18,9 +18,8 @@ promise_test(t => {
 
   const writer = ts.writable.getWriter();
 
+  writer.write('a');
   return Promise.all([
-    promise_rejects(t, thrownError, writer.write('a'),
-                    'writable\'s write should reject with the thrown error'),
     promise_rejects(t, thrownError, reader.read(),
                     'readable\'s read should reject with the thrown error'),
     promise_rejects(t, thrownError, reader.closed,

--- a/reference-implementation/to-upstream-wpts/transform-stream/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-stream/errors.js
@@ -18,8 +18,9 @@ promise_test(t => {
 
   const writer = ts.writable.getWriter();
 
-  writer.write('a');
   return Promise.all([
+    promise_rejects(t, thrownError, writer.write('a'),
+                    'writable\'s write should reject with the thrown error'),
     promise_rejects(t, thrownError, reader.read(),
                     'readable\'s read should reject with the thrown error'),
     promise_rejects(t, thrownError, reader.closed,

--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -75,8 +75,6 @@ promise_test(t => {
     });
 }, 'Aborting a WritableStream immediately prevents future writes');
 
-// https://github.com/whatwg/streams/issues/611
-/*
 promise_test(t => {
   const ws = recordingWritableStream();
   const results = [];
@@ -103,7 +101,6 @@ promise_test(t => {
       return Promise.all(results);
     });
 }, 'Aborting a WritableStream prevents further writes after any that are in progress');
-*/
 
 promise_test(() => {
   const ws = new WritableStream({

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -33,7 +33,7 @@ promise_test(t => {
   const writer = ws.getWriter();
 
   return Promise.all([
-    promise_rejects(t, passedError, writer.close(), 'close() should be rejected with the passed error'),
+    writer.close(),
     delay(10).then(() => controller.error(passedError)),
     promise_rejects(t, passedError, writer.closed,
                     'closed promise should be rejected with the passed error'),
@@ -51,8 +51,7 @@ promise_test(t => {
 
   const writer = ws.getWriter();
 
-  return promise_rejects(t, passedError, writer.close(), 'close promise should be rejected with the passed error')
-      .then(() => promise_rejects(t, passedError, writer.closed, 'closed should stay rejected'));
+  return writer.close().then(() => promise_rejects(t, passedError, writer.closed, 'closed should stay rejected'));
 }, 'when sink calls error synchronously while closing, the stream should become errored');
 
 promise_test(() => {

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -51,7 +51,7 @@ promise_test(t => {
   const writer = ws.getWriter();
 
   return Promise.all([
-    promise_rejects(t, error1, writer.close(), 'close() should reject with the error'),
+    writer.close(),
     promise_rejects(t, error1, writer.closed, 'controller.error() in close() should error the stream')
   ]);
 }, 'controller argument should be passed to close method');

--- a/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/constructor.js
@@ -36,7 +36,7 @@ promise_test(t => {
   const writer = ws.getWriter();
 
   return Promise.all([
-    promise_rejects(t, error1, writer.write('a'), 'write() should reject with the error'),
+    writer.write('a'),
     promise_rejects(t, error1, writer.closed, 'controller.error() in write() should errored the stream')
   ]);
 }, 'controller argument should be passed to write method');


### PR DESCRIPTION
This is a work-in-progress for #611.

I haven't updated the standard language to match yet. I would like to get an initial round of feedback on the changes before I do that.

PTAL.