### PR TITLE
Fix pipeTo() to ensure all read chunks are written

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -649,10 +649,10 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
          complete before proceeding to the next read/write operation violates this recommendation. In doing so, such an
          implementation makes the <a>internal queue</a> of _dest_ useless, as it ensures _dest_ always contains at most
          one queued <a>chunk</a>.</p>
-     * <strong>Shutdown must stop all activity:</strong> if _shuttingDown_ becomes *true*, the user agent must not
-       initiate further reads from _reader_ or writes to _writer_. (Ongoing reads and writes may finish.) In particular,
-       the user agent must check the below conditions on *this*.[[state]] and _dest_.[[state]] before performing any
-       reads or writes, since they might lead to immediate shutdown.
+     * <strong>Shutdown must stop activity:</strong> if _shuttingDown_ becomes *true*, the user agent must not
+       initiate further reads from _reader_, and must only perform writes of already-read <a>chunks</a>, as described
+       below. In particular, the user agent must check the below conditions before performing any reads or writes,
+       since they might lead to immediate shutdown.
      * <strong>Errors must be propagated forward:</strong> if *this*.[[state]] is or becomes `"errored"`, then
        1. If _preventAbort_ is *false*, <a href="#rs-pipeTo-shutdown-with-action">shutdown with an action</a> of !
           WritableStreamAbort(_dest_, *this*.[[storedError]]) and with *this*.[[storedError]].
@@ -667,15 +667,19 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
        1. Otherwise, <a href="#rs-pipeTo-shutdown">shutdown</a>.
      * <strong>Closing must be propagated backward:</strong> if ! WritableStreamCloseQueuedOrInFlight(_dest_) is *true*
        or _dest_.[[state]] is `"closed"`, then
+       1. Assert: no <a>chunks</a> have been read or written.
        1. Let _destClosed_ be a new *TypeError*.
        1. If _preventCancel_ is *false*, <a href="#rs-pipeTo-shutdown-with-action">shutdown with an action</a> of !
           ReadableStreamCancel(*this*, _destClosed_) and with _destClosed_.
        1. Otherwise, <a href="#rs-pipeTo-shutdown">shutdown</a> with _destClosed_.
      * <i id="rs-pipeTo-shutdown-with-action">Shutdown with an action</i>: if any of the above requirements ask to
        shutdown with an action _action_, optionally with an error _originalError_, then:
+       1. If _dest_.[[state]] is `"writable"` and ! WritableStreamCloseQueuedOrInFlight(dest) is *false*,
+         1. If any <a>chunks</a> have been read but not yet written, write them to _dest_.
+         1. Wait until every <a>chunk</a> that has been read has been written (i.e. the corresponding promises have
+            settled).
        1. If _shuttingDown_ is *true*, abort these substeps.
        1. Set _shuttingDown_ to *true*.
-       1. Wait until any ongoing write finishes (i.e. the corresponding promises settle).
        1. Let _p_ be the result of performing _action_.
        1. <a>Upon fulfillment</a> of _p_, <a href="#rs-pipeTo-finalize">finalize</a>, passing along _originalError_ if
           it was given.
@@ -683,9 +687,12 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
           _newError_.
      * <i id="rs-pipeTo-shutdown">Shutdown</i>: if any of the above requirements or steps ask to shutdown, optionally
        with an error _error_, then:
+       1. If _dest_.[[state]] is `"writable"` and ! WritableStreamCloseQueuedOrInFlight(dest) is *false*,
+         1. If any <a>chunks</a> have been read but not yet written, write them to _dest_.
+         1. Wait until every <a>chunk</a> that has been read has been written (i.e. the corresponding promises have
+            settled).
        1. If _shuttingDown_ is *true*, abort these substeps.
        1. Set _shuttingDown_ to *true*.
-       1. Wait until any ongoing write finishes (i.e. the corresponding promises settle).
        1. <a href="#rs-pipeTo-finalize">Finalize</a>, passing along _error_ if it was given.
      * <i id="rs-pipeTo-finalize">Finalize</i>: both forms of shutdown will eventually ask to finalize, optionally with
        an error _error_, which means to perform the following steps:

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -191,8 +191,8 @@ class ReadableStream {
         if (dest._state === 'writable' && WritableStreamCloseQueuedOrInFlight(dest) === false) {
           // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait
           // for that too.
-          const before = currentWrite;
-          return currentWrite.then(() => before !== currentWrite ? waitForWritesToFinish() : undefined);
+          const oldCurrentWrite = currentWrite;
+          return currentWrite.then(() => oldCurrentWrite !== currentWrite ? waitForWritesToFinish() : undefined);
         }
         return Promise.resolve();
       }


### PR DESCRIPTION
Previously, the spec wording allowed for immediate shutdown if the readable stream became closed, even if there were outstanding writes which did not yet get written. This fixes that, by requiring any already-read chunks to be written when possible.

The reference implementation mostly did not suffer from this, but did in the case where a read completes while a write is ongoing. This was fixed by making its "wait for writes to finish" functionality more robust.

Fixes #644.

Tests: https://github.com/w3c/web-platform-tests/pull/5270