### PR TITLE
Properly coerce mode to a string in getReader()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -514,8 +514,9 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 
 <emu-alg>
   1. If ! IsReadableStream(*this*) is *false*, throw a *TypeError* exception.
-  1. If _mode_ is `"byob"`, return ? AcquireReadableStreamBYOBReader(*this*).
   1. If _mode_ is *undefined*, return ? AcquireReadableStreamDefaultReader(*this*).
+  1. Set _mode_ to ? ToString(_mode_).
+  1. If _mode_ is `"byob"`, return ? AcquireReadableStreamBYOBReader(*this*).
   1. Throw a *RangeError* exception.
 </emu-alg>
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -69,12 +69,14 @@ class ReadableStream {
       throw streamBrandCheckException('getReader');
     }
 
-    if (mode === 'byob') {
-      return AcquireReadableStreamBYOBReader(this);
-    }
-
     if (mode === undefined) {
       return AcquireReadableStreamDefaultReader(this);
+    }
+
+    mode = String(mode);
+
+    if (mode === 'byob') {
+      return AcquireReadableStreamBYOBReader(this);
     }
 
     throw new RangeError('Invalid mode is specified');


### PR DESCRIPTION
Discovered in https://github.com/w3c/web-platform-tests/pull/5260.

@isonmad, please take a look!

The corresponding test PR Is @isonmad's https://github.com/w3c/web-platform-tests/pull/5260, which currently tests the opposite condition, but it is a spec bug.