### PR TITLE
Use promise_test in ported transform-stream.js tests

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/errors.https.html
+++ b/reference-implementation/to-upstream-wpts/transform-streams/errors.https.html
@@ -5,6 +5,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-
+<script src="../resources/test-utils.js"></script>
 
 <script src="errors.js"></script>


### PR DESCRIPTION
Replace uses of async_test in tests that were ported to the web-platform-tests
framework with promise_test. Use flushAsyncEvents() rather than timeouts.
Change descriptions to "should" style.