### PR TITLE
Allow aborting an ongoing pipe operation using AbortSignals

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -747,8 +747,8 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
   1. If ! IsWritableStream(_dest_) is *false*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. Set _preventClose_ to ! ToBoolean(_preventClose_), set _preventAbort_ to ! ToBoolean(_preventAbort_), and set
      _preventCancel_ to ! ToBoolean(_preventCancel_).
-  1. If _signal_ is not *undefined*, and _signal_ is not an instance of the {{AbortSignal}} interface, return <a>a
-     promise rejected with</a> a *TypeError* exception.
+  1. If _signal_ is not *undefined*, and _signal_ is not an instance of the `<a idl>AbortSignal</a>` interface, return
+     <a>a promise rejected with</a> a *TypeError* exception.
   1. If ! IsReadableStreamLocked(*this*) is *true*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. If ! IsWritableStreamLocked(_dest_) is *true*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. If ! IsReadableByteStreamController(*this*.[[readableStreamController]]) is *true*, let _reader_ be either !
@@ -758,6 +758,20 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
   1. Let _writer_ be ! AcquireWritableStreamDefaultWriter(_dest_).
   1. Let _shuttingDown_ be *false*.
   1. Let _promise_ be <a>a new promise</a>.
+  1. If _signal_ is not *undefined*,
+    1. Let _abortAlgorithm_ be the following steps:
+      1. Let _error_ be a new "`<a idl>AbortError</a>`" `<a idl>DOMException</a>`.
+      1. Let _actions_ be an empty <a>ordered set</a>.
+      1. If _preventAbort_ is *false*, <a for="set">append</a> the following action to _actions_:
+        1. If _dest_.[[_state_]] is `"writable"`, return ! WritableStreamAbort(_dest_, _error_).
+        1. Otherwise, return <a>a promise resolved with</a> *undefined*.
+      1. If _preventCancel_ is *false*, <a for="set">append</a> the following action action to _actions_:
+        1. If *this*.[[_state_]] is `"readable"`, return ! ReadableStreamCancel(*this*, _error_).
+        1. Otherwise, return <a>a promise resolved with</a> *undefined*.
+      1. <a href="#rs-pipeTo-shutdown-with-action">Shutdown with an action</a> consisting of <a>waiting for all</a>
+         of the actions in _actions_, and with _error_.
+    1. If _signal_'s <a for=AbortSignal>aborted flag</a> is set, perform _abortAlgorithm_ and return _promise_.
+    1. <a for="AbortSignal">Add</a> _abortAlgorithm_ to _signal_.
   1. <a>In parallel</a> <span class="XXX">but not really; see <a
      href="https://github.com/whatwg/streams/issues/905">#905</a></span>, using _reader_ and _writer_, read all
      <a>chunks</a> from *this* and write them to _dest_. Due to the locking provided by the reader and writer, the exact
@@ -800,16 +814,6 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
          1. If _preventCancel_ is *false*, <a href="#rs-pipeTo-shutdown-with-action">shutdown with an action</a> of !
             ReadableStreamCancel(*this*, _destClosed_) and with _destClosed_.
          1. Otherwise, <a href="#rs-pipeTo-shutdown">shutdown</a> with _destClosed_.
-     * <strong>Abort signals must stop activity:</strong> if _signal_ is not *undefined*, the following algorithm
-       _abortAlgorithm_ must be <a for="AbortSignal">added</a> to _signal_:
-         1. Let _error_ be a new "`<a idl>AbortError</a>`" `<a idl>DOMException</a>`.
-         1. Let _actions_ be an empty <a>ordered set</a>.
-         1. If _preventAbort_ is *false*, <a for="set">append</a> the action of performing !
-            WritableStreamAbort(_dest_, _error_) to _actions_.
-         1. If _preventCancel_ is *false*, <a for="set">append</a> the action of performing !
-            ReadableStreamCancel(*this*, _error_) to _actions_.
-         1. <a href="#rs-pipeTo-shutdown-with-action">Shutdown with an action</a> consisting of <a>waiting for all</a>
-            of the actions in _actions_, and with _error_.
      * <i id="rs-pipeTo-shutdown-with-action">Shutdown with an action</i>: if any of the above requirements ask to
        shutdown with an action _action_, optionally with an error _originalError_, then:
        1. If _shuttingDown_ is *true*, abort these substeps.

