### PR TITLE
Add ReadableStreamDefaultControllerHasBackpressure operation and use it in TransformStream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1618,7 +1618,6 @@ readable stream implementation will polymorphically call to either these or thei
   1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingSource]], `"cancel"`, « _reason_ »)
 </emu-alg>
 
-
 <h5 id="rs-default-controller-private-pull">\[[PullSteps]]()</h5>
 
 <emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -1618,16 +1618,6 @@ readable stream implementation will polymorphically call to either these or thei
   1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingSource]], `"cancel"`, « _reason_ »)
 </emu-alg>
 
-<h5 id="rs-default-controller-private-has-backpressure">\[[HasBackpressure]]()</h5>
-
-<div class="note">
-  This method is used in the implementation of TransformStream.
-</div>
-
-<emu-alg>
-  1. If ! ReadableStreamDefaultControllerShouldCallPull(*this*) is *true*, return *false*.
-  1. Otherwise, return *true*.
-</emu-alg>
 
 <h5 id="rs-default-controller-private-pull">\[[PullSteps]]()</h5>
 
@@ -1779,6 +1769,18 @@ Specifications should <em>not</em> use this on streams they did not create.
   1. If _state_ is `"errored"`, return *null*.
   1. If _state_ is `"closed"`, return *0*.
   1. Return _controller_.[[strategyHWM]] − _controller_.[[queueTotalSize]].
+</emu-alg>
+
+<h4 id="rs-default-controller-has-backpressure" aoid="ReadableStreamDefaultControllerHasBackpressure"
+nothrow>ReadableStreamDefaultControllerHasBackpressure ( <var>controller</var> )</h4>
+
+<div class="note">
+  This method is used in the implementation of TransformStream.
+</div>
+
+<emu-alg>
+  1. If ! ReadableStreamDefaultControllerShouldCallPull(_controller_) is *true*, return *false*.
+  1. Otherwise, return *true*.
 </emu-alg>
 
 <h3 id="rbs-controller-class" interface lt="ReadableByteStreamController">Class
@@ -2008,17 +2010,6 @@ readable stream implementation will polymorphically call to either these or thei
     1. Set _firstDescriptor_.[[bytesFilled]] to *0*.
   1. Perform ! ResetQueue(*this*).
   1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingByteSource]], `"cancel"`, « _reason_ »)
-</emu-alg>
-
-<h5 id="rbs-controller-private-has-backpressure">\[[HasBackpressure]]()</h5>
-
-<div class="note">
-  This method is used in the implementation of TransformStream.
-</div>
-
-<emu-alg>
-  1. If ! ReadableByteStreamControllerShouldCallPull(*this*) is *true*, return *false*.
-  1. Otherwise, return *true*.
 </emu-alg>
 
 <h5 id="rbs-controller-private-pull">\[[PullSteps]]()</h5>

--- a/index.bs
+++ b/index.bs
@@ -1618,6 +1618,17 @@ readable stream implementation will polymorphically call to either these or thei
   1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingSource]], `"cancel"`, « _reason_ »)
 </emu-alg>
 
+<h5 id="rs-default-controller-private-has-backpressure">\[[HasBackpressure]]()</h5>
+
+<div class="note">
+  This method is used in the implementation of TransformStream.
+</div>
+
+<emu-alg>
+  1. If ! ReadableStreamDefaultControllerShouldCallPull(*this*) is *true*, return *false*.
+  1. Otherwise, return *true*.
+</emu-alg>
+
 <h5 id="rs-default-controller-private-pull">\[[PullSteps]]()</h5>
 
 <emu-alg>
@@ -1997,6 +2008,17 @@ readable stream implementation will polymorphically call to either these or thei
     1. Set _firstDescriptor_.[[bytesFilled]] to *0*.
   1. Perform ! ResetQueue(*this*).
   1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingByteSource]], `"cancel"`, « _reason_ »)
