### PR TITLE
Unified error handling for WritableStream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2679,7 +2679,7 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
       <a>underlying sink</a>. It can return a promise to signal success or failure of the write operation. The stream
       implementation guarantees that this method will be called only after previous writes have succeeded, and never
       after <code>close</code> or <code>abort</code> is called.
-    <li> <code>close(controller)</code> is called after the producer signals that they are done writing chunks to the
+    <li> <code>close()</code> is called after the producer signals that they are done writing chunks to the
       stream, and all queued-up writes successfully complete. It can perform any actions necessary to finalize writes
       to the <a>underlying sink</a>, and release access to it. If this process is asynchronous, it can return a promise
       to signal success or failure. The stream implementation guarantees that this method will be called only after all
@@ -2799,43 +2799,18 @@ writable stream is <a>locked to a writer</a>.
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"closed"`, return <a>a promise resolved with</a> *undefined*.
   1. If _state_ is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
-  1. Assert: _state_ is `"writable"`.
   1. Let _error_ be a new *TypeError* indicating that the stream has been requested to abort.
   1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return <a>a promise rejected with</a> _error_.
-  1. Let _controller_ be _stream_.[[writableStreamController]].
-  1. Assert: _controller_ is not *undefined*.
-  1. If ! WritableStreamHasOperationMarkedInFlight(_stream_) is *false* and _controller_.[[started]] is *true*,
-    1. Perform ! WritableStreamFinishAbort(_stream_).
-    1. Return ! _controller_.[[AbortSteps]](_reason_).
-  1. Let _writer_ be _stream_.[[writer]].
-  1. If _writer_ is not *undefined*,
-    1. Perform ! WritableStreamDefaultWriterEnsureReadyPromiseRejected(_writer_, _error_).
+  1. Assert: _state_ is `"writable"` or `"erroring"`.
+  1. Let _wasAlreadyErroring_ be *false*.
+  1. If _state_ is `"erroring"`,
+    1. Set _wasAlreadyErroring_ to *true*.
+    1. Set _reason_ to *undefined*.
   1. Let _promise_ be <a>a new promise</a>.
-  1. Set _stream_.[[pendingAbortRequest]] to Record {[[promise]]: _promise_, [[reason]]: _reason_}.
+  1. Set _stream_.[[pendingAbortRequest]] to Record {[[promise]]: _promise_, [[reason]]: _reason_,
+     [[wasAlreadyErroring]]: _wasAlreadyErroring_}.
+  1. If _wasAlreadyErroring_ is *false*, perform ! WritableStreamStartErroring(_stream_, _error_).
   1. Return _promise_.
-</emu-alg>
-
-<h4 id="writable-stream-error" aoid="WritableStreamError" nothrow>WritableStreamError ( <var>stream</var>,
-<var>error</var> )</h4>
-
-<emu-alg>
-  1. Set _stream_.[[state]] to `"errored"`.
-  1. Set _stream_.[[storedError]] to _error_.
-  1. Perform ! _stream_.[[writableStreamController]].[[ErrorSteps]]().
-  1. If _stream_.[[pendingAbortRequest]] is *undefined*,
-    1. Let _writer_ be _stream_.[[writer]].
-    1. If _writer_ is not *undefined*,
-      1. Perform ! WritableStreamDefaultWriterEnsureReadyPromiseRejected(_writer_, _error_).
-  1. If ! WritableStreamHasOperationMarkedInFlight(_stream_) is *false*, perform !
-     WritableStreamRejectPromisesInReactionToError(_stream_).
-</emu-alg>
-
-<h4 id="writable-stream-finish-abort" aoid="WritableStreamFinishAbort" nothrow>WritableStreamFinishAbort (
-<var>stream</var> )</h4>
-
-<emu-alg>
-  1. Let _error_ be a new *TypeError* indicating that the stream has been aborted.
-  1. Perform ! WritableStreamError(_stream_, _error_).
 </emu-alg>
 
 <h3 id="ws-abstract-ops-used-by-controllers">Writable Stream Abstract Operations Used by Controllers</h3>
@@ -2861,6 +2836,65 @@ visible through the {{WritableStream}}'s public API.
   1. Return _promise_.
 </emu-alg>
 
+<h4 id="writable-stream-deal-with-rejection" aoid="WritableStreamDealWithRejection"
+nothrow>WritableStreamDealWithRejection ( <var>stream</var>, <var>error</var> )</h4>
+
+<emu-alg>
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"writable"`,
+    1. Perform ! WritableStreamStartErroring(_stream_).
+    1. Return.
+  1. Assert: _state_ is `"erroring"`.
+  1. Perform ! WritableStreamFinishErroring(_stream_).
+</emu-alg>
+
+<h4 id="writable-stream-start-erroring" aoid="WritableStreamStartErroring" nothrow>WritableStreamStartErroring (
+<var>stream</var>, <var>reason</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[storedError]] is *undefined*.
+  1. Assert: _stream_.[[state]] is `"writable"`.
+  1. Let _controller_ be _stream_.[[writableStreamController]].
+  1. Assert: _controller_ is not *undefined*.
+  1. Set _stream_.[[state]] to `"erroring"`.
+  1. Set _stream_.[[storedError]] to _reason_.
+  1. Let _writer_ be _stream_.[[writer]].
+  1. If _writer_ is not *undefined*, perform !
+     WritableStreamDefaultWriterEnsureReadyPromiseRejected(_writer_, _reason_).
+  1. If ! WritableStreamHasOperationMarkedInFlight(_stream_) is *false* and _controller_.[[started]] is *true*, perform
+     ! WritableStreamFinishErroring(_stream_).
+</emu-alg>
+
+<h4 id="writable-stream-finish-erroring" aoid="WritableStreamFinishErroring" nothrow>WritableStreamFinishErroring
+( <var>stream</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[state]] is `"erroring"`.
+  1. Assert: ! WritableStreamHasOperationMarkedInFlight(_stream_) is *false*.
+  1. Set _stream_.[[state]] to `"errored"`.
+  1. Perform ! _stream_.[[writableStreamController]].[[ErrorSteps]]().
+  1. Let _storedError_ be _stream_.[[storedError]].
+  1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
+    1. <a>Reject</a> _writeRequest_ with _storedError_.
+  1. Set _stream_.[[writeRequest]] to an empty List.
+  1. if _stream_.[[pendingAbortRequest]] is *undefined*,
+    1. Perform !  WritableStreamRejectCloseAndClosedPromiseIfNeeded(_stream_).
+    1. Return.
+  1. Let _abortRequest_ be _stream_.[[pendingAbortRequest]].
+  1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
+  1. If _abortRequest_.[[wasAlreadyErroring]] is *true*,
+    1. <a>Reject</a> _abortRequest_.[[promise]] with _storedError_.
+    1. Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(_stream_).
+    1. Return.
+  1. Let _promise_ be ! stream.[[writableStreamController]].[[AbortSteps]](_abortRequest_.[[reason]]).
+  1. <a>Upon fulfillment</a> of _promise_,
+    1. <a>Resolve</a> _abortRequest_.[[promise]] with *undefined*.
+    1. Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(_stream_).
+  1. <a>Upon rejection</a> of _promise_ with reason _reason_,
+    1. <a>Reject</a> _abortRequest_.[[promise]] with _reason_.
+    1. Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(_stream_).
+</emu-alg>
+
 <h4 id="writable-stream-finish-in-flight-write" aoid="WritableStreamFinishInFlightWrite"
 nothrow>WritableStreamFinishInFlightWrite ( <var>stream</var> )</h4>
 
