### PR TITLE
TransformStream: Make strategy arguments positional

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -9,7 +9,7 @@ const { WritableStream, WritableStreamDefaultControllerError } = require('./writ
 // Class TransformStream
 
 class TransformStream {
-  constructor(transformer = {}, { readableStrategy, writableStrategy } = {}) {
+  constructor(transformer = {}, writableStrategy = undefined, readableStrategy = undefined) {
     this._transformer = transformer;
 
     this._transforming = false;

--- a/reference-implementation/to-upstream-wpts/transform-streams/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/errors.js
@@ -150,9 +150,7 @@ test(() => {
       c.enqueue('a');
     },
     transform() {}
-  }, {
-    readableStrategy: strategy
-  }), 'throws same error strategy.size throws');
+  }, undefined, strategy), 'throws same error strategy.size throws');
 }, 'TransformStream throw in readableStrategy.size');
 
 test(() => {
@@ -172,9 +170,7 @@ test(() => {
       c.enqueue('a');
     },
     transform() {}
-  }, {
-    readableStrategy: strategy
-  }), 'first error gets thrown');
+  }, undefined, strategy), 'first error gets thrown');
 }, 'TransformStream throw in tricky readableStrategy.size');
 
 done();


### PR DESCRIPTION
Change the calling convention for the TransformStream constructor from
`(transformer, {readableStrategy, writableStrategy})` to `(transformer,
writableStrategy, readableStrategy)`. This makes the calling convention
closer to the other Streams API constructors, and emphasises the
writableStrategy parameter.