### PR TITLE
Make writer.write() reject with the stream's stored error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3357,10 +3357,12 @@ nothrow>WritableStreamDefaultWriterWrite ( <var>writer</var>, <var>chunk</var> )
   1. If _stream_ is not equal to _writer_.[[ownerWritableStream]], return <a>a promise rejected with</a> a *TypeError*
      exception.
   1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is not `"writable"` or ! WritableStreamCloseQueuedOrInFlight(_stream_) is *true*, return
-     <a>a promise rejected with</a> a *TypeError* exception.
+  1. If _state_ is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
+  1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *true* or _state_ is `"closed"`, return
+     <a>a promise rejected with</a> a *TypeError* exception indicating that the stream is closing or closed.
+  1. Assert: _state_ is `"writable"`.
   1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return <a>a promise rejected with</a> a *TypeError*
-     indicating that the stream has been requested to abort.
+     indicating that the stream is in the process of being aborted.
   1. Let _promise_ be ! WritableStreamAddWriteRequest(_stream_).
   1. Perform ! WritableStreamDefaultControllerWrite(_controller_, _chunk_, _chunkSize_).
   1. Return _promise_.

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -656,12 +656,17 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
   }
 
   const state = stream._state;
-  if (state !== 'writable' || WritableStreamCloseQueuedOrInFlight(stream) === true) {
-    return Promise.reject(new TypeError(
-      `The stream (in ${state} state) is not in the writable state and cannot be written to`));
+  if (state === 'errored') {
+    return Promise.reject(stream._storedError);
   }
+  if (state === 'closed' || WritableStreamCloseQueuedOrInFlight(stream) === true) {
+    return Promise.reject(new TypeError('The stream is closing or closed and cannot be written to'));
+  }
+
+  assert(state === 'writable');
+
   if (stream._pendingAbortRequest !== undefined) {
-    return Promise.reject(new TypeError('Requested to abort'));
+    return Promise.reject(new TypeError('The stream is being aborted and cannot be written to'));
   }
 
   const promise = WritableStreamAddWriteRequest(stream);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -659,7 +659,7 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
   if (state === 'errored') {
     return Promise.reject(stream._storedError);
   }
-  if (state === 'closed' || WritableStreamCloseQueuedOrInFlight(stream) === true) {
+  if (WritableStreamCloseQueuedOrInFlight(stream) === true || state === 'closed') {
     return Promise.reject(new TypeError('The stream is closing or closed and cannot be written to'));
   }
 


### PR DESCRIPTION
Closes #700.

Tests: https://github.com/w3c/web-platform-tests/pull/5240

(reminder to self: remember to do the multi-step test update dance before pressing the merge button)