### PR TITLE
don't invoke [[strategySize]] as method

### DIFF
--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1067,8 +1067,9 @@ function ReadableStreamDefaultControllerEnqueue(controller, chunk) {
     let chunkSize = 1;
 
     if (controller._strategySize !== undefined) {
+      const strategySize = controller._strategySize;
       try {
-        chunkSize = controller._strategySize(chunk);
+        chunkSize = strategySize(chunk);
       } catch (chunkSizeE) {
         ReadableStreamDefaultControllerErrorIfNeeded(controller, chunkSizeE);
         throw chunkSizeE;

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -597,8 +597,9 @@ function WritableStreamDefaultControllerWrite(controller, chunk) {
   let chunkSize = 1;
 
   if (controller._strategySize !== undefined) {
+    const strategySize = controller._strategySize;
     try {
-      chunkSize = controller._strategySize(chunk);
+      chunkSize = strategySize(chunk);
     } catch (chunkSizeE) {
       // TODO: Should we notify the sink of this error?
       WritableStreamDefaultControllerErrorIfNeeded(controller, chunkSizeE);

--- a/reference-implementation/to-upstream-wpts/writable-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/general.js
@@ -188,6 +188,21 @@ promise_test(t => {
 }, 'methods should not not have .apply() or .call() called');
 
 promise_test(() => {
+  const strategy = {
+    size() {
+      if (this !== undefined) {
+        throw new Error('size called as a method');
+      }
+      return 1;
+    }
+  };
+
+  const ws = new WritableStream({}, strategy);
+  const writer = ws.getWriter();
+  return writer.write('a');
+}, 'WritableStream\'s strategy.size should not be called as a method');
+
+promise_test(() => {
   const ws = new WritableStream();
   const writer1 = ws.getWriter();
   assert_equals(undefined, writer1.releaseLock(), 'releaseLock() should return undefined');


### PR DESCRIPTION
The spec text says to Call it with *this* as undefined. That wasn't what the reference implementation was doing.