### PR TITLE
Use ResetQueue in WritableStreamDefaultControllerProcessWrite

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3636,7 +3636,7 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
     1. If _stream_.[[state]] is `"errored"`, set _wasErrored_ to *true*.
     1. Perform ! WritableStreamFinishInFlightWriteWithError(_stream_, _reason_).
     1. Assert: _stream_.[[state]] is `"errored"`.
-    1. If _wasErrored_ is *false*, set _controller_.[[queue]] to an empty List.
+    1. If _wasErrored_ is *false*, perform ! ResetQueue(_controller_).
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-get-backpressure" aoid="WritableStreamDefaultControllerGetBackpressure"

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -919,7 +919,7 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
 
       assert(stream._state === 'errored');
       if (wasErrored === false) {
-        controller._queue = [];
+        ResetQueue(controller);
       }
     }
   )


### PR DESCRIPTION
WritableStreamDefaultControllerProcessWrite contained the line "If wasErrored is
false, set controller.[[queue]] to an empty List."

Generally it is better to use ResetQueue() to keep the [[queue]] and
[[queueTotalSize]] slots in sink. Do that instead.