### PR TITLE
Require pipeTo() to properly use the destination queue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -643,12 +643,11 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
          from _reader_.
        * If _reader_ is a <a>BYOB reader</a>, WritableStreamDefaultWriterGetDesiredSize(_writer_) should be used to
          determine the size of the chunks read from _reader_.
-       * After taking into account these backpressure signals, reading and writing should be done promptly; other
-         signals should not be used to delay the continual reading/writing.
-         <p class="example" id="example-bad-backpressure">An implementation that waits for each write to successfully complete before proceeding to
-         the next read/write operation violates this recommendation. In doing so, such an implementation makes the
-         <a>internal queue</a> of _dest_ useless, as it ensures _dest_ always contains at most one queued
-         <a>chunk</a>.</p>
+       * Reads or writes should not be delayed for reasons other than these backpressure signals.
+         <p class="example" id="example-bad-backpressure">An implementation that waits for each write to successfully
+         complete before proceeding to the next read/write operation violates this recommendation. In doing so, such an
+         implementation makes the <a>internal queue</a> of _dest_ useless, as it ensures _dest_ always contains at most
+         one queued <a>chunk</a>.</p>
      * <strong>Shutdown must stop all activity:</strong> if _shuttingDown_ becomes *true*, the user agent must not
        initiate further reads from _reader_ or writes to _writer_. (Ongoing reads and writes may finish.) In particular,
        the user agent must check the below conditions on *this*.[[state]] and _dest_.[[state]] before performing any

--- a/index.bs
+++ b/index.bs
@@ -645,8 +645,8 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
          determine the size of the chunks read from _reader_. Otherwise, the desired size may be used to determine the
          flow rate heuristically, e.g. by delaying reads while the desired size is judged to be "low" compared to the
          size of <a>chunks</a> that have been typically read.
-       * After taking into account these backpressure signals, reading and writing should be done as fast as possible;
-         other signals should not be used to delay the continual reading/writing.
+       * After taking into account these backpressure signals, reading and writing should be done promptly; other
+         signals should not be used to delay the continual reading/writing.
          <p class="example" id="example-bad-backpressure">An implementation that waits for each write to successfully complete before proceeding to
          the next read/write operation violates this recommendation. In doing so, such an implementation makes the
          <a>internal queue</a> of _dest_ useless, as it ensures _dest_ always contains at most one queued

--- a/index.bs
+++ b/index.bs
@@ -642,9 +642,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
        * While WritableStreamDefaultWriterGetDesiredSize(_writer_) is ≤ *0* or is *null*, the user agent must not read
          from _reader_.
        * If _reader_ is a <a>BYOB reader</a>, WritableStreamDefaultWriterGetDesiredSize(_writer_) should be used to
-         determine the size of the chunks read from _reader_. Otherwise, the desired size may be used to determine the
-         flow rate heuristically, e.g. by delaying reads while the desired size is judged to be "low" compared to the
-         size of <a>chunks</a> that have been typically read.
+         determine the size of the chunks read from _reader_.
        * After taking into account these backpressure signals, reading and writing should be done promptly; other
          signals should not be used to delay the continual reading/writing.
          <p class="example" id="example-bad-backpressure">An implementation that waits for each write to successfully complete before proceeding to

--- a/index.bs
+++ b/index.bs
@@ -642,10 +642,15 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
        * While WritableStreamDefaultWriterGetDesiredSize(_writer_) is ≤ *0* or is *null*, the user agent must not read
          from _reader_.
        * If _reader_ is a <a>BYOB reader</a>, WritableStreamDefaultWriterGetDesiredSize(_writer_) should be used to
-         determine the size of the chunks read from _reader_.
-       * Otherwise, WritableStreamDefaultWriterGetDesiredSize(_writer_) may be used to determine the flow rate
-         heuristically, e.g. by delaying reads while it is judged to be "low" compared to the size of chunks that have
-         been typically read.
+         determine the size of the chunks read from _reader_. Otherwise, the desired size may be used to determine the
+         flow rate heuristically, e.g. by delaying reads while the desired size is judged to be "low" compared to the
+         size of <a>chunks</a> that have been typically read.
+       * After taking into account these backpressure signals, reading and writing should be done as fast as possible;
+         other signals should not be used to delay the continual reading/writing.
+         <p class="example" id="example-bad-backpressure">An implementation that waits for each write to successfully complete before proceeding to
+         the next read/write operation violates this recommendation. In doing so, such an implementation makes the
+         <a>internal queue</a> of _dest_ useless, as it ensures _dest_ always contains at most one queued
+         <a>chunk</a>.</p>
      * <strong>Shutdown must stop all activity:</strong> if _shuttingDown_ becomes *true*, the user agent must not
        initiate further reads from _reader_ or writes to _writer_. (Ongoing reads and writes may finish.) In particular,
        the user agent must check the below conditions on *this*.[[state]] and _dest_.[[state]] before performing any


### PR DESCRIPTION
Fixes #653.

Tests: https://github.com/w3c/web-platform-tests/pull/5262 by @isonmad. I've confirmed these modifications to the reference implementation pass those tests.