### PR TITLE
Update WebSocket examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4230,7 +4230,10 @@ promises returned by its <a lt="writable stream writer">writer</a>'s {{WritableS
 
     return new WritableStream({
       start(controller) {
-        ws.onerror = () => controller.error(new Error("The WebSocket errored!"));
+        ws.onerror = () => {
+          controller.error(new Error("The WebSocket errored!"));
+          ws.onclose = null;
+        };
         ws.onclose = () => controller.error(new Error("The server closed the connection unexpectedly!"));
         return new Promise(resolve => ws.onopen = resolve);
       },
@@ -4386,6 +4389,7 @@ source abstractions.
       this._ws.onclose = () => controller.error(new Error("The server closed the connection unexpectedly!"));
       this._ws.addEventListener("error", () => {
         controller.error(new Error("The WebSocket errored!"));
+        this._ws.onclose = null;
       });
 
       return new Promise(resolve => this._ws.onopen = resolve);

--- a/index.bs
+++ b/index.bs
@@ -4231,6 +4231,7 @@ promises returned by its <a lt="writable stream writer">writer</a>'s {{WritableS
     return new WritableStream({
       start(controller) {
         ws.onerror = () => controller.error(new Error("The WebSocket errored!"));
+        ws.onclose = () => controller.error(new Error("The server closed the connection unexpectedly!"));
         return new Promise(resolve => ws.onopen = resolve);
       },
 
@@ -4241,19 +4242,26 @@ promises returned by its <a lt="writable stream writer">writer</a>'s {{WritableS
       },
 
       close() {
-        return new Promise((resolve, reject) => {
-          ws.onclose = resolve;
-          ws.close(1000);
-        });
+        return closeWS(1000);
       },
 
       abort(reason) {
-        return new Promise((resolve, reject) => {
-          ws.onclose = resolve;
-          ws.close(4000, reason && reason.message);
-        });
-      }
+        return closeWS(4000, reason && reason.message);
+      },
     });
+
+    function closeWS(code, reasonString) {
+      return new Promise((resolve, reject) => {
+        ws.onclose = e => {
+          if (e.wasClean) {
+            resolve();
+          } else {
+            reject(new Error("The connection was not closed cleanly"));
+          }
+        };
+        ws.close(code, reasonString);
+      });
+    }
   }
 </code></pre>
 
@@ -4375,6 +4383,7 @@ source abstractions.
     }
 
     start(controller) {
+      this._ws.onclose = () => controller.error(new Error("The server closed the connection unexpectedly!"));
       this._ws.addEventListener("error", () => {
         controller.error(new Error("The WebSocket errored!"));
       });
@@ -4387,16 +4396,23 @@ source abstractions.
     }
 
     close() {
-      return new Promise((resolve, reject) => {
-        this._ws.onclose = resolve;
-        this._ws.close();
-      });
+      return this._closeWS(1000);
     }
 
     abort(reason) {
+      return this._closeWS(4000, reason && reason.message);
+    }
+
+    _closeWS(code, reason) {
       return new Promise((resolve, reject) => {
-        ws.onclose = resolve;
-        ws.close(4000, reason && reason.message);
+        this._ws.onclose = e => {
+          if (e.wasClean) {
+            resolve();
+          } else {
+            reject(new Error("The connection was not closed cleanly"));
+          }
+        };
+        this._ws.close(code, reasonString);
       });
     }
   }


### PR DESCRIPTION
I recently learned that WebSockets will tell you if they closed cleanly. This allows us to illustrate returning a potentially-rejected promise from the underlying sink's close() and abort() methods.

This also makes the writable streams error themselves if the WebSockets are closed by the server (as opposed to closed by the client), as this represents an unexpected cessation of the ability to write data.

Finally this synchronizes the examples so that they both send a status code of 1000 for closing successfully.

---

Please carefully check my semantics here as I have not used the web socket API in anger recently. I may not be holding it right.