### PR TITLE
A couple fixes for ArrayBuffer transferring

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2463,11 +2463,11 @@ nothrow>ReadableByteStreamControllerPullInto ( <var>controller</var>, <var>view<
        _view_.[[TypedArrayName]].
     1. Set _ctor_ to the constructor specified in <a>the typed array constructors table</a> for
        _view_.[[TypedArrayName]].
-  1. Let _pullIntoDescriptor_ be Record {[[buffer]]: _view_.[[ViewedArrayBuffer]], [[byteOffset]]:
+  1. Let _buffer_ be ! TransferArrayBuffer(_view_.[[ViewedArrayBuffer]]).
+  1. Let _pullIntoDescriptor_ be Record {[[buffer]]: _buffer_, [[byteOffset]]:
      _view_.[[ByteOffset]], [[byteLength]]: _view_.[[ByteLength]], [[bytesFilled]]: *0*, [[elementSize]]: _elementSize_,
      [[ctor]]: _ctor_, [[readerType]]: `"byob"`}.
   1. If _controller_.[[pendingPullIntos]] is not empty,
-    1. Set _pullIntoDescriptor_.[[buffer]] to ! TransferArrayBuffer(_pullIntoDescriptor_.[[buffer]]).
     1. Append _pullIntoDescriptor_ as the last element of _controller_.[[pendingPullIntos]].
     1. Return ! ReadableStreamAddReadIntoRequest(_stream_).
   1. If _stream_.[[state]] is `"closed"`,
@@ -2482,7 +2482,6 @@ nothrow>ReadableByteStreamControllerPullInto ( <var>controller</var>, <var>view<
       1. Let _e_ be a *TypeError* exception.
       1. Perform ! ReadableByteStreamControllerError(_controller_, _e_).
       1. Return <a>a promise rejected with</a> _e_.
-  1. Set _pullIntoDescriptor_.[[buffer]] to ! TransferArrayBuffer(_pullIntoDescriptor_.[[buffer]]).
   1. Append _pullIntoDescriptor_ as the last element of _controller_.[[pendingPullIntos]].
   1. Let _promise_ be ! ReadableStreamAddReadIntoRequest(_stream_).
   1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).

--- a/index.bs
+++ b/index.bs
@@ -1382,7 +1382,10 @@ ReadableStreamBYOBReader(<var>stream</var>)</h4>
   1. If ! IsReadableStreamBYOBReader(*this*) is *false*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. If *this*.[[ownerReadableStream]] is *undefined*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. If Type(_view_) is not Object, return <a>a promise rejected with</a> a *TypeError* exception.
-  1. If _view_ does not have a [[ViewedArrayBuffer]] internal slot, return <a>a promise rejected with</a> a *TypeError* exception.
+  1. If _view_ does not have a [[ViewedArrayBuffer]] internal slot, return <a>a promise rejected with</a> a *TypeError*
+     exception.
+  1. If ! IsDetachedBuffer(_view_.[[ViewedArrayBuffer]]) is *true*, return <a>a promise rejected with</a> a *TypeError*
+     exception.
   1. If _view_.[[ByteLength]] is *0*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. Return ! ReadableStreamBYOBReaderRead(*this*, _view_).
 </emu-alg>
@@ -2049,6 +2052,7 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
   1. If *this*.[[controlledReadableStream]].[[state]] is not `"readable"`, throw a *TypeError* exception.
   1. If Type(_chunk_) is not Object, throw a *TypeError* exception.
   1. If _chunk_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+  1. If ! IsDetachedBuffer(_chunk_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
   1. Return ! ReadableByteStreamControllerEnqueue(*this*, _chunk_).
 </emu-alg>
 
@@ -2182,6 +2186,7 @@ ReadableStreamBYOBRequest(<var>controller</var>, <var>view</var>)</h4>
 <emu-alg>
   1. If ! IsReadableStreamBYOBRequest(*this*) is *false*, throw a *TypeError* exception.
   1. If *this*.[[associatedReadableByteStreamController]] is *undefined*, throw a *TypeError* exception.
+  1. If ! IsDetachedBuffer(*this*.[[view]].[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
   1. Return ? ReadableByteStreamControllerRespond(*this*.[[associatedReadableByteStreamController]], _bytesWritten_).
 </emu-alg>
 
@@ -2193,6 +2198,7 @@ for="ReadableStreamBYOBRequest">respondWithNewView(<var>view</var>)</h5>
   1. If *this*.[[associatedReadableByteStreamController]] is *undefined*, throw a *TypeError* exception.
   1. If Type(_view_) is not Object, throw a *TypeError* exception.
   1. If _view_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
+  1. If ! IsDetachedBuffer(_view_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
   1. Return ? ReadableByteStreamControllerRespondWithNewView(*this*.[[associatedReadableByteStreamController]], _view_).
 </emu-alg>
 

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -101,7 +101,19 @@ exports.PromiseInvokeOrPerformFallback = (O, P, args, F, argsF) => {
 };
 
 // Not implemented correctly
-exports.TransferArrayBuffer = O => O.slice();
+exports.TransferArrayBuffer = O => {
+  const transferredIshVersion = O.slice();
+
+  // This is specifically to fool tests that test "is transferred" by taking a non-zero-length
+  // ArrayBuffer and checking if its byteLength starts returning 0.
+  Object.defineProperty(O, 'byteLength', {
+    get() {
+      return 0;
+    }
+  });
+
+  return transferredIshVersion;
+};
 
 exports.ValidateAndNormalizeHighWaterMark = highWaterMark => {
   highWaterMark = Number(highWaterMark);

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -1,6 +1,8 @@
 'use strict';
 const assert = require('assert');
 
+const isFakeDetached = Symbol('is "detached" for our purposes');
+
 function IsPropertyKey(argument) {
   return typeof argument === 'string' || typeof argument === 'symbol';
 }
@@ -102,6 +104,7 @@ exports.PromiseInvokeOrPerformFallback = (O, P, args, F, argsF) => {
 
 // Not implemented correctly
 exports.TransferArrayBuffer = O => {
+  assert(!exports.IsDetachedBuffer(O), 'Cannot transfer a previously detached ArrayBuffer');
   const transferredIshVersion = O.slice();
 
   // This is specifically to fool tests that test "is transferred" by taking a non-zero-length
@@ -111,8 +114,14 @@ exports.TransferArrayBuffer = O => {
       return 0;
     }
   });
+  O[isFakeDetached] = true;
 
   return transferredIshVersion;
+};
+
+// Not implemented correctly
+exports.IsDetachedBuffer = O => {
+  return isFakeDetached in O;
 };
 
 exports.ValidateAndNormalizeHighWaterMark = highWaterMark => {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1600,8 +1600,9 @@ function ReadableByteStreamControllerPullInto(controller, view) {
 
   const ctor = view.constructor;
 
+  const buffer = TransferArrayBuffer(view.buffer);
   const pullIntoDescriptor = {
-    buffer: view.buffer,
+    buffer,
     byteOffset: view.byteOffset,
     byteLength: view.byteLength,
     bytesFilled: 0,
@@ -1611,7 +1612,6 @@ function ReadableByteStreamControllerPullInto(controller, view) {
   };
 
   if (controller._pendingPullIntos.length > 0) {
-    pullIntoDescriptor.buffer = TransferArrayBuffer(pullIntoDescriptor.buffer);
     controller._pendingPullIntos.push(pullIntoDescriptor);
 
     // No ReadableByteStreamControllerCallPullIfNeeded() call since:
@@ -1643,7 +1643,6 @@ function ReadableByteStreamControllerPullInto(controller, view) {
     }
   }
 
-  pullIntoDescriptor.buffer = TransferArrayBuffer(pullIntoDescriptor.buffer);
   controller._pendingPullIntos.push(pullIntoDescriptor);
 
   const promise = ReadableStreamAddReadIntoRequest(stream);


### PR DESCRIPTION
This implements what I proposed in #752: it moves the transfer to the beginning of `ReadableByteStreamControllerPullInto` and removes the other transfers.

All tests continue passing. 