### PR TITLE
Fix queue total size tracking logic

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3808,6 +3808,8 @@ total in the \[[queueTotalSize]] slot, is <em>not</em> equivalent to adding up t
   1. Remove _pair_ from _container_.[[queue]], shifting all other elements downward (so that the second becomes the
      first, and so on).
   1. Set _container_.[[queueTotalSize]] to _container_.[[queueTotalSize]] − _pair_.[[size]].
+  1. If _container_.[[queueTotalSize]] < *0*, set _container_.[[queueTotalSize]] to *0*. (This can occur due to
+     floating-point arithmetic.)
   1. Return _pair_.[[value]].
 </emu-alg>
 

--- a/index.bs
+++ b/index.bs
@@ -30,6 +30,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: %Uint8Array%; url: #sec-typedarray-objects; type: constructor
     text: ArrayBuffer; url: #sec-arraybuffer-objects; type: interface
     text: DataView; url: #sec-dataview-objects; type: interface
+    text: Number; url: #sec-ecmascript-language-types-number-type; type: interface
     text: Uint8Array; url: #sec-typedarray-objects; type: interface
     text: typed array; url: #sec-typedarray-objects; type: dfn
     text: the typed array constructors table; url: #table-49; type: dfn
@@ -1470,6 +1471,10 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
     <td>A List representing the stream's internal queue of <a>chunks</a>
   </tr>
   <tr>
+    <td>\[[queueTotalSize]]
+    <td>The total size of all the chunks stored in \[[queue]] (see [[#queue-with-sizes]])
+  </tr>
+  <tr>
     <td>\[[started]]
     <td>A boolean flag indicating whether the <a>underlying source</a> has finished starting
   </tr>
@@ -1505,7 +1510,7 @@ ReadableStreamDefaultController(<var>stream</var>, <var>underlyingSource</var>, 
   1. If _stream_.[[readableStreamController]] is not *undefined*, throw a *TypeError* exception.
   1. Set *this*.[[controlledReadableStream]] to _stream_.
   1. Set *this*.[[underlyingSource]] to _underlyingSource_.
-  1. Set *this*.[[queue]] to a new empty List.
+  1. Perform ! ResetQueue(*this*).
   1. Set *this*.[[started]], *this*.[[closeRequested]], *this*.[[pullAgain]], and *this*.[[pulling]] to *false*.
   1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
   1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to
@@ -1588,7 +1593,7 @@ polymorphic dispatch from the readable stream implementation to either these or 
 <h5 id="rs-default-controller-private-cancel">\[[Cancel]](<var>reason</var>)</h5>
 
 <emu-alg>
-  1. Set *this*.[[queue]] to a new empty List.
+  1. Perform ! ResetQueue(*this*).
   1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingSource]], `"cancel"`, « _reason_ »)
 </emu-alg>
 
@@ -1597,7 +1602,7 @@ polymorphic dispatch from the readable stream implementation to either these or 
 <emu-alg>
   1. Let _stream_ be *this*.[[controlledReadableStream]].
   1. If *this*.[[queue]] is not empty,
-    1. Let _chunk_ be ! DequeueValue(*this*.[[queue]]).
+    1. Let _chunk_ be ! DequeueValue(*this*).
     1. If *this*.[[closeRequested]] is *true* and *this*.[[queue]] is empty, perform ! ReadableStreamClose(_stream_).
     1. Otherwise, perform ! ReadableStreamDefaultControllerCallPullIfNeeded(*this*).
     1. Return <a>a promise resolved with</a> ! CreateIterResultObject(_chunk_, *false*).
@@ -1690,7 +1695,7 @@ asserts).
         1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _chunkSize_.[[Value]]).
         1. Return _chunkSize_.
       1. Let _chunkSize_ be _chunkSize_.[[Value]].
-    1. Let _enqueueResult_ be ! EnqueueValueWithSize(_controller_.[[queue]], _chunk_, _chunkSize_).
+    1. Let _enqueueResult_ be ! EnqueueValueWithSize(_controller_, _chunk_, _chunkSize_).
     1. If _enqueueResult_ is an abrupt completion,
       1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _enqueueResult_.[[Value]]).
       1. Return _enqueueResult_.
@@ -1716,7 +1721,7 @@ an assert).
 <emu-alg>
   1. Let _stream_ be _controller_.[[controlledReadableStream]].
   1. Assert: _stream_.[[state]] is `"readable"`.
-  1. Set _controller_.[[queue]] to a new empty List.
+  1. Perform ! ResetQueue(_controller_).
   1. Perform ! ReadableStreamError(_stream_, _e_).
 </emu-alg>
 
@@ -1737,8 +1742,11 @@ the {{ReadableStreamDefaultController/desiredSize}} property of the stream's ass
 Specifications should <em>not</em> use this on streams they did not create.
 
 <emu-alg>