+</emu-alg>
+
+<h5 id="rbs-controller-private-has-backpressure">\[[HasBackpressure]]()</h5>
+
+<div class="note">
+  This method is used in the implementation of TransformStream.
+</div>
+
+<emu-alg>
+  1. If ! ReadableByteStreamControllerShouldCallPull(*this*) is *true*, return *false*.
+  1. Otherwise, return *true*.
 </emu-alg>
 
 <h5 id="rbs-controller-private-pull">\[[PullSteps]]()</h5>

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -13,6 +13,7 @@ const { AcquireWritableStreamDefaultWriter, IsWritableStream, IsWritableStreamLo
 
 const CancelSteps = Symbol('[[CancelSteps]]');
 const PullSteps = Symbol('[[PullSteps]]');
+const HasBackpressure = Symbol('[[HasBackpressure]]');
 
 class ReadableStream {
   constructor(underlyingSource = {}, { size, highWaterMark } = {}) {
@@ -274,7 +275,8 @@ module.exports = {
   ReadableStreamDefaultControllerClose,
   ReadableStreamDefaultControllerEnqueue,
   ReadableStreamDefaultControllerError,
-  ReadableStreamDefaultControllerGetDesiredSize
+  ReadableStreamDefaultControllerGetDesiredSize,
+  HasBackpressure
 };
 
 // Abstract operations for the ReadableStream.
@@ -965,6 +967,10 @@ class ReadableStreamDefaultController {
     return PromiseInvokeOrNoop(this._underlyingSource, 'cancel', [reason]);
   }
 
+  [HasBackpressure]() {
+    return ReadableStreamDefaultControllerShouldCallPull(this) === false;
+  }
+
   [PullSteps]() {
     const stream = this._controlledReadableStream;
 
@@ -1327,6 +1333,10 @@ class ReadableByteStreamController {
     ResetQueue(this);
 
     return PromiseInvokeOrNoop(this._underlyingByteSource, 'cancel', [reason]);
+  }
+
+  [HasBackpressure]() {
+    return ReadableByteStreamControllerShouldCallPull(this) === false;
   }
 
   [PullSteps]() {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,9 +1,10 @@
 'use strict';
 const assert = require('assert');
 const { InvokeOrNoop, PromiseInvokeOrPerformFallback, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
-const { HasBackpressure, ReadableStream, ReadableStreamDefaultControllerClose,
+const { ReadableStream, ReadableStreamDefaultControllerClose,
         ReadableStreamDefaultControllerEnqueue, ReadableStreamDefaultControllerError,
-        ReadableStreamDefaultControllerGetDesiredSize } = require('./readable-stream.js');
+        ReadableStreamDefaultControllerGetDesiredSize,
+        ReadableStreamDefaultControllerHasBackpressure } = require('./readable-stream.js');
 const { WritableStream, WritableStreamDefaultControllerError } = require('./writable-stream.js');
 
 // Class TransformStream
@@ -45,7 +46,7 @@ class TransformStream {
     assert(this._writableController !== undefined);
     assert(this._readableController !== undefined);
 
-    TransformStreamSetBackpressure(this, this._readableController[HasBackpressure]());
+    TransformStreamSetBackpressure(this, ReadableStreamDefaultControllerHasBackpressure(this._readableController));
 
     const transformStream = this;
     const startResult = InvokeOrNoop(transformer, 'start',
@@ -151,9 +152,9 @@ function TransformStreamEnqueueToReadable(transformStream, chunk) {
     throw transformStream._storedError;
   }
 
-  const backpressure = controller[HasBackpressure]();
+  const backpressure = ReadableStreamDefaultControllerHasBackpressure(controller);
   if (backpressure !== transformStream._backpressure) {
-    TransformStreamSetBackpressure(transformStream, controller[HasBackpressure]());
+    TransformStreamSetBackpressure(transformStream, backpressure);
   }
 }
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -46,7 +46,7 @@ class TransformStream {
     assert(this._writableController !== undefined);
     assert(this._readableController !== undefined);
 
-    TransformStreamSetBackpressure(this, ReadableStreamDefaultControllerHasBackpressure(this._readableController));
+    TransformStreamSetBackpressure(this, true);
 
     const transformStream = this;
     const startResult = InvokeOrNoop(transformer, 'start',
@@ -391,20 +391,7 @@ class TransformStreamDefaultSource {
 
     transformStream._readableController = c;
 
-    return this._startPromise.then(() => {
-      // Prevent the first pull() call until there is backpressure.
-
-      assert(transformStream._backpressureChangePromise !== undefined,
-             '_backpressureChangePromise should have been initialized');
-
-      if (transformStream._backpressure === true) {
-        return Promise.resolve();
-      }
-
-      assert(transformStream._backpressure === false, '_backpressure should have been initialized');
-
-      return transformStream._backpressureChangePromise;
-    });
+    return this._startPromise;
   }
 
   pull() {


### PR DESCRIPTION
The TransformStream implementation currently looks at desiredSize to get
an approximation of whether there is backpressure on the readable side
or not. This is fragile and not really clean enough for standardisation.

Add an abstract operation ReadableStreamDefaultControllerHasBackpressure
which reflect the ReadableStream's own notion of whether there is
backpressure. Use it in TransformStream to accurately detect when an
enqueue() operation has filled the queue.

Since ReadableStream always considers itself to have backpressure until
the underlying source start() method completes, use the same convention
in TransformStream. This simplifies some logic.