--- a/index.bs
+++ b/index.bs
@@ -401,7 +401,7 @@ like
     <a href="#rs-cancel">cancel</a>(reason)
     <a href="#rs-get-reader">getReader</a>()
     <a href="#rs-pipe-through">pipeThrough</a>({ writable, readable }, options)
-    <a href="#rs-pipe-to">pipeTo</a>(dest, { preventClose, preventAbort, preventCancel } = {})
+    <a href="#rs-pipe-to">pipeTo</a>(dest, { preventClose, preventAbort, preventCancel, signal } = {})
     <a href="#rs-tee">tee</a>()
   }
 </code></pre>
@@ -701,8 +701,9 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
   </code></pre>
 </div>
 
-<h5 id="rs-pipe-to" method for="ReadableStream" lt="pipeTo(dest, options)">pipeTo(<var ignore>dest</var>, {
-<var ignore>preventClose</var>, <var ignore>preventAbort</var>, <var ignore>preventCancel</var> } = {})</h5>
+<h5 id="rs-pipe-to" method for="ReadableStream" lt="pipeTo(dest, options)">pipeTo(<var ignore>dest</var>,
+{ <var ignore>preventClose</var>, <var ignore>preventAbort</var>, <var ignore>preventCancel</var>,
+<var ignore>signal</var> } = {})</h5>
 
 <div class="note">
   The <code>pipeTo</code> method <a lt="piping">pipes</a> this <a>readable stream</a> to a given <a>writable
@@ -733,6 +734,12 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
     promise will be rejected with an error indicating piping to a closed stream failed, or with any error that occurs
     during canceling the source.</p></li>
   </ul>
+
+  The <code>signal</code> option can be set to an {{AbortSignal}} to allow aborting an ongoing pipe operation via the
+  corresponding {{AbortController}}. In this case, the source <a>readable stream</a> will be <a lt="cancel a readable
+  stream">canceled</a>, and the destination <a>writable stream</a> <a lt="abort a writable stream">aborted</a>, unless
+  the respective options <code>preventCancel</code> or <code>preventAbort</code> are set.
+
 </div>
 
 <emu-alg>
@@ -740,6 +747,8 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
   1. If ! IsWritableStream(_dest_) is *false*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. Set _preventClose_ to ! ToBoolean(_preventClose_), set _preventAbort_ to ! ToBoolean(_preventAbort_), and set
      _preventCancel_ to ! ToBoolean(_preventCancel_).
+  1. If _signal_ is not *undefined*, and _signal_ is not an instance of the {{AbortSignal}} interface, return <a>a
+     promise rejected with</a> a *TypeError* exception.
   1. If ! IsReadableStreamLocked(*this*) is *true*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. If ! IsWritableStreamLocked(_dest_) is *true*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. If ! IsReadableByteStreamController(*this*.[[readableStreamController]]) is *true*, let _reader_ be either !
@@ -791,6 +800,16 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
          1. If _preventCancel_ is *false*, <a href="#rs-pipeTo-shutdown-with-action">shutdown with an action</a> of !
             ReadableStreamCancel(*this*, _destClosed_) and with _destClosed_.
          1. Otherwise, <a href="#rs-pipeTo-shutdown">shutdown</a> with _destClosed_.
+     * <strong>Abort signals must stop activity:</strong> if _signal_ is not *undefined*, the following algorithm
+       _abortAlgorithm_ must be <a for="AbortSignal">added</a> to _signal_:
+         1. Let _error_ be a new "`<a idl>AbortError</a>`" `<a idl>DOMException</a>`.
+         1. Let _actions_ be an empty <a>ordered set</a>.
+         1. If _preventAbort_ is *false*, <a for="set">append</a> the action of performing !
+            WritableStreamAbort(_dest_, _error_) to _actions_.
+         1. If _preventCancel_ is *false*, <a for="set">append</a> the action of performing !
+            ReadableStreamCancel(*this*, _error_) to _actions_.
+         1. <a href="#rs-pipeTo-shutdown-with-action">Shutdown with an action</a> consisting of <a>waiting for all</a>
+            of the actions in _actions_, and with _error_.
      * <i id="rs-pipeTo-shutdown-with-action">Shutdown with an action</i>: if any of the above requirements ask to
        shutdown with an action _action_, optionally with an error _originalError_, then:
        1. If _shuttingDown_ is *true*, abort these substeps.
