### PR TITLE
Do not leak the closed promise on errored release

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3167,7 +3167,8 @@ nothrow>WritableStreamDefaultWriterRelease ( <var>writer</var> )</h4>
   1. Assert: _stream_.[[writer]] is _writer_.
   1. Let _releasedError_ be a new *TypeError*.
   1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"writable"` or `"closing"`, <a>reject</a> _writer_.[[closedPromise]] with _releasedError_.
+  1. If _state_ is `"writable"` or `"closing"`, or _stream_.[[pendingAbortRequest]] is not *undefined*, <a>reject</a>
+  _writer_.[[closedPromise]] with _releasedError_.
   1. Otherwise, set _writer_.[[closedPromise]] to <a>a promise rejected with</a> _releasedError_.
   1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
   1. If _state_ is `"writable"` and !

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -471,7 +471,7 @@ function WritableStreamDefaultWriterRelease(writer) {
     'Writer was released and can no longer be used to monitor the stream\'s closedness');
   const state = stream._state;
 
-  if (state === 'writable' || state === 'closing') {
+  if (state === 'writable' || state === 'closing' || stream._pendingAbortRequest !== undefined) {
     defaultWriterClosedPromiseReject(writer, releasedError);
   } else {
     defaultWriterClosedPromiseResetToRejected(writer, releasedError);

--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -483,9 +483,10 @@ promise_test(t => {
     const abortPromise = writer.abort();
     writer.releaseLock();
     resolveWrite();
-    return Promise.all([writePromise,
-                        abortPromise,
-                        promise_rejects(t, new TypeError(), closed, 'closed should reject')]);
+    return Promise.all([
+      writePromise,
+      abortPromise,
+      promise_rejects(t, new TypeError(), closed, 'closed should reject')]);
   });
 }, 'releaseLock() while aborting should reject the original promise');
 
@@ -493,7 +494,7 @@ promise_test(t => {
   let resolveWrite;
   let resolveAbort;
   let resolveAbortStarted;
-  let abortStarted = new Promise(resolve => {
+  const abortStarted = new Promise(resolve => {
     resolveAbortStarted = resolve;
   });
   const ws = new WritableStream({
@@ -519,9 +520,11 @@ promise_test(t => {
       writer.releaseLock();
       assert_not_equals(writer.closed, closed, 'closed promise should have changed');
       resolveAbort();
-      return Promise.all([abortPromise,
-                          promise_rejects(t, new TypeError(), closed, 'original closed should reject'),
-                          promise_rejects(t, new TypeError(), writer.closed, 'new closed should reject')]);
+      return Promise.all([
+        writePromise,
+        abortPromise,
+        promise_rejects(t, new TypeError(), closed, 'original closed should reject'),
+        promise_rejects(t, new TypeError(), writer.closed, 'new closed should reject')]);
     });
   });
 }, 'releaseLock() during delayed async abort() should create a new rejected promise');

--- a/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/aborting.js
@@ -488,7 +488,7 @@ promise_test(t => {
       abortPromise,
       promise_rejects(t, new TypeError(), closed, 'closed should reject')]);
   });
-}, 'releaseLock() while aborting should reject the original promise');
+}, 'releaseLock() while aborting should reject the original closed promise');
 
 promise_test(t => {
   let resolveWrite;
@@ -527,6 +527,6 @@ promise_test(t => {
         promise_rejects(t, new TypeError(), writer.closed, 'new closed should reject')]);
     });
   });
-}, 'releaseLock() during delayed async abort() should create a new rejected promise');
+}, 'releaseLock() during delayed async abort() should create a new rejected closed promise');
 
 done();


### PR DESCRIPTION
Prior to #619, abort() would reject the closed promise immediately. Now
it waits for queued sink operations to finish. This means that there can
be a window when the stream is errored but the closed promise has not
been rejected. If releaseLock() was called during the window it would
incorrectly create a new closed promise on the assumption it was already
rejected.

Instead, when an abort() is pending, reject the promise rather than
creating a new one.