@@ -2868,20 +2902,6 @@ nothrow>WritableStreamFinishInFlightWrite ( <var>stream</var> )</h4>
   1. Assert: _stream_.[[inFlightWriteRequest]] is not *undefined*.
   1. <a>Resolve</a> _stream_.[[inFlightWriteRequest]] with *undefined*.
   1. Set _stream_.[[inFlightWriteRequest]] to *undefined*.
-  1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"errored"`,
-    1. Perform ! WritableStreamFinishInFlightWriteInErroredState(_stream_).
-    1. Return.
-  1. Assert: _state_ is `"writable"`.
-  1. Perform ! WritableStreamHandleAbortRequestIfPending(_stream_).
-</emu-alg>
-
-<h4 id="writable-stream-finish-in-flight-write-in-errored-state" aoid="WritableStreamFinishInFlightWriteInErroredState"
-nothrow>WritableStreamFinishInFlightWriteInErroredState ( <var>stream</var> )</h4>
-
-<emu-alg>
-  1. Perform ! WritableStreamRejectAbortRequestIfPending(_stream_).
-  1. Perform ! WritableStreamRejectPromisesInReactionToError(_stream_).
 </emu-alg>
 
 <h4 id="writable-stream-finish-in-flight-write-with-error" aoid="WritableStreamFinishInFlightWriteWithError"
@@ -2891,13 +2911,8 @@ nothrow>WritableStreamFinishInFlightWriteWithError ( <var>stream</var>, <var>err
   1. Assert: _stream_.[[inFlightWriteRequest]] is not *undefined*.
   1. <a>Reject</a> _stream_.[[inFlightWriteRequest]] with _error_.
   1. Set _stream_.[[inFlightWriteRequest]] to *undefined*.
-  1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"errored"`,
-    1. Perform ! WritableStreamFinishInFlightWriteInErroredState(_stream_).
-    1. Return.
-  1. Assert: _state_ is `"writable"`.
-  1. Perform ! WritableStreamError(_stream_, _error_).
-  1. Perform ! WritableStreamRejectAbortRequestIfPending(_stream_).
+  1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+  1. Perform ! WritableStreamDealWithRejection(_stream_, _error_).
 </emu-alg>
 
 <h4 id="writable-stream-finish-in-flight-close" aoid="WritableStreamFinishInFlightClose"
@@ -2908,24 +2923,17 @@ nothrow>WritableStreamFinishInFlightClose ( <var>stream</var> )</h4>
   1. <a>Resolve</a> _stream_.[[inFlightCloseRequest]] with *undefined*.
   1. Set _stream_.[[inFlightCloseRequest]] to *undefined*.
   1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"errored"`,
-    1. Perform ! WritableStreamFinishInFlightCloseInErroredState(_stream_).
-    1. Return.
-  1. Assert: _state_ is `"writable"`.
+  1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+  1. If _state_ is `"erroring"`,
+    1. Set _stream_.[[storedError]] to *undefined*.
+    1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
+      1. <a>Resolve</a> _stream_.[[pendingAbortRequest]].[[promise]] with *undefined*.
+      1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
   1. Set _stream_.[[state]] to `"closed"`.
   1. Let _writer_ be _stream_.[[writer]].
   1. If _writer_ is not *undefined*, <a>resolve</a> _writer_.[[closedPromise]] with *undefined*.
-  1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
-    1. <a>Resolve</a> _stream_.[[pendingAbortRequest]].[[promise]] with *undefined*.
-    1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
-</emu-alg>
-
-<h4 id="writable-stream-finish-in-flight-close-in-errored-state" aoid="WritableStreamFinishInFlightCloseInErroredState"
-nothrow>WritableStreamFinishInFlightCloseInErroredState ( <var>stream</var> )</h4>
-
-<emu-alg>
-  1. Perform ! WritableStreamRejectAbortRequestIfPending(_stream_).
-  1. Perform ! WritableStreamRejectClosedPromiseInReactionToError(_stream_).
+  1. Assert: _stream_.[[pendingAbortRequest]] is *undefined*.
+  1. Assert: _stream_.[[storedError]] is *undefined*.
 </emu-alg>
 
 <h4 id="writable-stream-finish-in-flight-close-with-error" aoid="WritableStreamFinishInFlightCloseWithError"
@@ -2935,13 +2943,11 @@ nothrow>WritableStreamFinishInFlightCloseWithError ( <var>stream</var>, <var>err
   1. Assert: _stream_.[[inFlightCloseRequest]] is not *undefined*.
   1. <a>Reject</a> _stream_.[[inFlightCloseRequest]] with _error_.
   1. Set _stream_.[[inFlightCloseRequest]] to *undefined*.
-  1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"errored"`,
-    1. Perform ! WritableStreamFinishInFlightCloseInErroredState(_stream_).
-    1. Return.
-  1. Assert: _state_ is `"writable"`.
-  1. Perform ! WritableStreamError(_stream_, _error_).
-  1. Perform ! WritableStreamRejectAbortRequestIfPending(_stream_).
+  1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+  1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
+    1. <a>Reject</a> _stream_.[[pendingAbortRequest]].[[promise]] with _error_.
+    1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
+  1. Perform ! WritableStreamDealWithRejection(_stream_, _error_).
 </emu-alg>
 
 <h4 id="writable-stream-close-queued-or-in-flight" aoid="WritableStreamCloseQueuedOrInFlight" nothrow>
@@ -2950,19 +2956,6 @@ WritableStreamCloseQueuedOrInFlight ( <var>stream</var> )</h4>
 <emu-alg>
   1. If _stream_.[[closeRequest]] is *undefined* and _stream_.[[inFlightCloseRequest]] is *undefined*, return *false*.
   1. Return *true*.
-</emu-alg>
-
-<h4 id="writable-stream-handle-abort-request-if-pending" aoid="WritableStreamHandleAbortRequestIfPending"
-nothrow>WritableStreamHandleAbortRequestIfPending ( <var>stream</var> )</h4>
-
-<emu-alg>
-  1. If _stream_.[[pendingAbortRequest]] is *undefined*, return.
-  1. Perform ! WritableStreamFinishAbort(_stream_).
-  1. Let _abortRequest_ be _stream_.[[pendingAbortRequest]].
-  1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
-  1. Let _promise_ be ! _stream_.[[writableStreamController]].[[AbortSteps]](_abortRequest_.[[reason]]).
-  1. <a>Upon fulfillment</a> of _promise_ with value _result_, <a>resolve</a> _abortRequest_.[[promise]] with _result_.
-  1. <a>Upon rejection</a> of _promise_ with reason _reason_, <a>reject</a> _abortRequest_.[[promise]] with _reason_.
 </emu-alg>
 
 <h4 id="writable-stream-has-operation-marked-in-flight" aoid="WritableStreamHasOperationMarkedInFlight"
@@ -2995,39 +2988,20 @@ nothrow>WritableStreamMarkFirstWriteRequestInFlight ( <var>stream</var> )</h4>
   1. Set _stream_.[[inFlightWriteRequest]] to _writeRequest_.
 </emu-alg>
 
