### PR TITLE
Specify ReadableStream.[[Transfer]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -376,7 +376,7 @@ Instances of {{ReadableStream}} are created with the internal slots described in
     </tr>
   </thead>
   <tr>
-    <td>\[[Detached]]
+    <td>{{[[Detached]]}}</a>
     <td>A boolean flag set to <emu-val>true</emu-val> when the stream has been transferred away to another realm
   </tr>
   <tr>
@@ -452,7 +452,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 <emu-alg>
   1. Set *this*.[[state]] to `"readable"`.
   1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
-  1. Set *this*.[[Detached]] to *false*.
+  1. Set *this*.<a idl>[[Detached]]</a> to *false*.
   1. Set *this*.[[disturbed]] to *false*.
   1. Set *this*.[[readableStreamController]] to *undefined*.
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
@@ -742,7 +742,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 
 The following internal method is implemented by each {{ReadableStream}} instance.
 
-<h5 id="rs-internal-method-transfer">\[[Transfer]](<var>targetRealm</var>)</h5>
+<h5 id="rs-internal-method-transfer"><a idl lt="[[Transfer]]()">\[[Transfer]](<var>targetRealm</var>)</a></h5>
 
 <emu-alg>
   1. If ! IsReadableStreamLocked(*this*) is *true*, throw a *TypeError* exception.
@@ -758,7 +758,7 @@ The following internal method is implemented by each {{ReadableStream}} instance
   1. Repeat for each Record {[[value]], [[size]]} _pair_ that is an element of _queue_,
     1. Set _pair_.[[value]] to ! <a abstract-op>StructuredClone</a>(_pair_.[[value]], _targetRealm_).
   1. Set _controller_.[[targetRealm]] to _targetRealm_.
-  1. Set _this_.[[Detached]] to *true*.
+  1. Set _this_.<a idl>[[Detached]]</a> to *true*.
   1. Return _that_.
 </emu-alg>
 
@@ -814,7 +814,7 @@ readable stream is <a>locked to a reader</a> or has been transferred away to ano
 
 <emu-alg>
   1. Assert: ! IsReadableStream(_stream_) is *true*.
-  1. If _stream_.[[Detached]] is *true*, return *true*.
+  1. If _stream_.<a idl>[[Detached]]</a> is *true*, return *true*.
   1. If _stream_.[[reader]] is *undefined*, return *false*.
   1. Return *true*.
 </emu-alg>
@@ -970,7 +970,7 @@ nothrow>ReadableStreamAddReadIntoRequest ( <var>stream</var> )</h4>
 <var>reason</var> )</h4>
 
 <emu-alg>
-  1. Assert: _stream_.[[Detached]] is *false*.
+  1. Assert: _stream_.<a idl>[[Detached]]</a> is *false*.
   1. Set _stream_.[[disturbed]] to *true*.
   1. If _stream_.[[state]] is `"closed"`, return <a>a promise resolved with</a> *undefined*.
   1. If _stream_.[[state]] is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].

--- a/index.bs
+++ b/index.bs
@@ -376,7 +376,7 @@ Instances of {{ReadableStream}} are created with the internal slots described in
     </tr>
   </thead>
   <tr>
-    <td>{{[[Detached]]}}</a>
+    <td>{{[[Detached]]}}
     <td>A boolean flag set to <emu-val>true</emu-val> when the stream has been transferred away to another realm
   </tr>
   <tr>

--- a/index.bs
+++ b/index.bs
@@ -461,10 +461,10 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
     1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableByteStreamController</a>`, « *this*,
        _underlyingSource_, _highWaterMark_ »).
-  1. Otherwise, if _type_ is *undefined*,
+  1. Otherwise, if _type_ is *undefined* or _type_ is `"cloning"`,
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
     1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableStreamDefaultController</a>`, « *this*,
-       _underlyingSource_, _size_, _highWaterMark_ »).
+       _underlyingSource_, _size_, _highWaterMark_, _type_ »).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
 
