### PR TITLE
Add tests for TransformStream backpressure

### DIFF
--- a/reference-implementation/to-upstream-wpts/.eslintrc.json
+++ b/reference-implementation/to-upstream-wpts/.eslintrc.json
@@ -56,7 +56,9 @@
     "flushAsyncEvents": true,
     "methodRejects": true,
     "readableStreamToArray": true,
+    "recordingIdentityTransformStream": true,
     "recordingReadableStream": true,
+    "recordingTransformStream": true,
     "recordingWritableStream": true,
     "sequentialReadableStream": true
   }

--- a/reference-implementation/to-upstream-wpts/.eslintrc.json
+++ b/reference-implementation/to-upstream-wpts/.eslintrc.json
@@ -56,7 +56,6 @@
     "flushAsyncEvents": true,
     "methodRejects": true,
     "readableStreamToArray": true,
-    "recordingIdentityTransformStream": true,
     "recordingReadableStream": true,
     "recordingTransformStream": true,
     "recordingWritableStream": true,

--- a/reference-implementation/to-upstream-wpts/resources/recording-streams.js
+++ b/reference-implementation/to-upstream-wpts/resources/recording-streams.js
@@ -90,3 +90,52 @@ self.recordingWritableStream = (extras = {}, strategy) => {
 
   return stream;
 };
+
+self.recordingTransformStream = (extras = {}, writableStrategy, readableStrategy) => {
+  let controllerToCopyOver;
+  const stream = new TransformStream({
+    start(controller) {
+      controllerToCopyOver = controller;
+
+      if (extras.start) {
+        return extras.start(controller);
+      }
+
+      return undefined;
+    },
+
+    transform(chunk, controller) {
+      stream.events.push('transform', chunk);
+
+      if (extras.transform) {
+        return extras.transform(chunk, controller);
+      }
+
+      return undefined;
+    },
+
+    flush(controller) {
+      stream.events.push('flush');
+
+      if (extras.flush) {
+        return extras.flush(controller);
+      }
+
+      return undefined;
+    }
+  }, writableStrategy, readableStrategy);
+
+  stream.controller = controllerToCopyOver;
+  stream.events = [];
+
+  return stream;
+};
+
+self.recordingIdentityTransformStream = (writableStrategy, readableStrategy) => {
+  const stream = self.recordingTransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+    }
+  }, writableStrategy, readableStrategy);
+  return stream;
+};

--- a/reference-implementation/to-upstream-wpts/resources/recording-streams.js
+++ b/reference-implementation/to-upstream-wpts/resources/recording-streams.js
@@ -111,6 +111,8 @@ self.recordingTransformStream = (extras = {}, writableStrategy, readableStrategy
         return extras.transform(chunk, controller);
       }
 
+      controller.enqueue(chunk);
+
       return undefined;
     },
 
@@ -128,14 +130,5 @@ self.recordingTransformStream = (extras = {}, writableStrategy, readableStrategy
   stream.controller = controllerToCopyOver;
   stream.events = [];
 
-  return stream;
-};
-
-self.recordingIdentityTransformStream = (writableStrategy, readableStrategy) => {
-  const stream = self.recordingTransformStream({
-    transform(chunk, controller) {
-      controller.enqueue(chunk);
-    }
-  }, writableStrategy, readableStrategy);
   return stream;
 };

--- a/reference-implementation/to-upstream-wpts/transform-streams/backpressure.html
+++ b/reference-implementation/to-upstream-wpts/transform-streams/backpressure.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backpressure.js browser context wrapper file</title>
+
+<!-- This is a temporary file. Once these tests are upstreamed a standard  generated file will be used instead. -->
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+
+<script src="backpressure.js"></script>

--- a/reference-implementation/to-upstream-wpts/transform-streams/backpressure.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/backpressure.js
@@ -1,0 +1,112 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js', '../resources/recording-streams.js', '../resources/test-utils.js');
+}
+
+promise_test(() => {
+  const ts = recordingIdentityTransformStream();
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.write('b');
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, ['transform', 'a'], 'transform should be called once');
+  });
+}, 'transform() should be called once with default identity transform');
+
+promise_test(() => {
+  // Without a transform() implementation, recordingTransformStream() never enqueues anything.
+  const ts = recordingTransformStream();
+  const writer = ts.writable.getWriter();
+  const writePromises = [];
+  for (let i = 0; i < 4; ++i) {
+    writePromises.push(writer.write(i));
+  }
+  return Promise.all(writePromises).then(() => {
+    assert_array_equals(ts.events, ['transform', 0, 'transform', 1, 'transform', 2, 'transform', 3],
+                        'all 4 events should be transformed');
+  });
+}, 'transform() should keep being called as long as there is no backpressure');
+
+promise_test(() => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const events = [];
+  writer.write('a').then(() => events.push('a'));
+  writer.write('b').then(() => events.push('b'));
+  writer.close().then(() => events.push('closed'));
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(events, [], 'no writes should have resolved yet');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should not be true');
+    assert_equals('a', value, 'value should be "a"');
+    return delay(0);
+  }).then(() => {
+    assert_array_equals(events, ['a'], 'the first write should have resolved');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should still not be true');
+    assert_equals('b', value, 'value should be "b"');
+    return delay(0);
+  }).then(() => {
+    assert_array_equals(events, ['a', 'b', 'closed'], 'the second write and close should be resolved');
+    return reader.read();
+  }).then(({ done }) => {
+    assert_true(done, 'done should be true');
+  });
+}, 'writes should not resolve until backpressure clears');
+
+promise_test(() => {
+  const ts = new TransformStream({}, {}, { highWaterMark: 0 });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const readPromise = reader.read();
+  writer.write('a');
+  return readPromise.then(({ value, done }) => {
+    assert_false(done, 'not done');
+    assert_equals(value, 'a', 'value should be "a"');
+  });
+}, 'calling pull() before the first write() with backpressure should work');
+
+promise_test(() => {
+  let reader;
+  const ts = recordingTransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      return reader.read();
+    }
+  });
+  const writer = ts.writable.getWriter();
+  reader = ts.readable.getReader();
+  return writer.write('a');
+}, 'read from within transform() clears backpressure');
+
+promise_test(() => {
+  let resolveTransform;
+  const transformPromise = new Promise(resolve => {
+    resolveTransform = resolve;
+  });
+  const ts = recordingTransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, new CountQueuingStrategy({ highWaterMark: Infinity }));
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+  return delay(0).then(() => {
+    writer.write('a');
+    assert_array_equals(ts.events, ['transform', 'a']);
+    assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+    return flushAsyncEvents();
+  }).then(() => {
+    assert_equals(writer.desiredSize, 0, 'desiredSize should still be 0');
+    resolveTransform();
+    return delay(0);
+  }).then(() => {
+    assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+  });
+}, 'blocking transform() should cause backpressure');
+
+done();


### PR DESCRIPTION
Verify that backpressure is correctly applied when the readable side queue is
full, or when the transform() method blocks.