-<h4 id="writable-stream-reject-closed-promise-in-reaction-to-error"
-aoid="WritableStreamRejectClosedPromiseInReactionToError" nothrow>WritableStreamRejectClosedPromiseInReactionToError (
+<h4 id="writable-stream-reject-close-and-closed-promise-if-needed"
+aoid="WritableStreamRejectCloseAndClosedPromiseIfNeeded" nothrow>WritableStreamRejectCloseAndClosedPromiseIfNeeded (
 <var>stream</var> )</h4>
 
 <emu-alg>
+  1. Assert: _stream_.[[state]] is `"errored"`.
+  1. If _stream_.[[closeRequest]] is not *undefined*,
+    1. Assert: _stream_.[[inFlightCloseRequest]] is *undefined*.
+    1. <a>Reject</a> _stream_.[[closeRequest]] with _stream_.[[storedError]].
+    1. Set _stream_.[[closeRequest]] to *undefined*.
   1. Let _writer_ be _stream_.[[writer]].
   1. If _writer_ is not *undefined*,
     1. <a>Reject</a> _writer_.[[closedPromise]] with _stream_.[[storedError]].
     1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
-</emu-alg>
-
-<h4 id="writable-stream-reject-abort-request-if-pending" aoid="WritableStreamRejectAbortRequestIfPending"
-nothrow>WritableStreamRejectAbortRequestIfPending ( <var>stream</var> )</h4>
-
-<emu-alg>
-  1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
-    1. <a>Reject</a> _stream_.[[pendingAbortRequest]].[[promise]] with _stream_.[[storedError]].
-    1. Set _stream_.[[pendingAbortRequest]] to *undefined*.
-</emu-alg>
-
-<h4 id="writable-stream-reject-promises-in-reaction-to-error" aoid="WritableStreamRejectPromisesInReactionToError"
-nothrow>WritableStreamRejectPromisesInReactionToError ( <var>stream</var> )</h4>
-
-<emu-alg>
-  1. Let _storedError_ be _stream_.[[storedError]].
-  1. Repeat for each _writeRequest_ that is an element of _stream_.[[writeRequests]],
-    1. <a>Reject</a> _writeRequest_ with _storedError_.
-  1. Set _stream_.[[writeRequests]] to an empty List.
-  1. If _stream_.[[closeRequest]] is not *undefined*,
-    1. Assert: _stream_.[[inFlightCloseRequest]] is *undefined*.
-    1. <a>Reject</a> _stream_.[[closeRequest]] with _storedError_.
-    1. Set _stream_.[[closeRequest]] to *undefined*.
-  1. Perform ! WritableStreamRejectClosedPromiseInReactionToError(_stream_).
 </emu-alg>
 
 <h4 id="writable-stream-update-backpressure" aoid="WritableStreamUpdateBackpressure"
@@ -3035,7 +3009,7 @@ nothrow>WritableStreamUpdateBackpressure ( <var>stream</var>, <var>backpressure<
 
 <emu-alg>
   1. Assert: _stream_.[[state]] is `"writable"`.
-  1. Assert: WritableStreamCloseQueuedOrInFlight(_stream_) is *false*.
+  1. Assert: ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false*.
   1. Let _writer_ be _stream_.[[writer]].
   1. If _writer_ is not *undefined* and _backpressure_ is not _stream_.[[backpressure]],
     1. If _backpressure_ is *true*, set _writer_.[[readyPromise]] to <a>a new promise</a>.
@@ -3113,14 +3087,14 @@ lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>st
   1. Set _stream_.[[writer]] to *this*.
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"writable"`,
-    1. If _stream_.[[pendingAbortRequest]] is not *undefined*,
-      1. Let _error_ be a new *TypeError* indicating that the stream has been requested to abort.
-      1. Set *this*.[[readyPromise]] to <a>a promise rejected with</a> _error_.
-      1. Set *this*.[[readyPromise]].[[PromiseIsHandled]] to *true*.
-    1. Otherwise, if ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false* and _stream_.[[backpressure]] is *true*,
+    1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false* and _stream_.[[backpressure]] is *true*,
        set *this*.[[readyPromise]] to <a>a new promise</a>.
     1. Otherwise, set *this*.[[readyPromise]] to <a>a promise resolved with</a> *undefined*.
     1. Set *this*.[[closedPromise]] to <a>a new promise</a>.
+  1. Otherwise, if _state_ is `"erroring"`,
+      1. Set *this*.[[readyPromise]] to <a>a promise rejected with</a> _stream_.[[storedError]].
+      1. Set *this*.[[readyPromise]].[[PromiseIsHandled]] to *true*.
+      1. Set *this*.[[closedPromise]] to <a>a new promise</a>.
   1. Otherwise, if _state_ is `"closed"`,
     1. Set *this*.[[readyPromise]] to <a>a promise resolved with</a> *undefined*.
     1. Set *this*.[[closedPromise]] to <a>a promise resolved with</a> *undefined*.
@@ -3285,13 +3259,12 @@ nothrow>WritableStreamDefaultWriterClose ( <var>writer</var> )</h4>
   1. Assert: _stream_ is not *undefined*.
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"closed"` or `"errored"`, return <a>a promise rejected with</a> a *TypeError* exception.
-  1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return <a>a promise rejected with</a> a *TypeError*
-     indicating that the stream has been requested to abort.
-  1. Assert: _state_ is `"writable"`.
+  1. Assert: _state_ is `"writable"` or `"erroring"`.
   1. Assert: ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false*.
   1. Let _promise_ be <a>a new promise</a>.
   1. Set _stream_.[[closeRequest]] to _promise_.
-  1. If _stream_.[[backpressure]] is *true*, <a>resolve</a> _writer_.[[readyPromise]] with *undefined*.
+  1. If _stream_.[[backpressure]] is *true* and _state_ is `"writable"`, <a>resolve</a> _writer_.[[readyPromise]] with
+     *undefined*.
   1. Perform ! WritableStreamDefaultControllerClose(_stream_.[[writableStreamController]]).
   1. Return _promise_.
 </emu-alg>
@@ -3309,8 +3282,19 @@ nothrow>WritableStreamDefaultWriterCloseWithErrorPropagation ( <var>writer</var>
   1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *true* or _state_ is `"closed"`, return
      <a>a promise resolved with</a> *undefined*.
   1. If _state_ is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
-  1. Assert: _state_ is `"writable"`.
+  1. Assert: _state_ is `"writable"` or `"erroring"`.
   1. Return ! WritableStreamDefaultWriterClose(_writer_).
+</emu-alg>
+
+<h4 id="writable-stream-default-writer-ensure-closed-promise-rejected"
+aoid="WritableStreamDefaultWriterEnsureClosedPromiseRejected"
+nothrow>WritableStreamDefaultWriterEnsureClosedPromiseRejected( <var>writer</var>, <var>error</var> )</h4>
+
+<emu-alg>
+  1. If _writer_.[[closedPromise]].[[PromiseState]] is `"pending"`, <a>reject</a> _writer_.[[closedPromise]] with
+     _error_.
+  1. Otherwise, set _writer_.[[closedPromise]] to <a>a promise rejected with</a> _error_.
+  1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
 </emu-alg>
 
 <h4 id="writable-stream-default-writer-ensure-ready-promise-rejected"
@@ -3318,7 +3302,7 @@ aoid="WritableStreamDefaultWriterEnsureReadyPromiseRejected"
 nothrow>WritableStreamDefaultWriterEnsureReadyPromiseRejected( <var>writer</var>, <var>error</var> )</h4>
 
 <emu-alg>
-  1. If _writer_.[[readyPromise]].[[PromiseState]] is `"pending"`, <a>reject</a> _writer.[[readyPromise]] with _error_.
+  1. If _writer_.[[readyPromise]].[[PromiseState]] is `"pending"`, <a>reject</a> _writer_.[[readyPromise]] with _error_.
   1. Otherwise, set _writer_.[[readyPromise]] to <a>a promise rejected with</a> _error_.
   1. Set _writer_.[[readyPromise]].[[PromiseIsHandled]] to *true*.
 </emu-alg>
@@ -3329,7 +3313,7 @@ nothrow>WritableStreamDefaultWriterGetDesiredSize ( <var>writer</var> )</h4>
 <emu-alg>
   1. Let _stream_ be _writer_.[[ownerWritableStream]].
   1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"errored"` or _stream_.[[pendingAbortRequest]] is not *undefined*, return *null*.
+  1. If _state_ is `"errored"` or `"erroring"`, return *null*.
   1. If _state_ is `"closed"`, return *0*.
   1. Return ! WritableStreamDefaultControllerGetDesiredSize(_stream_.[[writableStreamController]]).
 </emu-alg>
@@ -3342,12 +3326,8 @@ nothrow>WritableStreamDefaultWriterRelease ( <var>writer</var> )</h4>
   1. Assert: _stream_ is not *undefined*.
   1. Assert: _stream_.[[writer]] is _writer_.
   1. Let _releasedError_ be a new *TypeError*.
-  1. Let _state_ be _stream_.[[state]].
   1. Perform ! WritableStreamDefaultWriterEnsureReadyPromiseRejected(_writer_, _releasedError_).
-  1. If _state_ is `"writable"` or ! WritableStreamHasOperationMarkedInFlight(_stream_) is *true*,
-     <a>reject</a> _writer_.[[closedPromise]] with _releasedError_.
-  1. Otherwise, set _writer_.[[closedPromise]] to <a>a promise rejected with</a> _releasedError_.
-  1. Set _writer_.[[closedPromise]].[[PromiseIsHandled]] to *true*.
+  1. Perform ! WritableStreamDefaultWriterEnsureClosedPromiseRejected(_writer_, _releasedError_).
   1. Set _stream_.[[writer]] to *undefined*.
   1. Set _writer_.[[ownerWritableStream]] to *undefined*.
 </emu-alg>
@@ -3366,9 +3346,8 @@ nothrow>WritableStreamDefaultWriterWrite ( <var>writer</var>, <var>chunk</var> )
   1. If _state_ is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
   1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *true* or _state_ is `"closed"`, return
      <a>a promise rejected with</a> a *TypeError* exception indicating that the stream is closing or closed.
+  1. If _state_ is `"erroring"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
   1. Assert: _state_ is `"writable"`.
-  1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return <a>a promise rejected with</a> a *TypeError*
-     indicating that the stream is in the process of being aborted.
   1. Let _promise_ be ! WritableStreamAddWriteRequest(_stream_).
   1. Perform ! WritableStreamDefaultControllerWrite(_controller_, _chunk_, _chunkSize_).
   1. Return _promise_.
@@ -3480,7 +3459,7 @@ WritableStreamDefaultController(<var>stream</var>, <var>underlyingSink</var>, <v
 <emu-alg>
   1. If ! IsWritableStreamDefaultController(*this*) is *false*, throw a *TypeError* exception.
   1. Let _state_ be *this*.[[controlledWritableStream]].[[state]].
-  1. If _state_ is `"closed"` or `"errored"`, throw a *TypeError* exception.
+  1. If _state_ is not `"writable"`, return.
   1. Perform ! WritableStreamDefaultControllerError(*this*, _e_).
 </emu-alg>
 
@@ -3499,9 +3478,7 @@ used polymorphically.
 <var>reason</var> )</h5>
 
 <emu-alg>
-  1. Let _sinkAbortPromise_ be ! PromiseInvokeOrNoop(*this*.[[underlyingSink]], `"abort"`, « _reason_ »).
-  1. Return the result of <a>transforming</a> _sinkAbortPromise_ with a fulfillment handler that returns
-     *undefined*.
+  1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingSink]], `"abort"`, « _reason_ »).
 </emu-alg>
 
 <h5 id="ws-default-controller-private-error">\[[ErrorSteps]]()</h5>