-  1. Let _queueSize_ be ! GetTotalQueueSize(_controller_.[[queue]]).
-  1. Return _controller_.[[strategyHWM]] − _queueSize_.
+  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"errored"`, return *null*.
+  1. If _state_ is `"closed"`, return *0*.
+  1. Return _controller_.[[strategyHWM]] − _controller_.[[queueTotalSize]].
 </emu-alg>
 
 <h3 id="rbs-controller-class" interface lt="ReadableByteStreamController">Class
@@ -1817,6 +1825,10 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
     <td>A List representing the stream's internal queue of <a>chunks</a>
   </tr>
   <tr>
+    <td>\[[queueTotalSize]]
+    <td>The total size (in bytes) of all the chunks stored in \[[queue]]
+  </tr>
+  <tr>
     <td>\[[started]]
     <td>A boolean flag indicating whether the <a>underlying source</a> has finished starting
   </tr>
@@ -1826,15 +1838,19 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
       which the stream will apply <a>backpressure</a> to its <a>underlying byte source</a>
   </tr>
   <tr>
-    <td>\[[totalQueuedBytes]]
-    <td>The number of bytes stored in \[[queue]]
-  </tr>
-  <tr>
     <td>\[[underlyingByteSource]]
     <td>An object representation of the stream's <a>underlying byte source</a>;
       also used for the <a href="#is-readable-byte-stream-controller">IsReadableByteStreamController</a> brand check
   </tr>
 </table>
+
+<div class="note">
+  <p>Although {{ReadableByteStreamController}} instances have \[[queue]] and \[[queueTotalSize]] slots, we do not use
+  most of the abstract operations in [[#queue-with-sizes]] on them, as the way in which we manipulate this queue is
+  rather different than the others in the spec. Instead, we update the two slots together manually.</p>
+
+  <p>This might be cleaned up in a future spec refactoring.</p>
+</div>
 
 <h4 id="rbs-controller-constructor" constructor for="ReadableByteStreamController"
 lt="ReadableByteStreamController(stream, underlyingByteSource, highWaterMark)">new
@@ -1852,9 +1868,8 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
   1. Set *this*.[[underlyingByteSource]] to _underlyingByteSource_.
   1. Set *this*.[[pullAgain]], and *this*.[[pulling]] to *false*.
   1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(*this*).
-  1. Set *this*.[[queue]] to a new empty List.
-  1. Set *this*.[[totalQueuedBytes]] to *0*.
-  1. Set *this*.[[started]], and *this*.[[closeRequested]] to *false*.
+  1. Perform ! ResetQueue(*this*).
+  1. Set *this*.[[started]] and *this*.[[closeRequested]] to *false*.
   1. Set *this*.[[strategyHWM]] to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
   1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
   1. If _autoAllocateChunkSize_ is not *undefined*,
@@ -1960,8 +1975,7 @@ dispatch from the readable stream implementation to either these or their counte
   1. If *this*.[[pendingPullIntos]] is not empty,
     1. Let _firstDescriptor_ be the first element of *this*.[[pendingPullIntos]].
     1. Set _firstDescriptor_.[[bytesFilled]] to *0*.
-  1. Set *this*.[[queue]] to a new empty List.
-  1. Set *this*.[[totalQueuedBytes]] to *0*.
+  1. Perform ! ResetQueue(*this*).
   1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingByteSource]], `"cancel"`, « _reason_ »)
 </emu-alg>
 
@@ -1970,12 +1984,12 @@ dispatch from the readable stream implementation to either these or their counte
 <emu-alg>
   1. Let _stream_ be *this*.[[controlledReadableStream]].
   1. Assert: ! ReadableStreamHasDefaultReader(_stream_) is *true*.
-  1. If *this*.[[totalQueuedBytes]] > *0*,
+  1. If *this*.[[queueTotalSize]] > *0*,
     1. Assert: ! ReadableStreamGetNumReadRequests(_stream_) is *0*.
     1. Let _entry_ be the first element of *this*.[[queue]].
     1. Remove _entry_ from *this*.[[queue]], shifting all other elements downward (so that the second becomes the
        first, and so on).
-    1. Set *this*.[[totalQueuedBytes]] to *this*.[[totalQueuedBytes]] − _entry_.[[byteLength]].
+    1. Set *this*.[[queueTotalSize]] to *this*.[[queueTotalSize]] − _entry_.[[byteLength]].
     1. Perform ! ReadableByteStreamControllerHandleQueueDrain(*this*).
     1. Let _view_ be ! Construct(<a idl>%Uint8Array%</a>, « _entry_.[[buffer]], _entry_.[[byteOffset]],
        _entry_.[[byteLength]] »).
@@ -2133,7 +2147,7 @@ throws>ReadableByteStreamControllerClose ( <var>controller</var> )</h4>
   1. Let _stream_ be _controller_.[[controlledReadableStream]].
   1. Assert: _controller_.[[closeRequested]] is *false*.
   1. Assert: _stream_.[[state]] is `"readable"`.
-  1. If _controller_.[[totalQueuedBytes]] > *0*,
+  1. If _controller_.[[queueTotalSize]] > *0*,
     1. Set _controller_.[[closeRequested]] to *true*.
     1. Return.
   1. If _controller_.[[pendingPullIntos]] is not empty,
@@ -2213,7 +2227,7 @@ nothrow>ReadableByteStreamControllerEnqueueChunkToQueue ( <var>controller</var>,
 <emu-alg>
   1. Append Record {[[buffer]]: _buffer_, [[byteOffset]]: _byteOffset_, [[byteLength]]: _byteLength_} as the last
      element of _controller_.[[queue]].
-  1. Add _byteLength_ to _controller_.[[totalQueuedBytes]].
+  1. Add _byteLength_ to _controller_.[[queueTotalSize]].
 </emu-alg>
 
 <h4 id="readable-byte-stream-controller-error" aoid="ReadableByteStreamControllerError"
@@ -2223,7 +2237,7 @@ nothrow>ReadableByteStreamControllerError ( <var>controller</var>, <var>e</var> 
   1. Let _stream_ be _controller_.[[controlledReadableStream]].
   1. Assert: _stream_.[[state]] is `"readable"`.
   1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(_controller_).
-  1. Let _controller_.[[queue]] be a new empty List.
+  1. Perform ! ResetQueue(_controller_).
   1. Perform ! ReadableStreamError(_stream_, _e_).
 </emu-alg>
 
@@ -2248,7 +2262,7 @@ nothrow>ReadableByteStreamControllerFillPullIntoDescriptorFromQueue ( <var>contr
   1. Let _elementSize_ be _pullIntoDescriptor_.[[elementSize]].
   1. Let _currentAlignedBytes_ be _pullIntoDescriptor_.[[bytesFilled]] − (_pullIntoDescriptor_.[[bytesFilled]] mod
      _elementSize_).
-  1. Let _maxBytesToCopy_ be min(_controller_.[[totalQueuedBytes]], _pullIntoDescriptor_.[[byteLength]] −
+  1. Let _maxBytesToCopy_ be min(_controller_.[[queueTotalSize]], _pullIntoDescriptor_.[[byteLength]] −
      _pullIntoDescriptor_.[[bytesFilled]]).
   1. Let _maxBytesFilled_ be _pullIntoDescriptor_.[[bytesFilled]] + _maxBytesToCopy_.
   1. Let _maxAlignedBytes_ be _maxBytesFilled_ − (_maxBytesFilled_ mod _elementSize_).
@@ -2270,12 +2284,12 @@ nothrow>ReadableByteStreamControllerFillPullIntoDescriptorFromQueue ( <var>contr
     1. Otherwise,
       1. Set _headOfQueue_.[[byteOffset]] to _headOfQueue_.[[byteOffset]] + _bytesToCopy_.
       1. Set _headOfQueue_.[[byteLength]] to _headOfQueue_.[[byteLength]] − _bytesToCopy_.
-    1. Set _controller_.[[totalQueuedBytes]] to _controller_.[[totalQueuedBytes]] − _bytesToCopy_.
+    1. Set _controller_.[[queueTotalSize]] to _controller_.[[queueTotalSize]] − _bytesToCopy_.
     1. Perform ! ReadableByteStreamControllerFillHeadPullIntoDescriptor(_controller_, _bytesToCopy_,
        _pullIntoDescriptor_).
     1. Set _totalBytesToCopyRemaining_ to _totalBytesToCopyRemaining_ − _bytesToCopy_.
   1. If _ready_ is *false*,
-    1. Assert: _controller_.[[totalQueuedBytes]] is *0*.
+    1. Assert: _controller_.[[queueTotalSize]] is *0*.
     1. Assert: _pullIntoDescriptor_.[[bytesFilled]] > *0*.
     1. Assert: _pullIntoDescriptor_.[[bytesFilled]] < _pullIntoDescriptor_.[[elementSize]].
   1. Return _ready_.
@@ -2285,7 +2299,11 @@ nothrow>ReadableByteStreamControllerFillPullIntoDescriptorFromQueue ( <var>contr
 nothrow>ReadableByteStreamControllerGetDesiredSize ( <var>controller</var> )</h4>
 
 <emu-alg>
-  1. Return _controller_.[[strategyHWM]] − _controller_.[[totalQueuedBytes]].
+  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"errored"`, return *null*.
+  1. If _state_ is `"closed"`, return *0*.
+  1. Return _controller_.[[strategyHWM]] − _controller_.[[queueTotalSize]].
 </emu-alg>
 
 <h4 id="readable-byte-stream-controller-handle-queue-drain" aoid="ReadableByteStreamControllerHandleQueueDrain"
