### PR TITLE
Do not assert() when writer is detached during close()

### DIFF
--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -164,10 +164,6 @@ function WritableStreamError(stream, e) {
 function WritableStreamFinishClose(stream) {
   assert(stream._state === 'closing');
 
-  // writer cannot be released while close() is ongoing. So, we can assert that
-  // there's an active writer.
-  assert(stream._writer !== undefined);
-
   stream._state = 'closed';
 
   defaultWriterClosedPromiseResolve(stream._writer);

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -139,4 +139,18 @@ promise_test(t => {
   return promise_rejects(t, rejection, ws.getWriter().close(), 'close() should return a rejection');
 }, 'returning a thenable from close() should work');
 
+promise_test(t => {
+  const ws = new WritableStream();
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const closePromise = writer.close();
+    const closedPromise = writer.closed;
+    writer.releaseLock();
+    return Promise.all([
+      closePromise,
+      promise_rejects(t, new TypeError(), closedPromise, '.closed promise should be rejected')
+    ]);
+  });
+}, 'releaseLock() should not change the result of close()');
+
 done();

--- a/reference-implementation/to-upstream-wpts/writable-streams/close.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/close.js
@@ -151,6 +151,24 @@ promise_test(t => {
       promise_rejects(t, new TypeError(), closedPromise, '.closed promise should be rejected')
     ]);
   });
-}, 'releaseLock() should not change the result of close()');
+}, 'releaseLock() should not change the result of sync close()');
+
+promise_test(t => {
+  const ws = new WritableStream({
+    close() {
+      return flushAsyncEvents();
+    }
+  });
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const closePromise = writer.close();
+    const closedPromise = writer.closed;
+    writer.releaseLock();
+    return Promise.all([
+      closePromise,
+      promise_rejects(t, new TypeError(), closedPromise, '.closed promise should be rejected')
+    ]);
+  });
+}, 'releaseLock() should not change the result of async close()');
 
 done();


### PR DESCRIPTION
When writer.releaseLock() was called during us.close(), an assert would
fire in WritableStreamFinishClose() as it expected the writer to still
be attached.

Since detaching the writer during close() is permitted, remove the
assert.

Also add tests that this works correctly.