@@ -3516,15 +3493,14 @@ used polymorphically.
   1. Let _startResult_ be ? InvokeOrNoop(*this*.[[underlyingSink]], `"start"`, « *this* »).
   1. Let _stream_ be *this*.[[controlledWritableStream]].
   1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
-    1. <a>Upon fulfillment</a>  of _startPromise_,
-      1. Set *this*.[[started]] to *true*.
-      1. If _stream_.[[state]] is `"errored"`, perform ! WritableStreamRejectAbortRequestIfPending(_stream_).
-      1. Otherwise, perform ! WritableStreamHandleAbortRequestIfPending(_stream_).
-      1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(*this*).
-    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-      1. Assert: _stream_.[[state]] is `"writable"` or `"errored"`.
-      1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(*this*, _r_).
-      1. Perform ! WritableStreamRejectAbortRequestIfPending(_stream_).
+  1. <a>Upon fulfillment</a>  of _startPromise_,
+    1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+    1. Set *this*.[[started]] to *true*.
+    1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(*this*).
+  1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+    1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+    1. Set *this*.[[started]] to *true*.
+    1. Perform ! WritableStreamDealWithRejection(_stream_, _r_).
 </emu-alg>
 
 <h3 id="ws-default-controller-abstract-ops">Writable Stream Default Controller Abstract Operations</h3>
@@ -3576,7 +3552,7 @@ nothrow>WritableStreamDefaultControllerWrite ( <var>controller</var>, <var>chunk
     1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _enqueueResult_.[[Value]]).
     1. Return.
   1. Let _stream_ be _controller_.[[controlledWritableStream]].
-  1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false*,
+  1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false* and _stream_.[[state]] is `"writable"`,
     1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
     1. Perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
   1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
@@ -3588,10 +3564,13 @@ aoid="WritableStreamDefaultControllerAdvanceQueueIfNeeded" nothrow>WritableStrea
 
 <emu-alg>
   1. Let _stream_ be _controller_.[[controlledWritableStream]].
