### PR TITLE
When underlyingSink.close() resolves, assert state

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3405,7 +3405,7 @@ nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h
   1. <a>Upon fulfillment</a> of _sinkClosePromise_,
     1. Assert: _controller_.[[inClose]] is *true*.
     1. Set  _controller_.[[inClose]] to *false*.
-    1. If _stream_.[[state]] is not `"closing"` or `"errored"`, return.
+    1. Assert: _stream_.[[state]] is `"closing"` or `"errored"`.
     1. Assert: _stream_.[[pendingCloseRequest]] is not *undefined*.
     1. <a>Resolve</a> _stream_.[[pendingCloseRequest]] with *undefined*.
     1. Set _stream_.[[pendingCloseRequest]] to *undefined*.

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -689,10 +689,7 @@ function WritableStreamDefaultControllerProcessClose(controller) {
     () => {
       assert(controller._inClose === true);
       controller._inClose = false;
-      if (stream._state !== 'closing' && stream._state !== 'errored') {
-        return;
-      }
-
+      assert(stream._state === 'closing' || stream._state === 'errored');
       assert(stream._pendingCloseRequest !== undefined);
       stream._pendingCloseRequest._resolve(undefined);
       stream._pendingCloseRequest = undefined;


### PR DESCRIPTION
Previously, WritableStreamDefaultControllerProcessClose checked the
state was "closing" or "errored" when underlyingSink.close()
resolved. In fact it can't be anything else, so make it an assert
instead.

Thanks to @tyoshino for spotting this.