### PR TITLE
Throw if undefined streams are passed to pipeThrough

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -570,9 +570,10 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 <emu-alg>
   1. If _writable_ is *undefined* or _readable_ is *undefined*, throw a *TypeError* exception indicating that undefined
      values are not permitted.
-     <div class="note"><emu-val>undefined</emu-val> is special-cased here to make it easier to debug errors such as
-     <code>rs.pipeThrough(writable, readable)</code> which otherwise would silently do nothing. pipeThrough() is
-     otherwise agnostic about the values that it passes through.</div>
+     <p class="note"><emu-val>undefined</emu-val> is special-cased here to make it easier to debug errors such as
+     <code>rs.pipeThrough(writable, readable)</code> which otherwise would silently do nothing. <code><a
+     lt="pipeThrough()" for="ReadableStream">pipeThrough()</a></code> is
+     otherwise agnostic about the values that it passes through.</p>
   1. Let _promise_ be ? Invoke(*this*, `"pipeTo"`, « _writable_, _options_ »).
   1. If Type(_promise_) is Object and _promise_ has a [[PromiseIsHandled]] internal slot, set
      _promise_.[[PromiseIsHandled]] to *true*.

--- a/index.bs
+++ b/index.bs
@@ -570,6 +570,9 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 <emu-alg>
   1. If _writable_ is *undefined* or _readable_ is *undefined*, throw a *TypeError* exception indicating that undefined
      values are not permitted.
+     <div class="note"><emu-val>undefined</emu-val> is special-cased here to make it easier to debug errors such as
+     <code>rs.pipeThrough(writable, readable)</code> which otherwise would silently do nothing. pipeThrough() is
+     otherwise agnostic about the values that it passes through.</div>
   1. Let _promise_ be ? Invoke(*this*, `"pipeTo"`, « _writable_, _options_ »).
   1. If Type(_promise_) is Object and _promise_ has a [[PromiseIsHandled]] internal slot, set
      _promise_.[[PromiseIsHandled]] to *true*.

--- a/index.bs
+++ b/index.bs
@@ -568,6 +568,8 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 </div>
 
 <emu-alg>
+  1. If _writable_ is *undefined* or _readable_ is *undefined*, throw a *TypeError* exception indicating that undefined
+     values are not permitted.
   1. Let _promise_ be ? Invoke(*this*, `"pipeTo"`, « _writable_, _options_ »).
   1. If Type(_promise_) is Object and _promise_ has a [[PromiseIsHandled]] internal slot, set
      _promise_.[[PromiseIsHandled]] to *true*.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -83,6 +83,10 @@ class ReadableStream {
   }
 
   pipeThrough({ writable, readable }, options) {
+    if (writable === undefined || readable === undefined) {
+      throw new TypeError('readable and writable arguments must be defined');
+    }
+
     const promise = this.pipeTo(writable, options);
 
     ifIsObjectAndHasAPromiseIsHandledInternalSlotSetPromiseIsHandledToTrue(promise);


### PR DESCRIPTION
pipeThrough() is intentionally flexible about what arguments it will
accept, but this can make it hard to diagnose when it's called
incorrectly. To catch common mistakes, throw an exception if the
readable or writable arguments are undefined.

Closes #756.