@@ -817,6 +836,7 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
        an error _error_, which means to perform the following steps:
        1. Perform ! WritableStreamDefaultWriterRelease(_writer_).
        1. Perform ! ReadableStreamReaderGenericRelease(_reader_).
+       1. If _signal_ is not *undefined*, <a for="AbortSignal">remove</a> _abortAlgorithm_ from _signal_.
        1. If _error_ was given, <a>reject</a> _promise_ with _error_.
        1. Otherwise, <a>resolve</a> _promise_ with *undefined*.
   1. Return _promise_.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -135,7 +135,7 @@ class ReadableStream {
     return new Promise((resolve, reject) => {
       if (signal !== undefined) {
         const abortAlgorithm = () => {
-          const error = newAbortError();
+          const error = new DOMException('Aborted', 'AbortError');
           const actions = [];
           if (preventAbort === false) {
             actions.push(() => {
@@ -2003,10 +2003,6 @@ function isAbortSignal(value) {
   } catch (e) {
     return false;
   }
-}
-
-function newAbortError() {
-  return new DOMException('AbortError');
 }
 
 function streamBrandCheckException(name) {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,6 +1,5 @@
 'use strict';
-
-/* global AbortSignal:false, DOMException:false */
+/* global AbortSignal:false */
 
 const assert = require('better-assert');
 const { ArrayBufferCopy, CreateAlgorithmFromUnderlyingMethod, IsFiniteNonNegativeNumber, InvokeOrNoop,
@@ -1996,11 +1995,6 @@ function isAbortSignal(value) {
     return false;
   }
 
-  if (typeof AbortSignal === 'undefined') {
-    // Assume we're running under wpt-runner, and use a fake brand check.
-    return value[Symbol.toStringTag] === 'AbortSignal';
-  }
-
   // Use the brand check to distinguish a real AbortSignal from a fake one.
   const aborted = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted').get;
   try {
@@ -2012,17 +2006,6 @@ function isAbortSignal(value) {
 }
 
 function newAbortError() {
-  if (typeof DOMException === 'undefined') {
-    // Assume we're running under wpt-runner, and use a fake DOMException.
-    return {
-      code: 20,
-      name: 'AbortError',
-      constructor: {
-        name: 'DOMException'
-      }
-    };
-  }
-
   return new DOMException('AbortError');
 }
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -2016,7 +2016,10 @@ function newAbortError() {
     // Assume we're running under wpt-runner, and use a fake DOMException.
     return {
       code: 20,
-      name: 'AbortError'
+      name: 'AbortError',
+      constructor: {
+        name: 'DOMException'
+      }
     };
   }
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -133,8 +133,9 @@ class ReadableStream {
     let currentWrite = Promise.resolve();
 
     return new Promise((resolve, reject) => {
+      let abortAlgorithm;
       if (signal !== undefined) {
-        const abortAlgorithm = () => {
+        abortAlgorithm = () => {
           const error = new DOMException('Aborted', 'AbortError');
           const actions = [];
           if (preventAbort === false) {
@@ -288,6 +289,9 @@ class ReadableStream {
         WritableStreamDefaultWriterRelease(writer);
         ReadableStreamReaderGenericRelease(reader);
 
+        if (signal !== undefined) {
+          signal.removeEventListener('abort', abortAlgorithm);
+        }
         if (isError) {
           reject(error);
         } else {

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -18,7 +18,7 @@
     "minimatch": "^3.0.4",
     "nyc": "^13.0.1",
     "opener": "^1.5.1",
-    "wpt-runner": "^2.2.0"
+    "wpt-runner": "^2.6.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
Closes #446.

---

Blocked on https://github.com/whatwg/dom/pull/437 finishing up, but it was important to write this up as a proof of concept; it shows that the AbortSignal design is good for our needs.

There's a bit of a namespace collision in how streams has chosen writer.abort() to mean one thing which is a bit different from signal.abort() on a pipe. Maybe we should put a bit more about that in the developer-facing domintro boxes. But I don't think it's avoidable.

/cc @annevk


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/744.html" title="Last updated on Nov 7, 2018, 9:23 PM GMT (8e0aaed)">Preview</a> | <a href="https://whatpr.org/streams/744/3197c7e...8e0aaed.html" title="Last updated on Nov 7, 2018, 9:23 PM GMT (8e0aaed)">Diff</a>