### PR TITLE
Specify WritableStream.[[Transfer]]

### DIFF
--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -15,6 +15,9 @@
     "Takeshi Yoshino <tyoshino@chromium.org>"
   ],
   "license": "(CC0-1.0 OR MIT)",
+  "dependencies": {
+    "realistic-structured-clone": "^0.0.3"
+  },
   "devDependencies": {
     "eslint": "^3.2.2",
     "glob": "^7.0.3",


### PR DESCRIPTION
The only trouble is that, currently, `writer.write()` is specified to indirectly invoke `strategy.size()` synchronously, which is bad if `strategy.size` runs in a different JS context entirely.

Cf. #623.