### PR TITLE
precision issues with very large chunks and desiredSize

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/general.js
@@ -215,4 +215,22 @@ promise_test(() => {
   return writer2.ready;
 }, 'redundant releaseLock() is no-op');
 
+promise_test(() => {
+  const strategy = {
+    size(x) {
+      return x;
+    },
+    highWaterMark: 0
+  };
+  const ws = new WritableStream({}, strategy);
+
+  const writer = ws.getWriter();
+  assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+
+  return Promise.all([
+    writer.write(2),
+    writer.write(Number.MAX_SAFE_INTEGER)])
+  .then(() => assert_equals(writer.desiredSize, 0, 'desiredSize should be 0 again after queue empties'));
+}, 'desiredSize of an empty queue must always equal highWaterMark');
+
 done();


### PR DESCRIPTION
Per https://github.com/whatwg/streams/issues/582#issuecomment-273016992 there's an observable problem with the current shortcut.

Should it be changed to follow the spec directly and add up the chunk sizes every time, or use some other way to cheat?