@@ -747,12 +747,17 @@ The following internal method is implemented by each {{ReadableStream}} instance
 <emu-alg>
   1. If ! IsReadableStreamLocked(*this*) is *true*, throw a *TypeError* exception.
   1. If *this*.[[state]] is `"errored"`, throw a *TypeError* exception.
+  1. Let _controller_ be *this*.[[readableStreamController]].
+  1. If _controller_.[[targetRealm]] is *undefined*, throw a *TypeError* exception.
   1. Let _that_ be a new instance of <a idl>ReadableStream</a> in _targetRealm_.
   1. Set _that_.[[state]] to  *this*.[[state]].
   1. Set _that_.[[disturbed]] to *this*.[[disturbed]].
-  1. Let _controller_ be *this*.[[readableStreamController]].
   1. Set _controller_.[[controlledReadableStream]] to _that_.
   1. Set _that_.[[readableStreamController]] to _controller_.
+  1. Let _queue_ be _controller_.[[queue]].
+  1. Repeat for each Record {[[value]], [[size]]} _pair_ that is an element of _queue_,
+    1. Set _pair_.[[value]] to ! <a abstract-op>StructuredClone</a>(_pair_.[[value]], _targetRealm_).
+  1. Set _controller_.[[targetRealm]] to _targetRealm_.
   1. Set _this_.[[Detached]] to *true*.
   1. Return _that_.
 </emu-alg>
@@ -1473,6 +1478,12 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
     </tr>
   </thead>
   <tr>
+    <td>\[[targetRealm]]
+    <td>Either *undefined*, or a Realm Record. If set to a Realm Record, ReadableStreamDefaultControllerEnqueue
+      will perform the structured clone algorithm on passed chunks, cloning them into the targetRealm
+      and enqueueing the result.
+  </tr>
+  <tr>
     <td>\[[closeRequested]]
     <td>A boolean flag indicating whether the stream has been closed by its <a>underlying source</a>, but still has
       <a>chunks</a> in its internal queue that have not yet been read
@@ -1520,7 +1531,7 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
 <h4 id="rs-default-controller-constructor" constructor for="ReadableStreamDefaultController"
 lt="ReadableStreamDefaultController(stream, underlyingSource, size, highWaterMark)">new
 ReadableStreamDefaultController(<var>stream</var>, <var>underlyingSource</var>, <var>size</var>,
-<var>highWaterMark</var>)</h4>
+<var>highWaterMark</var>, <var>type</var>)</h4>
 
 <div class="note">
   The <code>ReadableStreamDefaultController</code> constructor cannot be used directly; it only works on a
@@ -1534,6 +1545,8 @@ ReadableStreamDefaultController(<var>stream</var>, <var>underlyingSource</var>, 
   1. Set *this*.[[underlyingSource]] to _underlyingSource_.
   1. Set *this*.[[queue]] to a new empty List.
   1. Set *this*.[[started]], *this*.[[closeRequested]], *this*.[[pullAgain]], and *this*.[[pulling]] to *false*.
+  1. Set *this*.[[targetRealm]] to *undefined*.
+  1. If _type_ is `"cloning"`, set *this*.[[targetRealm]] to the current Realm Record.
   1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
   1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to
      _normalizedStrategy_.[[highWaterMark]].
@@ -1707,8 +1720,14 @@ asserts).
   1. Let _stream_ be _controller_.[[controlledReadableStream]].
   1. Assert: _controller_.[[closeRequested]] is *false*.
   1. Assert: _stream_.[[state]] is `"readable"`.
