### PR TITLE
Correctly handle releaseLock() during close()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2827,13 +2827,14 @@ visible through the {{WritableStream}}'s public API.
 
 <emu-alg>
   1. Assert: _stream_.[[state]] is `"closing"` or `"errored"`.
+  1. Let _writer_ be _stream_.[[writer]].
   1. If _stream_.[[state]] is `"closing"`,
-    1. <a>Resolve</a> _stream_.[[writer]].[[closedPromise]] with *undefined*.
+    1. If _writer_ is not *undefined*, <a>resolve</a> _writer_.[[closedPromise]] with *undefined*.
     1. Set _stream_.[[state]] to `"closed"`.
-  1. Otherwise,
+  1. Otherwise if _writer_ is not *undefined*,
     1. Assert: _stream_.[[state]] is `"errored"`.
-    1. <a>Reject</a> _stream_.[[writer]].[[closedPromise]] with _stream_.[[storedError]].
-    1. Set _stream_.[[writer]].[[closedPromise]].[[PromiseIsHandled]] to *true*.
+    1. <a>Reject</a> _writer_.[[closedPromise]] with _stream_.[[storedError]].
+    1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
   1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
     1. <a>Resolve</a> _stream_.[[pendingAbortRequest]] with *undefined*.
     1. Set _stream_.[[pendingAbortRequest]] to *undefined*.

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -190,13 +190,16 @@ function WritableStreamError(stream, e) {
 function WritableStreamFinishClose(stream) {
   assert(stream._state === 'closing' || stream._state === 'errored');
 
+  const writer = stream._writer;
   if (stream._state === 'closing') {
-    defaultWriterClosedPromiseResolve(stream._writer);
+    if (writer !== undefined) {
+      defaultWriterClosedPromiseResolve(writer);
+    }
     stream._state = 'closed';
-  } else {
+  } else if (writer !== undefined) {
     assert(stream._state === 'errored');
-    defaultWriterClosedPromiseReject(stream._writer, stream._storedError);
-    stream._writer._closedPromise.catch(() => {});
+    defaultWriterClosedPromiseReject(writer, stream._storedError);
+    writer._closedPromise.catch(() => {});
   }
 
   if (stream._pendingAbortRequest !== undefined) {


### PR DESCRIPTION
Code which calls `writer.releaseLock()` while `writer.close()` is in
progress can cause an exception in WritableStreamFinishClose because
`stream.[[writer]]` is undefined.

Existing tests did not find the issue because it is quite hard to
detect.

Add undefined checks to fix this. Also add tests to verify the correct
behaviour.