### PR TITLE
TransformStream: change readable cancel() to reflect the reason to the writable

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -433,10 +433,10 @@ class TransformStreamDefaultSource {
     return transformStream._backpressureChangePromise;
   }
 
-  cancel() {
+  cancel(reason) {
     const transformStream = this._transformStream;
     transformStream._readableClosed = true;
-    TransformStreamErrorInternal(transformStream, new TypeError('Readable side canceled'));
+    TransformStreamErrorInternal(transformStream, reason);
   }
 }
 

--- a/reference-implementation/to-upstream-wpts/transform-streams/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/errors.js
@@ -183,7 +183,7 @@ test(t => {
   const closedPromise = writer.closed;
   return Promise.all([
     ts.readable.cancel(thrownError),
-    promise_rejects(t, new TypeError(), closedPromise, 'closed should throw a TypeError')
+    promise_rejects(t, thrownError, closedPromise, 'closed should throw a TypeError')
   ]);
 }, 'cancelling the readable side should error the writable');
 

--- a/reference-implementation/to-upstream-wpts/transform-streams/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/errors.js
@@ -177,4 +177,14 @@ test(() => {
   }), 'first error gets thrown');
 }, 'TransformStream throw in tricky readableStrategy.size');
 
+test(t => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  const closedPromise = writer.closed;
+  return Promise.all([
+    ts.readable.cancel(thrownError),
+    promise_rejects(t, new TypeError(), closedPromise, 'closed should throw a TypeError')
+  ]);
+}, 'cancelling the readable side should error the writable');
+
 done();


### PR DESCRIPTION
Previously, the writable side would always be errored with a TypeError
if the readable side was cancelled. Change it to use the error that
was passed to the readable side's cancel() method instead.

Also add a test to verify that calling cancel() on the `readable` side
cancels the `writable` side and that the reason is copied.

Resolves #768.