-  1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"closed"` or `"errored"`, return.
   1. If _controller_.[[started]] is *false*, return.
   1. If _stream_.[[inFlightWriteRequest]] is not *undefined*, return.
+  1. Let _state_ be _stream_.[[state]].
+  1. If _state_ is `"closed"` or `"errored"`, return.
+  1. If _state_ is `"erroring"`,
+    1. Perform ! WritableStreamFinishErroring(_stream_).
+    1. Return.
   1. If _controller_.[[queue]] is empty, return.
   1. Let _writeRecord_ be ! PeekQueueValue(_controller_).
   1. If _writeRecord_ is `"close"`, perform ! WritableStreamDefaultControllerProcessClose(_controller_).
@@ -3614,7 +3593,7 @@ nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h
   1. Perform ! WritableStreamMarkCloseRequestInFlight(_stream_).
   1. Perform ! DequeueValue(_controller_).
   1. Assert: _controller_.[[queue]] is empty.
-  1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`, « _controller_ »).
+  1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`, « »).
   1. <a>Upon fulfillment</a> of _sinkClosePromise_,
     1. Perform ! WritableStreamFinishInFlightClose(_stream_).
   1. <a>Upon rejection</a> of _sinkClosePromise_ with reason _reason_,
@@ -3632,19 +3611,14 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
   1. <a>Upon fulfillment</a> of _sinkWritePromise_,
     1. Perform ! WritableStreamFinishInFlightWrite(_stream_).
     1. Let _state_ be _stream_.[[state]].
-    1. If _state_ is `"errored"`, return.
-    1. Assert: _state_ is `"writable"`.
+    1. Assert: _state_ is `"writable"` or `"erroring"`.
     1. Perform ! DequeueValue(_controller_).
-    1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false*,
+    1. If ! WritableStreamCloseQueuedOrInFlight(_stream_) is *false* and _state_ is `"writable"`,
       1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
       1. Perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
     1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
   1. <a>Upon rejection</a> of _sinkWritePromise_ with _reason_,
-    1. Let _wasErrored_ be *false*.
-    1. If _stream_.[[state]] is `"errored"`, set _wasErrored_ to *true*.
     1. Perform ! WritableStreamFinishInFlightWriteWithError(_stream_, _reason_).
-    1. Assert: _stream_.[[state]] is `"errored"`.
-    1. If _wasErrored_ is *false*, set _controller_.[[queue]] to an empty List.
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-get-backpressure" aoid="WritableStreamDefaultControllerGetBackpressure"
@@ -3661,7 +3635,7 @@ nothrow>WritableStreamDefaultControllerError ( <var>controller</var>, <var>error
 <emu-alg>
   1. Let _stream_ be _controller_.[[controlledWritableStream]].
   1. Assert: _stream_.[[state]] is `"writable"`.
-  1. Perform ! WritableStreamError(_stream_, _error_).
+  1. Perform ! WritableStreamStartErroring(_stream_, _error_).
 </emu-alg>
 
 <h2 id="ts">Transform Streams</h2>

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -12,6 +12,9 @@ const ErrorSteps = Symbol('[[ErrorSteps]]');
 class WritableStream {
   constructor(underlyingSink = {}, { size, highWaterMark = 1 } = {}) {
     this._state = 'writable';
+
+    // The error that will be reported by new method calls once the state becomes errored. Only set when [[state]] is
+    // 'erroring' or 'errored'. May be set to an undefined value.
     this._storedError = undefined;
 
     this._writer = undefined;
@@ -130,60 +133,34 @@ function WritableStreamAbort(stream, reason) {
   if (state === 'errored') {
     return Promise.reject(stream._storedError);
   }
-
-  assert(state === 'writable', 'state must be writable');
-
   const error = new TypeError('Requested to abort');
   if (stream._pendingAbortRequest !== undefined) {
     return Promise.reject(error);
   }
 
-  const controller = stream._writableStreamController;
-  assert(controller !== undefined, 'controller must not be undefined');
+  assert(state === 'writable' || state === 'erroring', 'state must be writable or erroring');
 
-  if (WritableStreamHasOperationMarkedInFlight(stream) === false && controller._started === true) {
-    WritableStreamFinishAbort(stream);
-    return controller[AbortSteps](reason);
-  }
-
-  const writer = stream._writer;
-  if (writer !== undefined) {
-    WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error);
+  let wasAlreadyErroring = false;
+  if (state === 'erroring') {
+    wasAlreadyErroring = true;
+    // reason will not be used, so don't keep a reference to it.
+    reason = undefined;
   }
 
   const promise = new Promise((resolve, reject) => {
     stream._pendingAbortRequest = {
       _resolve: resolve,
       _reject: reject,
-      _reason: reason
+      _reason: reason,
+      _wasAlreadyErroring: wasAlreadyErroring
     };
   });
 
+  if (wasAlreadyErroring === false) {
+    WritableStreamStartErroring(stream, error);
+  }
+
   return promise;
-}
-
-function WritableStreamError(stream, error) {
-  stream._state = 'errored';
-  stream._storedError = error;
-
-  stream._writableStreamController[ErrorSteps]();
-
-  if (stream._pendingAbortRequest === undefined) {
-    const writer = stream._writer;
-    if (writer !== undefined) {
-      WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error);
-    }
-  }
-
-  if (WritableStreamHasOperationMarkedInFlight(stream) === false) {
-    WritableStreamRejectPromisesInReactionToError(stream);
-  }
-}
-
-function WritableStreamFinishAbort(stream) {
-  const error = new TypeError('Aborted');
-
-  WritableStreamError(stream, error);
 }
 
 // WritableStream API exposed for controllers.
@@ -204,26 +181,80 @@ function WritableStreamAddWriteRequest(stream) {
   return promise;
 }
 
+function WritableStreamDealWithRejection(stream, error) {
+  const state = stream._state;
+
+  if (state === 'writable') {
+    WritableStreamStartErroring(stream, error);
+    return;
+  }
+
+  assert(state === 'erroring');
+  WritableStreamFinishErroring(stream);
+}
+
+function WritableStreamStartErroring(stream, reason) {
+  assert(stream._storedError === undefined, 'stream._storedError === undefined');
+  assert(stream._state === 'writable', 'state must be writable');
+
+  const controller = stream._writableStreamController;
+  assert(controller !== undefined, 'controller must not be undefined');
+
+  stream._state = 'erroring';
+  stream._storedError = reason;
+  const writer = stream._writer;
+  if (writer !== undefined) {
+    WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, reason);
+  }
+
+  if (WritableStreamHasOperationMarkedInFlight(stream) === false && controller._started === true) {
+    WritableStreamFinishErroring(stream);
+  }
+}
+
+function WritableStreamFinishErroring(stream) {
+  assert(stream._state === 'erroring', 'stream._state === erroring');
+  assert(WritableStreamHasOperationMarkedInFlight(stream) === false,
+         'WritableStreamHasOperationMarkedInFlight(stream) === false');
+  stream._state = 'errored';
+  stream._writableStreamController[ErrorSteps]();
+
+  const storedError = stream._storedError;
+  for (const writeRequest of stream._writeRequests) {
+    writeRequest._reject(storedError);
+  }
+  stream._writeRequests = [];
+
+  if (stream._pendingAbortRequest === undefined) {
+    WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
+    return;
+  }
+
+  const abortRequest = stream._pendingAbortRequest;
+  stream._pendingAbortRequest = undefined;
+
+  if (abortRequest._wasAlreadyErroring === true) {
+    abortRequest._reject(storedError);
+    WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
+    return;
+  }
+
+  const promise = stream._writableStreamController[AbortSteps](abortRequest._reason);
+  promise.then(
+      () => {
+        abortRequest._resolve();
+        WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
+      },
+      reason => {
+        abortRequest._reject(reason);
+        WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
+      });
+}
+
 function WritableStreamFinishInFlightWrite(stream) {
   assert(stream._inFlightWriteRequest !== undefined);
   stream._inFlightWriteRequest._resolve(undefined);
   stream._inFlightWriteRequest = undefined;
-
-  const state = stream._state;
-
-  if (state === 'errored') {
-    WritableStreamFinishInFlightWriteInErroredState(stream);
-    return;
-  }
-
-  assert(state === 'writable');
-
-  WritableStreamHandleAbortRequestIfPending(stream);
-}
-
-function WritableStreamFinishInFlightWriteInErroredState(stream) {
-  WritableStreamRejectAbortRequestIfPending(stream);
-  WritableStreamRejectPromisesInReactionToError(stream);
 }
 
 function WritableStreamFinishInFlightWriteWithError(stream, error) {
@@ -231,17 +262,9 @@ function WritableStreamFinishInFlightWriteWithError(stream, error) {
   stream._inFlightWriteRequest._reject(error);
   stream._inFlightWriteRequest = undefined;
 
-  const state = stream._state;
+  assert(stream._state === 'writable' || stream._state === 'erroring');
 
-  if (state === 'errored') {
-    WritableStreamFinishInFlightWriteInErroredState(stream);
-    return;
-  }
-
-  assert(state === 'writable');
-
-  WritableStreamError(stream, error);
-  WritableStreamRejectAbortRequestIfPending(stream);
+  WritableStreamDealWithRejection(stream, error);
 }
 
 function WritableStreamFinishInFlightClose(stream) {
@@ -251,12 +274,16 @@ function WritableStreamFinishInFlightClose(stream) {
 
   const state = stream._state;
 
-  if (state === 'errored') {
-    WritableStreamFinishInFlightCloseInErroredState(stream);
-    return;
-  }
+  assert(state === 'writable' || state === 'erroring');
 
-  assert(state === 'writable');
+  if (state === 'erroring') {
+    // The error was too late to do anything, so it is ignored.
+    stream._storedError = undefined;
+    if (stream._pendingAbortRequest !== undefined) {
+      stream._pendingAbortRequest._resolve();
+      stream._pendingAbortRequest = undefined;
+    }
+  }
 
   stream._state = 'closed';
 
@@ -265,15 +292,8 @@ function WritableStreamFinishInFlightClose(stream) {
     defaultWriterClosedPromiseResolve(writer);
   }
 
-  if (stream._pendingAbortRequest !== undefined) {
-    stream._pendingAbortRequest._resolve();
-    stream._pendingAbortRequest = undefined;
-  }
-}
-
-function WritableStreamFinishInFlightCloseInErroredState(stream) {
-  WritableStreamRejectAbortRequestIfPending(stream);
-  WritableStreamRejectClosedPromiseInReactionToError(stream);
+  assert(stream._pendingAbortRequest === undefined, 'stream._pendingAbortRequest === undefined');
+  assert(stream._storedError === undefined, 'stream._storedError === undefined');
 }
 
 function WritableStreamFinishInFlightCloseWithError(stream, error) {
@@ -281,41 +301,23 @@ function WritableStreamFinishInFlightCloseWithError(stream, error) {
   stream._inFlightCloseRequest._reject(error);
   stream._inFlightCloseRequest = undefined;
 
-  const state = stream._state;
+  assert(stream._state === 'writable' || stream._state === 'erroring');
 
-  if (state === 'errored') {
-    WritableStreamFinishInFlightCloseInErroredState(stream);
-    return;
+  // Never execute sink abort() after sink close().
+  if (stream._pendingAbortRequest !== undefined) {
+    stream._pendingAbortRequest._reject(error);
+    stream._pendingAbortRequest = undefined;
   }
-
-  assert(state === 'writable');
-
-  WritableStreamError(stream, error);
-  WritableStreamRejectAbortRequestIfPending(stream);
+  WritableStreamDealWithRejection(stream, error);
 }
 
+// TODO(ricea): Fix alphabetical order.
 function WritableStreamCloseQueuedOrInFlight(stream) {
   if (stream._closeRequest === undefined && stream._inFlightCloseRequest === undefined) {
     return false;
   }
 
   return true;
-}
-
-function WritableStreamHandleAbortRequestIfPending(stream) {
-  if (stream._pendingAbortRequest === undefined) {
-    return;
-  }
-
-  WritableStreamFinishAbort(stream);
-
-  const abortRequest = stream._pendingAbortRequest;
-  stream._pendingAbortRequest = undefined;
-  const promise = stream._writableStreamController[AbortSteps](abortRequest._reason);
-  promise.then(
-    abortRequest._resolve,
-    abortRequest._reject
-  );
 }
 
 function WritableStreamHasOperationMarkedInFlight(stream) {
@@ -339,37 +341,19 @@ function WritableStreamMarkFirstWriteRequestInFlight(stream) {
   stream._inFlightWriteRequest = stream._writeRequests.shift();
 }
 
-function WritableStreamRejectClosedPromiseInReactionToError(stream) {
+function WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
+  assert(stream._state === 'errored', '_stream_.[[state]] is `"errored"`');
+  if (stream._closeRequest !== undefined) {
+    assert(stream._inFlightCloseRequest === undefined);
+
+    stream._closeRequest._reject(stream._storedError);
+    stream._closeRequest = undefined;
+  }
   const writer = stream._writer;
   if (writer !== undefined) {
     defaultWriterClosedPromiseReject(writer, stream._storedError);
     writer._closedPromise.catch(() => {});
   }
-}
-
-function WritableStreamRejectAbortRequestIfPending(stream) {
-  if (stream._pendingAbortRequest !== undefined) {
-    stream._pendingAbortRequest._reject(stream._storedError);
-    stream._pendingAbortRequest = undefined;
-  }
-}
-
-function WritableStreamRejectPromisesInReactionToError(stream) {
-  const storedError = stream._storedError;
-
-  for (const writeRequest of stream._writeRequests) {
-    writeRequest._reject(storedError);
-  }
-  stream._writeRequests = [];
-
-  if (stream._closeRequest !== undefined) {
-    assert(stream._inFlightCloseRequest === undefined);
-
-    stream._closeRequest._reject(storedError);
-    stream._closeRequest = undefined;
-  }
-
-  WritableStreamRejectClosedPromiseInReactionToError(stream);
 }
 
 function WritableStreamUpdateBackpressure(stream, backpressure) {
@@ -405,16 +389,16 @@ class WritableStreamDefaultWriter {
     const state = stream._state;
 
     if (state === 'writable') {
-      if (stream._pendingAbortRequest !== undefined) {
-        const error = new TypeError('Requested to abort');
-        defaultWriterReadyPromiseInitializeAsRejected(this, error);
-        this._readyPromise.catch(() => {});
-      } else if (WritableStreamCloseQueuedOrInFlight(stream) === false && stream._backpressure === true) {
+      if (WritableStreamCloseQueuedOrInFlight(stream) === false && stream._backpressure === true) {
         defaultWriterReadyPromiseInitialize(this);
       } else {
         defaultWriterReadyPromiseInitializeAsResolved(this);
       }
 
+      defaultWriterClosedPromiseInitialize(this);
+    } else if (state === 'erroring') {
+      defaultWriterReadyPromiseInitializeAsRejected(this, stream._storedError);
+      this._readyPromise.catch(() => {});
       defaultWriterClosedPromiseInitialize(this);
     } else if (state === 'closed') {
       defaultWriterReadyPromiseInitializeAsResolved(this);
@@ -551,11 +535,8 @@ function WritableStreamDefaultWriterClose(writer) {
     return Promise.reject(new TypeError(
       `The stream (in ${state} state) is not in the writable state and cannot be closed`));
   }
-  if (stream._pendingAbortRequest !== undefined) {
-    return Promise.reject(new TypeError('Requested to abort'));
-  }
 
-  assert(state === 'writable');
+  assert(state === 'writable' || state === 'erroring');
   assert(WritableStreamCloseQueuedOrInFlight(stream) === false);
 
   const promise = new Promise((resolve, reject) => {
@@ -567,7 +548,7 @@ function WritableStreamDefaultWriterClose(writer) {
     stream._closeRequest = closeRequest;
   });
 
-  if (stream._backpressure === true) {
+  if (stream._backpressure === true && state === 'writable') {
     defaultWriterReadyPromiseResolve(writer);
   }
 
@@ -591,9 +572,18 @@ function WritableStreamDefaultWriterCloseWithErrorPropagation(writer) {
     return Promise.reject(stream._storedError);
   }
 
-  assert(state === 'writable');
+  assert(state === 'writable' || state === 'erroring');
 
   return WritableStreamDefaultWriterClose(writer);
+}
+
+function WritableStreamDefaultWriterEnsureClosedPromiseRejected(writer, error) {
+  if (writer._closedPromiseState === 'pending') {
+    defaultWriterClosedPromiseReject(writer, error);
+  } else {
+    defaultWriterClosedPromiseResetToRejected(writer, error);
+  }
+  writer._closedPromise.catch(() => {});
 }
 
 function WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error) {
@@ -609,7 +599,7 @@ function WritableStreamDefaultWriterGetDesiredSize(writer) {
   const stream = writer._ownerWritableStream;
   const state = stream._state;
 
-  if (state === 'errored' || stream._pendingAbortRequest !== undefined) {
+  if (state === 'errored' || state === 'erroring') {
     return null;
   }
 
@@ -627,16 +617,12 @@ function WritableStreamDefaultWriterRelease(writer) {
 
   const releasedError = new TypeError(
     'Writer was released and can no longer be used to monitor the stream\'s closedness');
-  const state = stream._state;
 
   WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, releasedError);
 
-  if (state === 'writable' || WritableStreamHasOperationMarkedInFlight(stream) === true) {
-    defaultWriterClosedPromiseReject(writer, releasedError);
-  } else {
-    defaultWriterClosedPromiseResetToRejected(writer, releasedError);
-  }
-  writer._closedPromise.catch(() => {});
+  // The state transitions to "errored" before the sink abort() method runs, but the writer.closed promise is not
+  // rejected until afterwards. This means that simply testing state will not work.
+  WritableStreamDefaultWriterEnsureClosedPromiseRejected(writer, releasedError);
 
   stream._writer = undefined;
   writer._ownerWritableStream = undefined;
@@ -662,12 +648,11 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
   if (WritableStreamCloseQueuedOrInFlight(stream) === true || state === 'closed') {
     return Promise.reject(new TypeError('The stream is closing or closed and cannot be written to'));
   }
+  if (state === 'erroring') {
+    return Promise.reject(stream._storedError);
+  }
 
   assert(state === 'writable');
-
-  if (stream._pendingAbortRequest !== undefined) {
-    return Promise.reject(new TypeError('The stream is being aborted and cannot be written to'));
-  }
 
   const promise = WritableStreamAddWriteRequest(stream);
 
@@ -711,18 +696,18 @@ class WritableStreamDefaultController {
       throw new TypeError(
         'WritableStreamDefaultController.prototype.error can only be used on a WritableStreamDefaultController');
     }
-
     const state = this._controlledWritableStream._state;
-    if (state === 'closed' || state === 'errored') {
-      throw new TypeError(`The stream is ${state} and so cannot be errored`);
+    if (state !== 'writable') {
+      // The stream is closed, errored or will be soon. The sink can't do anything useful if it gets an error here, so
+      // just treat it as a no-op.
+      return;
     }
 
     WritableStreamDefaultControllerError(this, e);
   }
 
   [AbortSteps](reason) {
-    const sinkAbortPromise = PromiseInvokeOrNoop(this._underlyingSink, 'abort', [reason]);
-    return sinkAbortPromise.then(() => undefined);
+    return PromiseInvokeOrNoop(this._underlyingSink, 'abort', [reason]);
   }
 
   [ErrorSteps]() {
@@ -735,21 +720,14 @@ class WritableStreamDefaultController {
 
     Promise.resolve(startResult).then(
       () => {
+        assert(stream._state === 'writable' || stream._state === 'erroring');
         this._started = true;
-
-        if (stream._state === 'errored') {
-          WritableStreamRejectAbortRequestIfPending(stream);
-        } else {
-          WritableStreamHandleAbortRequestIfPending(stream);
-        }
-
-        // This is a no-op if the stream was errored above.
         WritableStreamDefaultControllerAdvanceQueueIfNeeded(this);
       },
       r => {
-        assert(stream._state === 'writable' || stream._state === 'errored');
-        WritableStreamDefaultControllerErrorIfNeeded(this, r);
-        WritableStreamRejectAbortRequestIfPending(stream);
+        assert(stream._state === 'writable' || stream._state === 'erroring');
+        this._started = true;
+        WritableStreamDealWithRejection(stream, r);
       }
     )
     .catch(rethrowAssertionErrorRejection);
@@ -793,7 +771,7 @@ function WritableStreamDefaultControllerWrite(controller, chunk, chunkSize) {
   }
 
   const stream = controller._controlledWritableStream;
-  if (WritableStreamCloseQueuedOrInFlight(stream) === false) {
+  if (WritableStreamCloseQueuedOrInFlight(stream) === false && stream._state === 'writable') {
     const backpressure = WritableStreamDefaultControllerGetBackpressure(controller);
     WritableStreamUpdateBackpressure(stream, backpressure);
   }
@@ -817,17 +795,21 @@ function IsWritableStreamDefaultController(x) {
 
 function WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller) {
   const stream = controller._controlledWritableStream;
-  const state = stream._state;
-
-  if (state === 'closed' || state === 'errored') {
-    return;
-  }
 
   if (controller._started === false) {
     return;
   }
 
   if (stream._inFlightWriteRequest !== undefined) {
+    return;
+  }
+
+  const state = stream._state;
+  if (state === 'closed' || state === 'errored') {
+    return;
+  }
+  if (state === 'erroring') {
+    WritableStreamFinishErroring(stream);
     return;
   }
 
@@ -857,7 +839,7 @@ function WritableStreamDefaultControllerProcessClose(controller) {
   DequeueValue(controller);
   assert(controller._queue.length === 0, 'queue must be empty once the final write record is dequeued');
 
-  const sinkClosePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'close', [controller]);
+  const sinkClosePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'close', []);
   sinkClosePromise.then(
     () => {
       WritableStreamFinishInFlightClose(stream);
@@ -880,15 +862,11 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
       WritableStreamFinishInFlightWrite(stream);
 
       const state = stream._state;
-      if (state === 'errored') {
-        return;
-      }
-
-      assert(state === 'writable');
+      assert(state === 'writable' || state === 'erroring');
 
       DequeueValue(controller);
 
-      if (WritableStreamCloseQueuedOrInFlight(stream) === false) {
+      if (WritableStreamCloseQueuedOrInFlight(stream) === false && state === 'writable') {
         const backpressure = WritableStreamDefaultControllerGetBackpressure(controller);
         WritableStreamUpdateBackpressure(stream, backpressure);
       }
@@ -896,17 +874,7 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
       WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
     },
     reason => {
-      let wasErrored = false;
-      if (stream._state === 'errored') {
-        wasErrored = true;
-      }
-
       WritableStreamFinishInFlightWriteWithError(stream, reason);
-
-      assert(stream._state === 'errored');
-      if (wasErrored === false) {
-        controller._queue = [];
-      }
     }
   )
   .catch(rethrowAssertionErrorRejection);
@@ -924,7 +892,7 @@ function WritableStreamDefaultControllerError(controller, error) {
 
   assert(stream._state === 'writable');
 
-  WritableStreamError(stream, error);
+  WritableStreamStartErroring(stream, error);
 }
 
 // Helper functions for the WritableStream.
@@ -948,6 +916,7 @@ function defaultWriterClosedPromiseInitialize(writer) {
   writer._closedPromise = new Promise((resolve, reject) => {
     writer._closedPromise_resolve = resolve;
     writer._closedPromise_reject = reject;
+    writer._closedPromiseState = 'pending';
   });
 }
 
@@ -955,37 +924,45 @@ function defaultWriterClosedPromiseInitializeAsRejected(writer, reason) {
   writer._closedPromise = Promise.reject(reason);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
+  writer._closedPromiseState = 'rejected';
 }
 
 function defaultWriterClosedPromiseInitializeAsResolved(writer) {
   writer._closedPromise = Promise.resolve(undefined);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
+  writer._closedPromiseState = 'resolved';
 }
 
 function defaultWriterClosedPromiseReject(writer, reason) {
-  assert(writer._closedPromise_resolve !== undefined);
-  assert(writer._closedPromise_reject !== undefined);
+  assert(writer._closedPromise_resolve !== undefined, 'writer._closedPromise_resolve !== undefined');
+  assert(writer._closedPromise_reject !== undefined, 'writer._closedPromise_reject !== undefined');
+  assert(writer._closedPromiseState === 'pending', 'writer._closedPromiseState is pending');
 
   writer._closedPromise_reject(reason);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
+  writer._closedPromiseState = 'rejected';
 }
 
 function defaultWriterClosedPromiseResetToRejected(writer, reason) {
-  assert(writer._closedPromise_resolve === undefined);
-  assert(writer._closedPromise_reject === undefined);
+  assert(writer._closedPromise_resolve === undefined, 'writer._closedPromise_resolve === undefined');
+  assert(writer._closedPromise_reject === undefined, 'writer._closedPromise_reject === undefined');
+  assert(writer._closedPromiseState !== 'pending', 'writer._closedPromiseState is not pending');
 
   writer._closedPromise = Promise.reject(reason);
+  writer._closedPromiseState = 'rejected';
 }
 
 function defaultWriterClosedPromiseResolve(writer) {
-  assert(writer._closedPromise_resolve !== undefined);
-  assert(writer._closedPromise_reject !== undefined);
+  assert(writer._closedPromise_resolve !== undefined, 'writer._closedPromise_resolve !== undefined');
+  assert(writer._closedPromise_reject !== undefined, 'writer._closedPromise_reject !== undefined');
+  assert(writer._closedPromiseState === 'pending', 'writer._closedPromiseState is pending');
 
   writer._closedPromise_resolve(undefined);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
+  writer._closedPromiseState = 'resolved';
 }
 
 function defaultWriterReadyPromiseInitialize(writer) {
@@ -1011,8 +988,8 @@ function defaultWriterReadyPromiseInitializeAsResolved(writer) {
 }
 
 function defaultWriterReadyPromiseReject(writer, reason) {
-  assert(writer._readyPromise_resolve !== undefined);
-  assert(writer._readyPromise_reject !== undefined);
+  assert(writer._readyPromise_resolve !== undefined, 'writer._readyPromise_resolve !== undefined');
+  assert(writer._readyPromise_reject !== undefined, 'writer._readyPromise_reject !== undefined');
 
   writer._readyPromise_reject(reason);
   writer._readyPromise_resolve = undefined;
@@ -1021,8 +998,8 @@ function defaultWriterReadyPromiseReject(writer, reason) {
 }
 
 function defaultWriterReadyPromiseReset(writer) {
-  assert(writer._readyPromise_resolve === undefined);
-  assert(writer._readyPromise_reject === undefined);
+  assert(writer._readyPromise_resolve === undefined, 'writer._readyPromise_resolve === undefined');
+  assert(writer._readyPromise_reject === undefined, 'writer._readyPromise_reject === undefined');
 
   writer._readyPromise = new Promise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
@@ -1032,16 +1009,16 @@ function defaultWriterReadyPromiseReset(writer) {
 }
 
 function defaultWriterReadyPromiseResetToRejected(writer, reason) {
-  assert(writer._readyPromise_resolve === undefined);
-  assert(writer._readyPromise_reject === undefined);
+  assert(writer._readyPromise_resolve === undefined, 'writer._readyPromise_resolve === undefined');
+  assert(writer._readyPromise_reject === undefined, 'writer._readyPromise_reject === undefined');
 
   writer._readyPromise = Promise.reject(reason);
   writer._readyPromiseState = 'rejected';
 }
 
 function defaultWriterReadyPromiseResolve(writer) {
-  assert(writer._readyPromise_resolve !== undefined);
-  assert(writer._readyPromise_reject !== undefined);
+  assert(writer._readyPromise_resolve !== undefined, 'writer._readyPromise_resolve !== undefined');
+  assert(writer._readyPromise_reject !== undefined, 'writer._readyPromise_reject !== undefined');
 
   writer._readyPromise_resolve(undefined);
   writer._readyPromise_resolve = undefined;


### PR DESCRIPTION
Previously, controller.error() and errors from strategy size() could transition
the stream state to change to 'errored' while an underlying sink operation 
was in flight.

Only change to 'errored' while no underlying sink operations are in flight,
consistent with abort(). The first error to happen sets the [[storedError]]
internal slot, regardless of type.

Other behavioural changes:
- The writer.closed promise now doesn't reject until the underlying sink
  abort() method has completed.
- writer.close(), writer.abort() and writer.closed promises now consistently
  don't fulfill or reject until no underlying sink methods are executing or will
  be executed. Exceptions:
  - Duplicate calls to close() or abort() still reject immediately.
  - writer.closed still rejects when writer.releaseLock() is called.
- writer.write(), writer.close() and writer.abort() consistently return the
  status of the underlying sink operation, provided it executes.
- It is no longer possible to error the stream once underlying sink close()
  has been called.
- The controller parameter to the underlying sink close() method is no
  longer useful and has been removed.
- Duplicate calls to controller.error() are now a no-op.
- Calls to controller.error() while the stream is erroring, errored or
  closed are no a no-op.

Major implementation changes:
- There is a new "erroring" state. The state synchronously changes
  from "writable" to "erroring" when an error condition is triggered,
  then changes to "errored" once the underlying sink operation
  has finished.
- The stream.[[pendingAbortRequest]] Record has an additional
  boolean field [[wasAlreadyErrored]]. When it is true the underlying
  sink abort() method will not be called.