### PR TITLE
Check precisely the way that transformer.transform() is called

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/general.js
@@ -316,7 +316,7 @@ promise_test(t => {
   //   return TransformStreamDefaultTransform(chunk, controller);
 
   const transformer = {
-    transform(chunk, controller) {
+    transform() {
       transformer.transform = undefined;
       throw thrownError;
     }
@@ -360,7 +360,7 @@ promise_test(() => {
   });
   const writer = ts.writable.getWriter();
   writer.write('a');
-  writer.write('b)');
+  writer.write('b');
   writer.close();
   return readableStreamToArray(ts.readable)
       .then(chunks => {


### PR DESCRIPTION
There is an incorrect possible optimisation to the call to
transformer.transform() in the TransformStreamTransform operation:

```javascript
let transformPromise;
try {
  transformPromise = Promise.resolve(transformer.transform(chunk, controller));
} catch (e) {
  if (transformer.transform === undefined) {
    transformPromise = TransformStreamDefaultTransform(chunk, controller);
  } else {
    transformPromise = Promise.reject(e);
  }
}
```

This optimisation is attractive because it moves the `undefined` check out of the
expected fast path. The flaw is the change in order of checking whether
transformer.transform is undefined is visible to user code.

Add a test to verify that the undefined check is performed before the method call.

Also test that transformer.transform is only looked up once, to protect against
flawed variations on this optimisation.