### PR TITLE
Include server-worker include in pipe-through test

### DIFF
--- a/reference-implementation/to-upstream-wpts/piping/pipe-through.https.html
+++ b/reference-implementation/to-upstream-wpts/piping/pipe-through.https.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script src="../resources/test-initializer.js"></script>
 <script src="../resources/rs-utils.js"></script>
 


### PR DESCRIPTION
pipe-through.https.html uses worker_test() and therefore needs the /service-workers/service-worker/resources/test-helpers.sub.js script included. Add it.