### PR TITLE
Do not assume a BYOB reader when fulfilling a BYOB request

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2412,9 +2412,10 @@ nothrow>ReadableByteStreamControllerRespondInClosedState ( <var>controller</var>
   1. Set _firstDescriptor_.[[buffer]] to ! TransferArrayBuffer(_firstDescriptor_.[[buffer]]).
   1. Assert: _firstDescriptor_.[[bytesFilled]] is *0*.
   1. Let _stream_ be _controller_.[[controlledReadableStream]].
-  1. Repeat the following steps while ! ReadableStreamGetNumReadIntoRequests(_stream_) > *0*,
-    1. Let _pullIntoDescriptor_ be ! ReadableByteStreamControllerShiftPendingPullInto(_controller_).
-    1. Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(_stream_, _pullIntoDescriptor_).
+  1. If ReadableStreamHasBYOBReader(_stream_) is *true*,
+    1. Repeat the following steps while ! ReadableStreamGetNumReadIntoRequests(_stream_) > *0*,
+      1. Let _pullIntoDescriptor_ be ! ReadableByteStreamControllerShiftPendingPullInto(_controller_).
+      1. Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(_stream_, _pullIntoDescriptor_).
 </emu-alg>
 
 <h4 id="readable-byte-stream-controller-respond-in-readable-state"
@@ -4476,6 +4477,7 @@ Marcos Caceres,
 Marvin Hagemeister,
 Michael Mior,
 Mihai Potra,
+Romain, <!-- rombel on GitHub -->
 Simon Menke,
 Stephen Sugden,
 Tab Atkins,

--- a/index.bs
+++ b/index.bs
@@ -4477,7 +4477,7 @@ Marcos Caceres,
 Marvin Hagemeister,
 Michael Mior,
 Mihai Potra,
-Romain, <!-- rombel on GitHub -->
+Romain Bellessort, <!-- rombel on GitHub -->
 Simon Menke,
 Stephen Sugden,
 Tab Atkins,

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1642,11 +1642,11 @@ function ReadableByteStreamControllerRespondInClosedState(controller, firstDescr
   assert(firstDescriptor.bytesFilled === 0, 'bytesFilled must be 0');
 
   const stream = controller._controlledReadableStream;
-
-  while (ReadableStreamGetNumReadIntoRequests(stream) > 0) {
-    const pullIntoDescriptor = ReadableByteStreamControllerShiftPendingPullInto(controller);
-
-    ReadableByteStreamControllerCommitPullIntoDescriptor(stream, pullIntoDescriptor);
+  if (ReadableStreamHasBYOBReader(stream) === true) {
+    while (ReadableStreamGetNumReadIntoRequests(stream) > 0) {
+      const pullIntoDescriptor = ReadableByteStreamControllerShiftPendingPullInto(controller);
+      ReadableByteStreamControllerCommitPullIntoDescriptor(stream, pullIntoDescriptor);
+    }
   }
 }
 
@@ -1717,11 +1717,11 @@ function ReadableByteStreamControllerShouldCallPull(controller) {
     return false;
   }
 
-  if (ReadableStreamHasDefaultReader(stream) && ReadableStreamGetNumReadRequests(stream) > 0) {
+  if (ReadableStreamHasDefaultReader(stream) === true && ReadableStreamGetNumReadRequests(stream) > 0) {
     return true;
   }
 
-  if (ReadableStreamHasBYOBReader(stream) && ReadableStreamGetNumReadIntoRequests(stream) > 0) {
+  if (ReadableStreamHasBYOBReader(stream) === true && ReadableStreamGetNumReadIntoRequests(stream) > 0) {
     return true;
   }
 


### PR DESCRIPTION
In particular, when autoAllocateChunkSize is in play, there may be a default reader instead. Fixes #686.

/cc @rombel. Let us know if you'd prefer a full name or similar in the acknowledgments!

@tyoshino I'm curious if this is the best solution. At first I tried to move the code into ReadableStreamClose, since ReadableStreamError has a branch on reader type and I thought ReadableStreamClose should be symmetric. But that caused failing tests, as I believe we want to keep the byobRequest around even if the stream gets closed. So this version seemed OK-ish.

This also needs tests before it can be merged. Let me know if there are any particular tests besides the one in https://github.com/whatwg/streams/issues/686#issuecomment-285368195 which might be good.