### PR TITLE
Add brand checks to TransformStream tests

### DIFF
--- a/reference-implementation/to-upstream-wpts/.eslintrc.json
+++ b/reference-implementation/to-upstream-wpts/.eslintrc.json
@@ -53,8 +53,13 @@
     "add_completion_callback": false,
 
     "delay": true,
+    "constructorThrowsForAll": true,
     "flushAsyncEvents": true,
+    "getterThrowsForAll": true,
+    "getterRejectsForAll": true,
     "methodRejects": true,
+    "methodRejectsForAll": true,
+    "methodThrowsForAll": true,
     "readableStreamToArray": true,
     "recordingReadableStream": true,
     "recordingWritableStream": true,

--- a/reference-implementation/to-upstream-wpts/resources/test-utils.js
+++ b/reference-implementation/to-upstream-wpts/resources/test-utils.js
@@ -5,13 +5,22 @@
 self.getterRejects = (t, obj, getterName, target) => {
   const getter = Object.getOwnPropertyDescriptor(obj, getterName).get;
 
-  return promise_rejects(t, new TypeError(), getter.call(target));
+  return promise_rejects(t, new TypeError(), getter.call(target), getterName + ' should reject with a TypeError');
+};
+
+self.getterRejectsForAll = (t, obj, getterName, targets) => {
+  return Promise.all(targets.map(target => self.getterRejects(t, obj, getterName, target)));
 };
 
 self.methodRejects = (t, obj, methodName, target, args) => {
   const method = obj[methodName];
 
-  return promise_rejects(t, new TypeError(), method.apply(target, args));
+  return promise_rejects(t, new TypeError(), method.apply(target, args),
+                         methodName + ' should reject with a TypeError');
+};
+
+self.methodRejectsForAll = (t, obj, methodName, targets, args) => {
+  return Promise.all(targets.map(target => self.methodRejects(t, obj, methodName, target, args)));
 };
 
 self.getterThrows = (obj, getterName, target) => {
@@ -20,10 +29,23 @@ self.getterThrows = (obj, getterName, target) => {
   assert_throws(new TypeError(), () => getter.call(target), getterName + ' should throw a TypeError');
 };
 
+self.getterThrowsForAll = (obj, getterName, targets) => {
+  targets.forEach(target => self.getterThrows(obj, getterName, target));
+};
+
 self.methodThrows = (obj, methodName, target, args) => {
   const method = obj[methodName];
 
   assert_throws(new TypeError(), () => method.apply(target, args), methodName + ' should throw a TypeError');
+};
+
+self.methodThrowsForAll = (obj, methodName, targets, args) => {
+  targets.forEach(target => self.methodThrows(obj, methodName, target, args));
+};
+
+self.constructorThrowsForAll = (constructor, firstArgs) => {
+  firstArgs.forEach(firstArg => assert_throws(new TypeError(), () => new constructor(firstArg),
+                                              'constructor should throw a TypeError'));
 };
 
 self.garbageCollect = () => {

--- a/reference-implementation/to-upstream-wpts/transform-streams/brand-checks.html
+++ b/reference-implementation/to-upstream-wpts/transform-streams/brand-checks.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>brand-checks.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/test-utils.js"></script>
+
+<script src="brand-checks.js"></script>

--- a/reference-implementation/to-upstream-wpts/transform-streams/brand-checks.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/brand-checks.js
@@ -1,0 +1,79 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+const TransformStreamDefaultController = getTransformStreamDefaultControllerConstructor();
+
+function getTransformStreamDefaultControllerConstructor() {
+  return realTSDefaultController().constructor;
+}
+
+function fakeTS() {
+  return Object.setPrototypeOf({
+    get readable() { return new ReadableStream(); },
+    get writable() { return new WritableStream(); }
+  }, TransformStream.prototype);
+}
+
+function realTS() {
+  return new TransformStream();
+}
+
+function fakeTSDefaultController() {
+  return Object.setPrototypeOf({
+    get desiredSize() { return 1; },
+    enqueue() { },
+    close() { },
+    error() { }
+  }, TransformStreamDefaultController.prototype);
+}
+
+function realTSDefaultController() {
+  let controller;
+  new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return controller;
+}
+
+test(() => {
+  getterThrowsForAll(TransformStream.prototype, 'readable',
+                     [fakeTS(), realTSDefaultController(), undefined, null]);
+}, 'TransformStream.prototype.readable enforces a brand check');
+
+test(() => {
+  getterThrowsForAll(TransformStream.prototype, 'writable',
+                     [fakeTS(), realTSDefaultController(), undefined, null]);
+}, 'TransformStream.prototype.writable enforces a brand check');
+
+test(() => {
+  constructorThrowsForAll(TransformStreamDefaultController,
+                          [fakeTS(), realTS(), realTSDefaultController(), undefined, null]);
+}, 'TransformStreamDefaultConstructor enforces a brand check and doesn\'t permit independant construction');
+
+test(() => {
+  getterThrowsForAll(TransformStreamDefaultController.prototype, 'desiredSize',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.desiredSize enforces a brand check');
+
+test(() => {
+  methodThrowsForAll(TransformStreamDefaultController.prototype, 'enqueue',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.enqueue enforces a brand check');
+
+test(() => {
+  methodThrowsForAll(TransformStreamDefaultController.prototype, 'close',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.close enforces a brand check');
+
+test(() => {
+  methodThrowsForAll(TransformStreamDefaultController.prototype, 'error',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.error enforces a brand check');
+
+done();

--- a/reference-implementation/to-upstream-wpts/transform-streams/brand-checks.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/brand-checks.js
@@ -54,7 +54,7 @@ test(() => {
 test(() => {
   constructorThrowsForAll(TransformStreamDefaultController,
                           [fakeTS(), realTS(), realTSDefaultController(), undefined, null]);
-}, 'TransformStreamDefaultConstructor enforces a brand check and doesn\'t permit independant construction');
+}, 'TransformStreamDefaultConstructor enforces a brand check and doesn\'t permit independent construction');
 
 test(() => {
   getterThrowsForAll(TransformStreamDefaultController.prototype, 'desiredSize',

--- a/reference-implementation/to-upstream-wpts/transform-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/general.js
@@ -26,6 +26,8 @@ test(() => {
   assert_equals(writableStream.set, undefined, 'writable should not have a setter');
   assert_true(writableStream.configurable, 'writable should be configurable');
   assert_true(ts.writable instanceof WritableStream, 'writable is an instance of WritableStream');
+  assert_not_equals(WritableStream.prototype.getWriter.call(ts.writable), undefined,
+                    'writable should pass WritableStream brand check');
 
   const readableStream = Object.getOwnPropertyDescriptor(proto, 'readable');
   assert_true(readableStream !== undefined, 'it has a readable property');
@@ -33,7 +35,9 @@ test(() => {
   assert_equals(typeof readableStream.get, 'function', 'readable should have a getter');
   assert_equals(readableStream.set, undefined, 'readable should not have a setter');
   assert_true(readableStream.configurable, 'readable should be configurable');
-  assert_true(ts.writable instanceof WritableStream, 'writable is an instance of WritableStream');
+  assert_true(ts.readable instanceof ReadableStream, 'readable is an instance of ReadableStream');
+  assert_not_equals(ReadableStream.prototype.getReader.call(ts.readable), undefined,
+                    'readable should pass ReadableStream brand check');
 }, 'TransformStream instances must have writable and readable properties of the correct types');
 
 test(() => {


### PR DESCRIPTION
Verify calls to IsTransformStream() and IsTransformStreamDefaultController()
abstract operations are correctly applied at public entry points.

Also add tests that the "readable" and "writable" properties pass the
IsReadableStream() and IsWritableStream() checks.

Also imports the latest version of test-utils.js from web-platform-tests and
adds a constructorThrowsForAll() test utility function.