@@ -2293,7 +2311,7 @@ nothrow>ReadableByteStreamControllerHandleQueueDrain ( <var>controller</var> )</
 
 <emu-alg>
   1. Assert: _controller_.[[controlledReadableStream]].[[state]] is `"readable"`.
-  1. If _controller_.[[totalQueuedBytes]] is *0* and _controller_.[[closeRequested]] is *true*,
+  1. If _controller_.[[queueTotalSize]] is *0* and _controller_.[[closeRequested]] is *true*,
     1. Perform ! ReadableStreamClose(_controller_.[[controlledReadableStream]]).
   1. Otherwise,
     1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
@@ -2317,7 +2335,7 @@ nothrow>ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue ( <var>
 <emu-alg>
   1. Assert: _controller_.[[closeRequested]] is *false*.
   1. Repeat the following steps while _controller_.[[pendingPullIntos]] is not empty,
-    1. If _controller_.[[totalQueuedBytes]] is *0*, return.
+    1. If _controller_.[[queueTotalSize]] is *0*, return.
     1. Let _pullIntoDescriptor_ be the first element of _controller_.[[pendingPullIntos]].
     1. If ! ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(_controller_, _pullIntoDescriptor_) is *true*,
       1. Perform ! ReadableByteStreamControllerShiftPendingPullInto(_controller_).
@@ -2348,7 +2366,7 @@ nothrow>ReadableByteStreamControllerPullInto ( <var>controller</var>, <var>view<
   1. If _stream_.[[state]] is `"closed"`,
     1. Let _emptyView_ be ! Construct(_ctor_, « _pullIntoDescriptor_.[[buffer]], _pullIntoDescriptor_.[[byteOffset]], *0* »).
     1. Return <a>a promise resolved with</a> ! CreateIterResultObject(_emptyView_, *true*).
-  1. If _controller_.[[totalQueuedBytes]] > *0*,
+  1. If _controller_.[[queueTotalSize]] > *0*,
     1. If ! ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(_controller_, _pullIntoDescriptor_) is *true*,
       1. Let _filledView_ be ! ReadableByteStreamControllerConvertPullIntoDescriptor(_pullIntoDescriptor_).
       1. Perform ! ReadableByteStreamControllerHandleQueueDrain(_controller_).
@@ -3353,6 +3371,10 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
     <td>A List representing the stream's internal queue of <a>chunks</a>
   </tr>
   <tr>
+    <td>\[[queueTotalSize]]
+    <td>The total size of all the chunks stored in \[[queue]] (see [[#queue-with-sizes]])
+  </tr>
+  <tr>
     <td>\[[started]]
     <td>A boolean flag indicating whether the <a>underlying sink</a> has finished starting
   </tr>
@@ -3393,8 +3415,8 @@ WritableStreamDefaultController(<var>stream</var>, <var>underlyingSink</var>, <v
   1. If _stream_.[[writableStreamController]] is not *undefined*, throw a *TypeError* exception.
   1. Set *this*.[[controlledWritableStream]] to _stream_.
   1. Set *this*.[[underlyingSink]] to _underlyingSink_.
-  1. Set *this*.[[queue]] to a new empty List.
-  1. Set *this*.[[started]] and *this*.[[writing]] and *this*.[[inClose]] to *false*.
+  1. Perform ! ResetQueue(*this*).
+  1. Set *this*.[[started]], *this*.[[writing]] and *this*.[[inClose]] to *false*.
   1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
   1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to
      _normalizedStrategy_.[[highWaterMark]].
@@ -3445,7 +3467,7 @@ nothrow>IsWritableStreamDefaultController ( <var>x</var> )</h4>
 nothrow>WritableStreamDefaultControllerAbort ( <var>controller</var>, <var>reason</var> )</h4>
 
 <emu-alg>
-  1. Set _controller_.[[queue]] to a new empty List.
+  1. Perform ! ResetQueue(_controller_).
   1. Let _sinkAbortPromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"abort"`, «
     _reason_ »).
   1. Return the result of <a>transforming</a> _sinkAbortPromise_ with a fulfillment handler that returns
@@ -3456,7 +3478,7 @@ nothrow>WritableStreamDefaultControllerAbort ( <var>controller</var>, <var>reaso
 nothrow>WritableStreamDefaultControllerClose ( <var>controller</var> )</h4>
 
 <emu-alg>
-  1. Perform ! EnqueueValueWithSize(_controller_.[[queue]], `"close"`, *0*).
+  1. Perform ! EnqueueValueWithSize(_controller_, `"close"`, *0*).
   1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
 </emu-alg>
 
@@ -3464,8 +3486,7 @@ nothrow>WritableStreamDefaultControllerClose ( <var>controller</var> )</h4>
 nothrow>WritableStreamDefaultControllerGetDesiredSize ( <var>controller</var> )</h4>
 
 <emu-alg>
-  1. Let _queueSize_ be ! GetTotalQueueSize(_controller_.[[queue]]).
-  1. Return _controller_.[[strategyHWM]] − _queueSize_.
+  1. Return _controller_.[[strategyHWM]] − _controller_.[[queueTotalSize]].
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-update-backpressure-if-needed"
@@ -3494,7 +3515,7 @@ nothrow>WritableStreamDefaultControllerWrite ( <var>controller</var>, <var>chunk
       1. Return.
   1. Let _writeRecord_ be Record {[[chunk]]: _chunk_}.
   1. Let _oldBackpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
-  1. Let _enqueueResult_ be ! EnqueueValueWithSize(_controller_.[[queue]], _writeRecord_, _chunkSize_).
+  1. Let _enqueueResult_ be ! EnqueueValueWithSize(_controller_, _writeRecord_, _chunkSize_).
   1. If _enqueueResult_ is an abrupt completion,
     1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _enqueueResult_.[[Value]]).
     1. Return.
@@ -3511,7 +3532,7 @@ aoid="WritableStreamDefaultControllerAdvanceQueueIfNeeded" nothrow>WritableStrea
   1. If _controller_.[[started]] is *false*, return.
   1. If _controller_.[[writing]] is *true*, return.
   1. If _controller_.[[queue]] is empty, return.
-  1. Let _writeRecord_ be ! PeekQueueValue(_controller_.[[queue]]).
+  1. Let _writeRecord_ be ! PeekQueueValue(_controller_).
   1. If _writeRecord_ is `"close"`, perform WritableStreamDefaultControllerProcessClose(_controller_).
   1. Otherwise, perform WritableStreamDefaultControllerProcessWrite(_controller_, _writeRecord_.[[chunk]]).
 </emu-alg>
@@ -3530,7 +3551,7 @@ nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h
 <emu-alg>
   1. Let _stream_ be _controller_.[[controlledWritableStream]].
   1. Assert: _stream_.[[state]] is `"closing"`.
-  1. Perform ! DequeueValue(_controller_.[[queue]]).
+  1. Perform ! DequeueValue(_controller_).
   1. Assert: _controller_.[[queue]] is empty.
   1. Set _controller_.[[inClose]] to *true*.
   1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`, « _controller_ »).
@@ -3562,7 +3583,7 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
     1. If _state_ is `"errored"`, return.
     1. Assert: _state_ is `"closing"` or `"writable"`.
     1. Let _oldBackpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
-    1. Perform ! DequeueValue(_controller_.[[queue]]).
+    1. Perform ! DequeueValue(_controller_).
     1. Perform ! WritableStreamDefaultControllerUpdateBackpressureIfNeeded(_controller_, _oldBackpressure_).
     1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
   1. <a>Upon rejection</a> of _sinkWritePromise_ with _reason_,
@@ -3599,7 +3620,7 @@ nothrow>WritableStreamDefaultControllerError ( <var>controller</var>, <var>e</va
        _readyPromiseIsPending_ to *true*.
     1. Perform ! WritableStreamDefaultWriterEnsureReadyPromiseRejectedWith(_stream_.[[writer]], _e_,
        _readyPromiseIsPending_).
-  1. Set _controller_.[[queue]] to a new empty List.
+  1. Perform ! ResetQueue(_controller_).
   1. If _controller_.[[writing]] is *false* and _controller_.[[inClose]] is *false*,
      perform ! WritableStreamRejectPromisesInReactionToError(_stream_).
 </emu-alg>
@@ -3767,46 +3788,55 @@ CountQueuingStrategy({ <var>highWaterMark</var> })</h4>
 <h3 id="queue-with-sizes">Queue-with-Sizes Operations</h3>
 
 The streams in this specification use a "queue-with-sizes" data structure to store queued up values, along with their
-determined sizes. A queue-with-sizes is a List of Records with \[[value]] and \[[size]] fields (although in
-implementations it would of course be backed by a more efficient data structure).
+determined sizes. Various specification objects contain a queue-with-sizes, represented by the object having two paired
+internal slots, always named \[[queue]] and \[[queueTotalSize]]. \[[queue]] is a List of Records with \[[value]] and
+\[[size]] fields, and \[[queueTotalSize]] is a JavaScript {{Number}}, i.e. a double-precision floating point number.
 
-A number of abstract operations are specified here to make working with queues-with-sizes more pleasant, and used
-throughout the rest of this standard.
+The following abstract operations are used when operating on objects that contain queues-with-sizes, in order to ensure
+that the two internal slots stay synchronized.
 
-<h4 id="dequeue-value" aoid="DequeueValue" nothrow>DequeueValue ( <var>queue</var> )</h4>
+<p class="warning">Due to the vagaries of floating point arithmetic, the framework specified here, of keeping a running
+total in the \[[queueTotalSize]] slot, is <em>not</em> equivalent to adding up the size of all <a>chunks</a> in
+\[[queue]]. This is most apparent when the total size is very small or very large.</p>
+
+<h4 id="dequeue-value" aoid="DequeueValue" nothrow>DequeueValue ( <var>container</var> )</h4>
 
 <emu-alg>
-  1. Assert: _queue_ is not empty.
-  1. Let _pair_ be the first element of _queue_.
-  1. Remove _pair_ from _queue_, shifting all other elements downward (so that the second becomes the first, and so on).
+  1. Assert: _container_ has [[queue]] and [[queueTotalSize]] internal slots.
+  1. Assert: _container_.[[queue]] is not empty.
+  1. Let _pair_ be the first element of _container_.[[queue]].
+  1. Remove _pair_ from _container_.[[queue]], shifting all other elements downward (so that the second becomes the
+     first, and so on).
+  1. Set _container_.[[queueTotalSize]] to _container_.[[queueTotalSize]] − _pair_.[[size]].
   1. Return _pair_.[[value]].
 </emu-alg>
 
-<h4 id="enqueue-value-with-size" aoid="EnqueueValueWithSize" throws>EnqueueValueWithSize ( <var>queue</var>,
+<h4 id="enqueue-value-with-size" aoid="EnqueueValueWithSize" throws>EnqueueValueWithSize ( <var>container</var>,
 <var>value</var>, <var>size</var> )</h4>
 
 <emu-alg>
+  1. Assert: _container_ has [[queue]] and [[queueTotalSize]] internal slots.
   1. Let _size_ be ? ToNumber(_size_).
   1. If ! IsFiniteNonNegativeNumber(_size_) is *false*, throw a *RangeError* exception.
-  1. Append Record {[[value]]: _value_, [[size]]: _size_} as the last element of _queue_.
+  1. Append Record {[[value]]: _value_, [[size]]: _size_} as the last element of _container_.[[queue]].
+  1. Set _container_.[[queueTotalSize]] to _container_.[[queueTotalSize]] + _size_.
 </emu-alg>
 
-<h4 id="get-total-queue-size" aoid="GetTotalQueueSize" nothrow>GetTotalQueueSize ( <var>queue</var> )</h4>
+<h4 id="peek-queue-value" aoid="PeekQueueValue" nothrow>PeekQueueValue ( <var>container</var> )</h4>
 
 <emu-alg>
-  1. Let _totalSize_ be *0*.
-  1. Repeat for each Record {[[value]], [[size]]} _pair_ that is an element of _queue_,
-    1. Assert: _pair_.[[size]] is a finite, non-*NaN* number.
-    1. Set _totalSize_ to _totalSize_ + _pair_.[[size]].
-  1. Return _totalSize_.
-</emu-alg>
-
-<h4 id="peek-queue-value" aoid="PeekQueueValue" nothrow>PeekQueueValue ( <var>queue</var> )</h4>
-
-<emu-alg>
-  1. Assert: _queue_ is not empty.
-  1. Let _pair_ be the first element of _queue_.
+  1. Assert: _container_ has [[queue]] and [[queueTotalSize]] internal slots.
+  1. Assert: _container_.[[queue]] is not empty.
+  1. Let _pair_ be the first element of _container_.[[queue]].
   1. Return _pair_.[[value]].
+</emu-alg>
+
+<h4 id="reset-queue" aoid="ResetQueue" nothrow>ResetQueue ( <var>container</var> )</h4>
+
+<emu-alg>
+  1. Assert: _container_ has [[queue]] and [[queueTotalSize]] internal slots.
+  1. Set _container_.[[queue]] to a new empty List.
+  1. Set _container_.[[queueTotalSize]] to *0*.
 </emu-alg>
 
 <h3 id="misc-abstract-ops">Miscellaneous Operations</h3>
@@ -4370,6 +4400,9 @@ itself will evolve in these ways.
   <li> We use the shorthand phrases from the [[!PROMISES-GUIDE]] to operate on promises at a higher level than the
     ECMAScript spec does.
 </ul>
+
+It's also worth noting that, as in [[!ECMASCRIPT]], all numbers are represented as double-precision floating point
+values, and all arithmetic operations performed on them must be done in the usual way for such values.
 
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -3795,9 +3795,10 @@ internal slots, always named \[[queue]] and \[[queueTotalSize]]. \[[queue]] is a
 The following abstract operations are used when operating on objects that contain queues-with-sizes, in order to ensure
 that the two internal slots stay synchronized.
 
-<p class="warning">Due to the vagaries of floating point arithmetic, the framework specified here, of keeping a running
-total in the \[[queueTotalSize]] slot, is <em>not</em> equivalent to adding up the size of all <a>chunks</a> in
-\[[queue]]. This is most apparent when the total size is very small or very large.</p>
+<p class="warning">Due to the limited precision of floating-point arithmetic, the framework specified here, of keeping a
+running total in the \[[queueTotalSize]] slot, is <em>not</em> equivalent to adding up the size of all <a>chunks</a> in
+\[[queue]]. (However, this only makes a difference when there is a huge (~10<sup>15</sup>) variance in size between
+chunks, or when trillions of chunks are enqueued.)</p>
 
 <h4 id="dequeue-value" aoid="DequeueValue" nothrow>DequeueValue ( <var>container</var> )</h4>
 
@@ -3809,7 +3810,7 @@ total in the \[[queueTotalSize]] slot, is <em>not</em> equivalent to adding up t
      first, and so on).
   1. Set _container_.[[queueTotalSize]] to _container_.[[queueTotalSize]] − _pair_.[[size]].
   1. If _container_.[[queueTotalSize]] < *0*, set _container_.[[queueTotalSize]] to *0*. (This can occur due to
-     floating-point arithmetic.)
+     rounding errors.)
   1. Return _pair_.[[value]].
 </emu-alg>
 
@@ -4404,7 +4405,7 @@ itself will evolve in these ways.
 </ul>
 
 It's also worth noting that, as in [[!ECMASCRIPT]], all numbers are represented as double-precision floating point
-values, and all arithmetic operations performed on them must be done in the usual way for such values.
+values, and all arithmetic operations performed on them must be done in the standard way for such values.
 
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -9,6 +9,9 @@ exports.DequeueValue = container => {
 
   const pair = container._queue.shift();
   container._queueTotalSize -= pair.size;
+  if (container._queueTotalSize < 0) {
+    container._queueTotalSize = 0;
+  }
 
   return pair.value;
 };

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -2,39 +2,44 @@
 const assert = require('assert');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
-exports.DequeueValue = queue => {
-  assert(queue.length > 0, 'Spec-level failure: should never dequeue from an empty queue.');
-  const pair = queue.shift();
+exports.DequeueValue = container => {
+  assert('_queue' in container && '_queueTotalSize' in container,
+    'Spec-level failure: DequeueValue should only be used on containers with [[queue]] and [[queueTotalSize]].');
+  assert(container._queue.length > 0, 'Spec-level failure: should never dequeue from an empty queue.');
 
-  queue._totalSize -= pair.size;
+  const pair = container._queue.shift();
+  container._queueTotalSize -= pair.size;
 
   return pair.value;
 };
 
-exports.EnqueueValueWithSize = (queue, value, size) => {
+exports.EnqueueValueWithSize = (container, value, size) => {
+  assert('_queue' in container && '_queueTotalSize' in container,
+    'Spec-level failure: EnqueueValueWithSize should only be used on containers with [[queue]] and ' +
+    '[[queueTotalSize]].');
+
   size = Number(size);
   if (!IsFiniteNonNegativeNumber(size)) {
     throw new RangeError('Size must be a finite, non-NaN, non-negative number.');
   }
 
-  queue.push({ value, size });
-
-  if (queue._totalSize === undefined) {
-    queue._totalSize = 0;
-  }
-  queue._totalSize += size;
+  container._queue.push({ value, size });
+  container._queueTotalSize += size;
 };
 
-// This implementation is not per-spec. Total size is cached for speed.
-exports.GetTotalQueueSize = queue => {
-  if (queue._totalSize === undefined) {
-    queue._totalSize = 0;
-  }
-  return queue._totalSize;
-};
+exports.PeekQueueValue = container => {
+  assert('_queue' in container && '_queueTotalSize' in container,
+    'Spec-level failure: PeekQueueValue should only be used on containers with [[queue]] and [[queueTotalSize]].');
+  assert(container._queue.length > 0, 'Spec-level failure: should never peek at an empty queue.');
 
-exports.PeekQueueValue = queue => {
-  assert(queue.length > 0, 'Spec-level failure: should never peek at an empty queue.');
-  const pair = queue[0];
+  const pair = container._queue[0];
   return pair.value;
+};
+
+exports.ResetQueue = container => {
+  assert('_queue' in container && '_queueTotalSize' in container,
+    'Spec-level failure: ResetQueue should only be used on containers with [[queue]] and [[queueTotalSize]].');
+
+  container._queue = [];
+  container._queueTotalSize = 0;
 };

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -860,7 +860,8 @@ class ReadableStreamDefaultController {
     this._underlyingSource = underlyingSource;
 
     // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
-    this._queue = this._queueTotalSize = undefined;
+    this._queue = undefined;
+    this._queueTotalSize = undefined;
     ResetQueue(this);
 
     this._started = false;

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -5,7 +5,7 @@ const { ArrayBufferCopy, CreateIterResultObject, IsFiniteNonNegativeNumber, Invo
       require('./helpers.js');
 const { createArrayFromList, createDataProperty, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
-const { DequeueValue, EnqueueValueWithSize, GetTotalQueueSize } = require('./queue-with-sizes.js');
+const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStream, IsWritableStreamLocked,
         WritableStreamAbort, WritableStreamDefaultWriterCloseWithErrorPropagation,
         WritableStreamDefaultWriterRelease, WritableStreamDefaultWriterWrite } = require('./writable-stream.js');
@@ -859,7 +859,10 @@ class ReadableStreamDefaultController {
 
     this._underlyingSource = underlyingSource;
 
-    this._queue = [];
+    // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
+    this._queue = this._queueTotalSize = undefined;
+    ResetQueue(this);
+
     this._started = false;
     this._closeRequested = false;
     this._pullAgain = false;
@@ -944,8 +947,7 @@ class ReadableStreamDefaultController {
   }
 
   [InternalCancel](reason) {
-    this._queue = [];
-
+    ResetQueue(this);
     return PromiseInvokeOrNoop(this._underlyingSource, 'cancel', [reason]);
   }
 
@@ -953,7 +955,7 @@ class ReadableStreamDefaultController {
     const stream = this._controlledReadableStream;
 
     if (this._queue.length > 0) {
-      const chunk = DequeueValue(this._queue);
+      const chunk = DequeueValue(this);
 
       if (this._closeRequested === true && this._queue.length === 0) {
         ReadableStreamClose(stream);
@@ -1083,7 +1085,7 @@ function ReadableStreamDefaultControllerEnqueue(controller, chunk) {
     }
 
     try {
-      EnqueueValueWithSize(controller._queue, chunk, chunkSize);
+      EnqueueValueWithSize(controller, chunk, chunkSize);
     } catch (enqueueE) {
       ReadableStreamDefaultControllerErrorIfNeeded(controller, enqueueE);
       throw enqueueE;
@@ -1100,7 +1102,7 @@ function ReadableStreamDefaultControllerError(controller, e) {
 
   assert(stream._state === 'readable');
 
-  controller._queue = [];
+  ResetQueue(controller);
 
   ReadableStreamError(stream, e);
 }
@@ -1112,8 +1114,17 @@ function ReadableStreamDefaultControllerErrorIfNeeded(controller, e) {
 }
 
 function ReadableStreamDefaultControllerGetDesiredSize(controller) {
-  const queueSize = GetTotalQueueSize(controller._queue);
-  return controller._strategyHWM - queueSize;
+  const stream = controller._controlledReadableStream;
+  const state = stream._state;
+
+  if (state === 'errored') {
+    return null;
+  }
+  if (state === 'closed') {
+    return 0;
+  }
+
+  return controller._strategyHWM - controller._queueTotalSize;
 }
 
 class ReadableStreamBYOBRequest {
@@ -1177,11 +1188,11 @@ class ReadableByteStreamController {
 
     ReadableByteStreamControllerClearPendingPullIntos(this);
 
-    this._queue = [];
-    this._totalQueuedBytes = 0;
+    // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
+    this._queue = this._queueTotalSize = undefined;
+    ResetQueue(this);
 
     this._closeRequested = false;
-
     this._started = false;
 
     this._strategyHWM = ValidateAndNormalizeHighWaterMark(highWaterMark);
@@ -1299,8 +1310,7 @@ class ReadableByteStreamController {
       firstDescriptor.bytesFilled = 0;
     }
 
-    this._queue = [];
-    this._totalQueuedBytes = 0;
+    ResetQueue(this);
 
     return PromiseInvokeOrNoop(this._underlyingByteSource, 'cancel', [reason]);
   }
@@ -1309,11 +1319,11 @@ class ReadableByteStreamController {
     const stream = this._controlledReadableStream;
     assert(ReadableStreamHasDefaultReader(stream) === true);
 
-    if (this._totalQueuedBytes > 0) {
+    if (this._queueTotalSize > 0) {
       assert(ReadableStreamGetNumReadRequests(stream) === 0);
 
       const entry = this._queue.shift();
-      this._totalQueuedBytes -= entry.byteLength;
+      this._queueTotalSize -= entry.byteLength;
 
       ReadableByteStreamControllerHandleQueueDrain(this);
 
@@ -1456,7 +1466,7 @@ function ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescripto
 
 function ReadableByteStreamControllerEnqueueChunkToQueue(controller, buffer, byteOffset, byteLength) {
   controller._queue.push({ buffer, byteOffset, byteLength });
-  controller._totalQueuedBytes += byteLength;
+  controller._queueTotalSize += byteLength;
 }
 
 function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor) {
@@ -1464,7 +1474,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
 
   const currentAlignedBytes = pullIntoDescriptor.bytesFilled - pullIntoDescriptor.bytesFilled % elementSize;
 
-  const maxBytesToCopy = Math.min(controller._totalQueuedBytes,
+  const maxBytesToCopy = Math.min(controller._queueTotalSize,
                                   pullIntoDescriptor.byteLength - pullIntoDescriptor.bytesFilled);
   const maxBytesFilled = pullIntoDescriptor.bytesFilled + maxBytesToCopy;
   const maxAlignedBytes = maxBytesFilled - maxBytesFilled % elementSize;
@@ -1492,7 +1502,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
       headOfQueue.byteOffset += bytesToCopy;
       headOfQueue.byteLength -= bytesToCopy;
     }
-    controller._totalQueuedBytes -= bytesToCopy;
+    controller._queueTotalSize -= bytesToCopy;
 
     ReadableByteStreamControllerFillHeadPullIntoDescriptor(controller, bytesToCopy, pullIntoDescriptor);
 
@@ -1500,7 +1510,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
   }
 
   if (ready === false) {
-    assert(controller._totalQueuedBytes === 0, 'queue must be empty');
+    assert(controller._queueTotalSize === 0, 'queue must be empty');
     assert(pullIntoDescriptor.bytesFilled > 0);
     assert(pullIntoDescriptor.bytesFilled < pullIntoDescriptor.elementSize);
   }
@@ -1518,7 +1528,7 @@ function ReadableByteStreamControllerFillHeadPullIntoDescriptor(controller, size
 function ReadableByteStreamControllerHandleQueueDrain(controller) {
   assert(controller._controlledReadableStream._state === 'readable');
 
-  if (controller._totalQueuedBytes === 0 && controller._closeRequested === true) {
+  if (controller._queueTotalSize === 0 && controller._closeRequested === true) {
     ReadableStreamClose(controller._controlledReadableStream);
   } else {
     ReadableByteStreamControllerCallPullIfNeeded(controller);
@@ -1539,7 +1549,7 @@ function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(contro
   assert(controller._closeRequested === false);
 
   while (controller._pendingPullIntos.length > 0) {
-    if (controller._totalQueuedBytes === 0) {
+    if (controller._queueTotalSize === 0) {
       return;
     }
 
@@ -1589,7 +1599,7 @@ function ReadableByteStreamControllerPullInto(controller, view) {
     return Promise.resolve(CreateIterResultObject(emptyView, true));
   }
 
-  if (controller._totalQueuedBytes > 0) {
+  if (controller._queueTotalSize > 0) {
     if (ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor) === true) {
       const filledView = ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescriptor);
 
@@ -1720,7 +1730,7 @@ function ReadableByteStreamControllerClose(controller) {
   assert(controller._closeRequested === false);
   assert(stream._state === 'readable');
 
-  if (controller._totalQueuedBytes > 0) {
+  if (controller._queueTotalSize > 0) {
     controller._closeRequested = true;
 
     return;
@@ -1776,13 +1786,22 @@ function ReadableByteStreamControllerError(controller, e) {
 
   ReadableByteStreamControllerClearPendingPullIntos(controller);
 
-  controller._queue = [];
-
+  ResetQueue(controller);
   ReadableStreamError(stream, e);
 }
 
 function ReadableByteStreamControllerGetDesiredSize(controller) {
-  return controller._strategyHWM - controller._totalQueuedBytes;
+  const stream = controller._controlledReadableStream;
+  const state = stream._state;
+
+  if (state === 'errored') {
+    return null;
+  }
+  if (state === 'closed') {
+    return 0;
+  }
+
+  return controller._strategyHWM - controller._queueTotalSize;
 }
 
 function ReadableByteStreamControllerRespond(controller, bytesWritten) {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const { InvokeOrNoop, PromiseInvokeOrNoop, ValidateAndNormalizeQueuingStrategy, typeIsObject } =
   require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
-const { DequeueValue, EnqueueValueWithSize, GetTotalQueueSize, PeekQueueValue } = require('./queue-with-sizes.js');
+const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
 class WritableStream {
   constructor(underlyingSink = {}, { size, highWaterMark = 1 } = {}) {
@@ -689,7 +689,10 @@ class WritableStreamDefaultController {
 
     this._underlyingSink = underlyingSink;
 
-    this._queue = [];
+    // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
+    this._queue = this._queueTotalSize = undefined;
+    ResetQueue(this);
+
     this._started = false;
     this._writing = false;
     this._inClose = false;
@@ -736,20 +739,18 @@ class WritableStreamDefaultController {
 // Abstract operations implementing interface required by the WritableStream.
 
 function WritableStreamDefaultControllerAbort(controller, reason) {
-  controller._queue = [];
-
+  ResetQueue(controller);
   const sinkAbortPromise = PromiseInvokeOrNoop(controller._underlyingSink, 'abort', [reason]);
   return sinkAbortPromise.then(() => undefined);
 }
 
 function WritableStreamDefaultControllerClose(controller) {
-  EnqueueValueWithSize(controller._queue, 'close', 0);
+  EnqueueValueWithSize(controller, 'close', 0);
   WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
 }
 
 function WritableStreamDefaultControllerGetDesiredSize(controller) {
-  const queueSize = GetTotalQueueSize(controller._queue);
-  return controller._strategyHWM - queueSize;
+  return controller._strategyHWM - controller._queueTotalSize;
 }
 
 function WritableStreamDefaultControllerUpdateBackpressureIfNeeded(controller, oldBackpressure) {
@@ -787,7 +788,7 @@ function WritableStreamDefaultControllerWrite(controller, chunk) {
   const oldBackpressure = WritableStreamDefaultControllerGetBackpressure(controller);
 
   try {
-    EnqueueValueWithSize(controller._queue, writeRecord, chunkSize);
+    EnqueueValueWithSize(controller, writeRecord, chunkSize);
   } catch (enqueueE) {
     WritableStreamDefaultControllerErrorIfNeeded(controller, enqueueE);
     return;
@@ -830,7 +831,7 @@ function WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller) {
     return;
   }
 
-  const writeRecord = PeekQueueValue(controller._queue);
+  const writeRecord = PeekQueueValue(controller);
   if (writeRecord === 'close') {
     WritableStreamDefaultControllerProcessClose(controller);
   } else {
@@ -850,7 +851,7 @@ function WritableStreamDefaultControllerProcessClose(controller) {
 
   assert(stream._state === 'closing', 'can\'t process final write record unless already closed');
 
-  DequeueValue(controller._queue);
+  DequeueValue(controller);
   assert(controller._queue.length === 0, 'queue must be empty once the final write record is dequeued');
 
   controller._inClose = true;
@@ -896,7 +897,7 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
       assert(state === 'closing' || state === 'writable');
 
       const oldBackpressure = WritableStreamDefaultControllerGetBackpressure(controller);
-      DequeueValue(controller._queue);
+      DequeueValue(controller);
       WritableStreamDefaultControllerUpdateBackpressureIfNeeded(controller, oldBackpressure);
 
       WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
@@ -944,7 +945,7 @@ function WritableStreamDefaultControllerError(controller, e) {
     WritableStreamDefaultWriterEnsureReadyPromiseRejectedWith(stream._writer, e, readyPromiseIsPending);
   }
 
-  controller._queue = [];
+  ResetQueue(controller);
 
   if (controller._writing === false && controller._inClose === false) {
     WritableStreamRejectPromisesInReactionToError(stream);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -690,7 +690,8 @@ class WritableStreamDefaultController {
     this._underlyingSink = underlyingSink;
 
     // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
-    this._queue = this._queueTotalSize = undefined;
+    this._queue = undefined;
+    this._queueTotalSize = undefined;
     ResetQueue(this);
 
     this._started = false;


### PR DESCRIPTION
Previously, we believed that the spec's inefficient-but-clear method, of adding up all the chunk sizes whenever it wanted to get the total queue size, was equivalent to keeping a running count. This was discussed in #582; note also #491 where we changed the reference implementation to the running-count strategy for speed reasons. As discovered in https://github.com/whatwg/streams/issues/582#issuecomment-273016992, and further elaborated on in #657, these two methods are not in fact equivalent, due to the vagaries of floating-point arithmetic. <del>(That is, they are equivalent if you assume the addition is floating-point addition, but that is less than clear from the spec.)</del> <ins>I was confused; see below. Let's remember to remove that sentence from the commit message when merging.</ins>

As such, this commit switches the spec to the more efficient running-count method, as that's realistically the only implementable version. It also adds tests to ensure floating point arithmetic is being used, exposing such cases.

This commit also includes a few unobservable cleanups:

- It introduces the ResetQueue abstract operation, to ensure that the queue total size gets reset to zero when the queue is cleared. This should not matter because no code paths check the queue's total size after it has been cleared, but keeping the two slots in sync seems virtuous.

- It updates the internal slot name for ReadableByteStreamController instances from [[totalQueuedBytes]] to [[queueTotalSize]], to be consistent with those for the other queue-containers. We do not yet use the queue-with-sizes abstract operations (except ResetQueue) on ReadableByteStreamController instances as the queue management is significantly more complicated there. But aligning makes the spec easier to read.

Closes #582. Closes #657.

---

Things to contemplate:

- I realized after making this whole change that we probably could have gotten away with simply reminding everyone that all arithmetic is floating point arithmetic. Unless I am very confused, I think the running-count methods and the sum-as-needed methods are equivalent as long as both use the same type of arithmetic. So really the only necessary part of this pull request is 

  ```diff
   +It's also worth noting that, as in [[!ECMASCRIPT]], all numbers are represented as double-precision floating point
   +values, and all arithmetic operations performed on them must be done in the usual way for such values.
   ```

- I would really like to unify the readable byte stream queue so that it uses the queue with sizes operations, instead of its own bespoke stuff. But I'll leave that for future work. There's no obvious way to do so that isn't at least a bit awkward for someone.

---

Tests: https://github.com/w3c/web-platform-tests/pull/4568 (for the updated semantics discussed in #582).