-  1. If ! IsReadableStreamLocked(_stream_) is *true* and ! ReadableStreamGetNumReadRequests(_stream_) > *0*, perform
-     ! ReadableStreamFulfillReadRequest(_stream_, _chunk_, *false*).
+  1. If ! IsReadableStreamLocked(_stream_) is *true* and ! ReadableStreamGetNumReadRequests(_stream_) > *0*,
+    1. If _controller_.[[targetRealm]] is not *undefined*,
+      1. Let _chunk_ be <a abstract-op>StructuredClone</a>(_chunk_, _controller_.[[targetRealm]]).
+      1. If _chunk_ is an abrupt completion,
+        1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _chunk_.[[Value]]).
+        1. Return _chunk_.
+      1. Let _chunk_ be _chunk_.[[Value]].
+    1. Perform ! ReadableStreamFulfillReadRequest(_stream_, _chunk_, *false*).
   1. Otherwise,
     1. Let _chunkSize_ be *1*.
     1. If _controller_.[[strategySize]] is not *undefined*,
@@ -3615,11 +3634,13 @@ throughout the rest of this standard.
 </emu-alg>
 
 <h4 id="enqueue-value-with-size" aoid="EnqueueValueWithSize" throws>EnqueueValueWithSize ( <var>queue</var>,
-<var>value</var>, <var>size</var> )</h4>
+<var>value</var>, <var>size</var>, <var>targetRealm</var> )</h4>
 
 <emu-alg>
+  1. If _targetRealm_ was not passed, let _targetRealm_ be *undefined*.
   1. Let _size_ be ? ToNumber(_size_).
   1. If ! IsFiniteNonNegativeNumber(_size_) is *false*, throw a *RangeError* exception.
+  1. If _targetRealm_ is not *undefined*, let _value_ be the result of ? StructuredClone(_value_, _targetRealm_).
   1. Append Record {[[value]]: _value_, [[size]]: _size_} as the last element of _queue_.
 </emu-alg>
 

--- a/index.bs
+++ b/index.bs
@@ -376,6 +376,10 @@ Instances of {{ReadableStream}} are created with the internal slots described in
     </tr>
   </thead>
   <tr>
+    <td>\[[Detached]]
+    <td>A boolean flag set to <emu-val>true</emu-val> when the stream has been transferred away to another realm
+  </tr>
+  <tr>
     <td>\[[disturbed]]
     <td>A boolean flag set to <emu-val>true</emu-val> when the stream has been read from or canceled
   </tr>
@@ -448,6 +452,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 <emu-alg>
   1. Set *this*.[[state]] to `"readable"`.
   1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
+  1. Set *this*.[[Detached]] to *false*.
   1. Set *this*.[[disturbed]] to *false*.
   1. Set *this*.[[readableStreamController]] to *undefined*.
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
@@ -733,6 +738,25 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
   </code></pre>
 </div>
 
+<h4 id="rs-internal-methods">Readable Stream Internal Methods</h4>
+
+The following internal method is implemented by each {{ReadableStream}} instance.
+
+<h5 id="rs-internal-method-transfer">\[[Transfer]](<var>targetRealm</var>)</h5>
+
+<emu-alg>
+  1. If ! IsReadableStreamLocked(*this*) is *true*, throw a *TypeError* exception.
+  1. If *this*.[[state]] is `"errored"`, throw a *TypeError* exception.
+  1. Let _that_ be a new instance of <a idl>ReadableStream</a> in _targetRealm_.
+  1. Set _that_.[[state]] to  *this*.[[state]].
+  1. Set _that_.[[disturbed]] to *this*.[[disturbed]].
+  1. Let _controller_ be *this*.[[readableStreamController]].
+  1. Set _controller_.[[controlledReadableStream]] to _that_.
+  1. Set _that_.[[readableStreamController]] to _controller_.
+  1. Set _this_.[[Detached]] to *true*.
+  1. Return _that_.
+</emu-alg>
+
 <h3 id="rs-abstract-ops">General Readable Stream Abstract Operations</h3>
 
 The following abstract operations, unlike most in this specification, are meant to be generally useful by other
@@ -781,10 +805,11 @@ readable stream has ever been read from or canceled.
 <var>stream</var> )</h4>
 
 This abstract operation is meant to be called from other specifications that may wish to query whether or not a
