### PR TITLE
Add a couple of missing exclamation marks standard text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3568,8 +3568,8 @@ aoid="WritableStreamDefaultControllerAdvanceQueueIfNeeded" nothrow>WritableStrea
   1. If _stream_.[[inFlightWriteRequest]] is not *undefined*, return.
   1. If _controller_.[[queue]] is empty, return.
   1. Let _writeRecord_ be ! PeekQueueValue(_controller_).
-  1. If _writeRecord_ is `"close"`, perform WritableStreamDefaultControllerProcessClose(_controller_).
-  1. Otherwise, perform WritableStreamDefaultControllerProcessWrite(_controller_, _writeRecord_.[[chunk]]).
+  1. If _writeRecord_ is `"close"`, perform ! WritableStreamDefaultControllerProcessClose(_controller_).
+  1. Otherwise, perform ! WritableStreamDefaultControllerProcessWrite(_controller_, _writeRecord_.[[chunk]]).
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-error-if-needed" aoid="WritableStreamDefaultControllerErrorIfNeeded"


### PR DESCRIPTION
WritableStreamDefaultControllerAdvanceQueueIfNeeded was missing the "!" which
indicates that we expect the call to the abstract operation to always succeed in
two places.

Add them.