### PR TITLE
Fix a few bugs in spec algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2346,7 +2346,7 @@ nothrow>ReadableByteStreamControllerPullInto ( <var>controller</var>, <var>view<
     1. Append _pullIntoDescriptor_ as the last element of _controller_.[[pendingPullIntos]].
     1. Return ! ReadableStreamAddReadIntoRequest(_stream_).
   1. If _stream_.[[state]] is `"closed"`,
-    1. Let _emptyView_ be ! Construct(_ctor_, « _view_.[[buffer]], _view_.[[byteOffset]], *0* »).
+    1. Let _emptyView_ be ! Construct(_ctor_, « _pullIntoDescriptor_.[[buffer]], _pullIntoDescriptor_.[[byteOffset]], *0* »).
     1. Return <a>a promise resolved with</a> ! CreateIterResultObject(_emptyView_, *true*).
   1. If _controller_.[[totalQueuedBytes]] > *0*,
     1. If ! ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(_controller_, _pullIntoDescriptor_) is *true*,

--- a/index.bs
+++ b/index.bs
@@ -2153,7 +2153,7 @@ aoid="ReadableByteStreamControllerCommitPullIntoDescriptor" nothrow>ReadableByte
   1. Assert: _stream_.[[state]] is not `"errored"`.
   1. Let _done_ be *false*.
   1. If _stream_.[[state]] is `"closed"`,
-    1. Assert: _pullIntoDescriptor_.[[bytesFilled]] is not *0*.
+    1. Assert: _pullIntoDescriptor_.[[bytesFilled]] is *0*.
     1. Set _done_ to *true*.
   1. Let _filledView_ be ! ReadableByteStreamControllerConvertPullIntoDescriptor(_pullIntoDescriptor_).
   1. If _pullIntoDescriptor_.[[readerType]] is `"default"`,

--- a/index.bs
+++ b/index.bs
@@ -2437,7 +2437,7 @@ throws>ReadableByteStreamControllerRespondWithNewView ( <var>controller</var>, <
   1. Let _firstDescriptor_ be the first element of _controller_.[[pendingPullIntos]].
   1. If _firstDescriptor_.[[byteOffset]] + _firstDescriptor_.[[bytesFilled]] is not _view_.[[ByteOffset]], throw a
      *RangeError* exception.
-  1. If _firstDescriptor_.[[byteLength]] is not _view_.[[ByteOffset]], throw a *RangeError* exception.
+  1. If _firstDescriptor_.[[byteLength]] is not _view_.[[ByteLength]], throw a *RangeError* exception.
   1. Set _firstDescriptor_.[[buffer]] to _view_.[[ViewedArrayBuffer]].
   1. Perform ? ReadableByteStreamControllerRespondInternal(_controller_, _view_.[[ByteLength]]).
 </emu-alg>

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1580,7 +1580,7 @@ function ReadableByteStreamControllerPullInto(controller, view) {
   }
 
   if (stream._state === 'closed') {
-    const emptyView = new view.constructor(view.buffer, view.byteOffset, 0);
+    const emptyView = new view.constructor(pullIntoDescriptor.buffer, pullIntoDescriptor.byteOffset, 0);
     return Promise.resolve(CreateIterResultObject(emptyView, true));
   }
 


### PR DESCRIPTION
These are all issues where the reference implementation is either correct or, in the `ReadableByteStreamControllerPullInto` case, doesn't make a testable difference. (For the reference implementation we could test that it invokes the `view`'s `buffer` and `byteOffset` property getters only once, but that doesn't make sense for actual implementations because those must directly access the underlying slots.)