-readable stream is <a>locked to a reader</a>.
+readable stream is <a>locked to a reader</a> or has been transferred away to another realm.
 
 <emu-alg>
   1. Assert: ! IsReadableStream(_stream_) is *true*.
+  1. If _stream_.[[Detached]] is *true*, return *true*.
   1. If _stream_.[[reader]] is *undefined*, return *false*.
   1. Return *true*.
 </emu-alg>
@@ -940,6 +965,7 @@ nothrow>ReadableStreamAddReadIntoRequest ( <var>stream</var> )</h4>
 <var>reason</var> )</h4>
 
 <emu-alg>
+  1. Assert: _stream_.[[Detached]] is *false*.
   1. Set _stream_.[[disturbed]] to *true*.
   1. If _stream_.[[state]] is `"closed"`, return <a>a promise resolved with</a> *undefined*.
   1. If _stream_.[[state]] is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -1,5 +1,7 @@
 'use strict';
 const assert = require('assert');
+/* structured clone is impossible to truly polyfill, but closest match */
+const StructuredClone = require('realistic-structured-clone');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
 exports.DequeueValue = queue => {
@@ -11,10 +13,14 @@ exports.DequeueValue = queue => {
   return pair.value;
 };
 
-exports.EnqueueValueWithSize = (queue, value, size) => {
+exports.EnqueueValueWithSize = (queue, value, size, targetRealm) => {
   size = Number(size);
   if (!IsFiniteNonNegativeNumber(size)) {
     throw new RangeError('Size must be a finite, non-NaN, non-negative number.');
+  }
+
+  if (targetRealm !== undefined) {
+    value = StructuredClone(value/* , targetRealm*/);
   }
 
   queue.push({ value, size });

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -14,7 +14,7 @@ const { AcquireWritableStreamDefaultWriter, IsWritableStream, IsWritableStreamLo
 
 const InternalCancel = Symbol('[[Cancel]]');
 const InternalPull = Symbol('[[Pull]]');
-const InternalTranfer = Symbol('[[Transfer]]');
+const InternalTransfer = Symbol('[[Transfer]]');
 
 class ReadableStream {
   constructor(underlyingSource = {}, { size, highWaterMark } = {}) {
@@ -258,7 +258,7 @@ class ReadableStream {
     return createArrayFromList(branches);
   }
 
-  [InternalTranfer](/* targetRealm */) {
+  [InternalTransfer](/* targetRealm */) {
     if (IsReadableStreamLocked(this) === true) {
       throw new TypeError('Cannot transfer a locked stream');
     }

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -15,6 +15,9 @@
     "Takeshi Yoshino <tyoshino@chromium.org>"
   ],
   "license": "(CC0-1.0 OR MIT)",
+  "dependencies": {
+    "realistic-structured-clone": "^0.0.3"
+  },
   "devDependencies": {
     "eslint": "^3.2.2",
     "glob": "^7.0.3",


### PR DESCRIPTION
See also #276.

As @domenic mentioned in https://github.com/whatwg/streams/issues/244#issuecomment-257041201, this effort seems more or less blocked on https://github.com/whatwg/html/issues/935, but this at least gives a general idea of the parts it would need to touch.

In particular, there's an apparent problem with transferring errored streams (namely `[[storedError]]`), as well as the open question of what even ends up in [[storedError]] if the underlyingSource throws or calls `controller.error()` it from the original realm with something uncloneable.

StructuredClone doesn't seem to be actually possible to truly polyfill as it iterates over objects in a different order than for-in does, and there doesn't seem to be an obvious way to replicate it; is there any reason StructuredClone isn't/ shouldn't be exposed on its own by the JS engine, for admittedly really niche use cases like this?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/623.html" title="Last updated on Jan 15, 2021, 7:26 AM UTC (ebe73f8)">Preview</a> | <a href="https://whatpr.org/streams/623/872188a...ebe73f8.html" title="Last updated on Jan 15, 2021, 7:26 AM UTC (ebe73f8)">Diff</a>