### PR TITLE
Reduce number of iterations in write test

### DIFF
--- a/reference-implementation/to-upstream-wpts/writable-streams/write.js
+++ b/reference-implementation/to-upstream-wpts/writable-streams/write.js
@@ -165,7 +165,7 @@ promise_test(t => {
 }, 'when sink\'s write throws an error, the stream should become errored and the promise should reject');
 
 promise_test(() => {
-  const numberOfWrites = 10000;
+  const numberOfWrites = 1000;
 
   let resolveFirstWritePromise;
   let writeCount = 0;


### PR DESCRIPTION
Test 'a large queue of writes should be processed completely' was timing
out in some configurations.

Reduce the number of iterations from 10000 to 1000.

Fixes #660.