### PR TITLE
Correct bad variable in PromiseInvokeOrNoop

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3885,7 +3885,7 @@ A few abstract operations are used in this specification for utility purposes. W
   1. Assert: ! IsPropertyKey(_P_) is *true*.
   1. Assert: _args_ is a List.
   1. Let _returnValue_ be InvokeOrNoop(_O_, _P_, _args_).
-  1. If _returnValue_ is an abrupt completion, return <a>a promise rejected with</a> _result_.[[Value]].
+  1. If _returnValue_ is an abrupt completion, return <a>a promise rejected with</a> _returnValue_.[[Value]].
   1. Otherwise, return <a>a promise resolved with</a> _returnValue_.[[Value]].
 </emu-alg>
 


### PR DESCRIPTION
"a promise rejected with result.[[Value]]" should be "a promise rejected
with returnValue.[[Value]]". Fixed.

Closes #682.