### PR TITLE
Revise abstract, introduction, and model

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -123,7 +123,7 @@ synchronously, e.g. if it is held by the operating system's in-memory buffers, o
 read from disk. An example pull source is a file handle, where you seek to specific locations and read specific amounts.
 
 Readable streams are designed to wrap both types of sources behind a single, unified interface. The implementation
-details of a source are provided by an object containing certain methods and properties that is passed to the
+details of a source are provided by an object with certain methods and properties. It is passed to the
 {{ReadableStream()}} constructor.
 
 <a>Chunks</a> are enqueued into the stream by the stream's <a>underlying source</a>. They can then be read one at a
@@ -144,9 +144,9 @@ independently.
 
 For streams representing bytes, an extended version of the <a>readable stream</a> is provided to handle bytes
 efficiently, in particular by minimizing copies. The <a>underlying source</a> for such a readable stream is called
-a <dfn>underlying byte source</dfn>. A readable stream whose underlying source is an underlying byte source is sometimes
-called a <dfn>readable byte stream</dfn>. Consumers of a readable byte stream can acquire a <a>BYOB reader</a> using
-the stream's {{ReadableStream/getReader()}} method.
+an <dfn>underlying byte source</dfn>. A readable stream whose underlying source is an underlying byte source is
+sometimes called a <dfn>readable byte stream</dfn>. Consumers of a readable byte stream can acquire a <a>BYOB reader</a>
+using the stream's {{ReadableStream/getReader()}} method.
 
 <h3 id="ws-model">Writable Streams</h3>
 
@@ -158,8 +158,8 @@ Analogously to readable streams, most writable streams wrap a lower-level I/O si
 queuing subsequent writes and only delivering them to the underlying sink one by one.
 
 <a>Chunks</a> are written to the stream via its public interface, and are passed one at a time to the stream's
-<a>underlying sink</a>. The implementation details of the sink are provided by an object containing certain methods that
-is passed to the {{WritableStream()}} constructor.
+<a>underlying sink</a>. The implementation details of the sink are provided by an object with certain methods that is
+passed to the {{WritableStream()}} constructor.
 
 Code that writes into a writable stream using its public interface is known as a <dfn>producer</dfn>.
 

--- a/index.bs
+++ b/index.bs
@@ -8,12 +8,8 @@ Inline Github Issues: title
 Status: LS
 Boilerplate: omit conformance, omit feedback-header
 No Editor: true
-Abstract: This specification provides APIs for creating, composing, and consuming streams of data.
-Abstract: These streams are designed to map efficiently to low-level I/O primitives, and allow easy
-Abstract: composition with built-in backpressure and queuing. On top of streams, the web platform can
-Abstract: build higher-level abstractions, such as filesystem or socket APIs, while at the same time
-Abstract: users can use the supplied tools to build their own streams which integrate well with those
-Abstract: of the web platform.
+Abstract: This specification provides APIs for creating, composing, and consuming streams of data that map efficiently
+Abstract: to low-level I/O primitives.
 Logo: https://resources.whatwg.org/logo-streams.svg
 !Participate: <a href="https://github.com/whatwg/streams">GitHub whatwg/streams</a> (<a href="https://github.com/whatwg/streams/issues/new">new issue</a>, <a href="https://github.com/whatwg/streams/issues">open issues</a>)
 !Participate: <a href="https://wiki.whatwg.org/wiki/IRC">IRC: #whatwg on Freenode</a>
@@ -68,32 +64,40 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
 
 <em>This section is non-normative.</em>
 
+<div class="non-normative">
+
 Large swathes of the web platform are built on streaming data: that is, data that is created, processed, and consumed
 in an incremental fashion, without ever reading all of it into memory. The Streams Standard provides a common set of
 APIs for creating and interfacing with such streaming data, embodied in <a>readable streams</a>,
 <a>writable streams</a>, and <a>transform streams</a>.
 
+These APIs have been designed to efficiently map to low-level I/O primitives, including specializations for byte streams
+where appropriate. They allow easy composition of multiple streams into <a>pipe chains</a>, or can be used directly via
+<a>readers</a> and <a>writers</a>. Finally, they are designed to automatically provide <a>backpressure</a> and queuing.
+
 This standard provides the base stream primitives which other parts of the web platform can use to expose their
-streaming data. For example, [[FETCH]] could expose request bodies as a writable stream, or response bodies as a
-readable stream. More generally, the platform is full of streaming abstractions waiting to be expressed as streams:
-multimedia streams, file streams, interprocess communication, and more benefit from being able to process data
-incrementally instead of buffering it all into memory and processing it in one go. By providing the foundation for
-these streams to be exposed to developers, the Streams Standard enables use cases like:
+streaming data. For example, [[FETCH]] exposes {{Response}} bodies as {{ReadableStream}} instances. More generally, the
+platform is full of streaming abstractions waiting to be expressed as streams: multimedia streams, file streams,
+inter-global communication, and more benefit from being able to process data incrementally instead of buffering it all
+into memory and processing it in one go. By providing the foundation for these streams to be exposed to developers, the
+Streams Standard enables use cases like:
 
 <ul>
   <li> Video effects: piping a readable video stream through a transform stream that applies effects in real time.
   <li> Decompression: piping a file stream through a transform stream that selectively decompresses files from a
-    <kbd>.tgz</kbd> archive, turning them into <code>img</code> elements as the user scrolls through an image gallery.
+    <kbd>.tgz</kbd> archive, turning them into <{img}> elements as the user scrolls through an image gallery.
   <li> Image decoding: piping an HTTP response stream through a transform stream that decodes bytes into bitmap data,
-    and then through another transform that translates bitmaps into PNGs. If installed inside the <code>fetch</code>
-    hook of a service worker [[SERVICE-WORKERS]], this would allow developers to transparently polyfill new image
-    formats.
+    and then through another transform that translates bitmaps into PNGs. If installed inside the
+    {{ServiceWorkerGlobalScope/fetch}} hook of a service worker, this would allow developers to
+    transparently polyfill new image formats. [[SERVICE-WORKERS]]
 </ul>
 
-The APIs described here provide unifying abstraction for all such streams, encouraging an ecosystem to grow around
-these shared and composable interfaces. At the same time, they have been carefully designed to map efficiently to
-low-level I/O concerns, and to encapsulate the trickier issues (such as <a>backpressure</a>) that come along for the
-ride.
+Web developers can also use the APIs described here to create their own streams, with the same APIs as those provided by
+the platform. Other developers can then transparently compose platform-provided streams with those supplied by
+libraries. In this way, the APIs described here provide unifying abstraction for all streams, encouraging an
+ecosystem to grow around these shared and composable interfaces.
+
+</div>
 
 <h2 id="model">Model</h2>
 
@@ -105,7 +109,7 @@ bytes.
 <h3 id="rs-model">Readable Streams</h3>
 
 A <dfn>readable stream</dfn> represents a source of data, from which you can read. In other words, data comes
-<em>out</em> of a readable stream.
+<em>out</em> of a readable stream. Concretely, a readable stream is an instance of the {{ReadableStream}} class.
 
 Although a readable stream can be created with arbitrary behavior, most readable streams wrap a lower-level I/O source,
 called the <dfn>underlying source</dfn>. There are two types of underlying source: push sources and pull sources.
@@ -118,49 +122,64 @@ constantly being pushed from the OS level, at a rate that can be controlled by c
 synchronously, e.g. if it is held by the operating system's in-memory buffers, or asynchronously, e.g. if it has to be
 read from disk. An example pull source is a file handle, where you seek to specific locations and read specific amounts.
 
-Readable streams are designed to wrap both types of sources behind a single, unified interface.
+Readable streams are designed to wrap both types of sources behind a single, unified interface. The implementation
+details of a source are provided by an object containing certain methods and properties that is passed to the
+{{ReadableStream()}} constructor.
 
 <a>Chunks</a> are enqueued into the stream by the stream's <a>underlying source</a>. They can then be read one at a
-time via the stream's public interface.
+time via the stream's public interface, in particular by using a <a>readable stream reader</a> acquired using the
+stream's {{ReadableStream/getReader()}} method.
 
 Code that reads from a readable stream using its public interface is known as a <dfn>consumer</dfn>.
 
-Consumers also have the ability to <dfn lt="cancel a readable stream">cancel</dfn> a readable stream. This indicates
-that the consumer has lost interest in the stream, and will immediately close the stream, throw away any queued
-<a>chunks</a>, and execute any cancellation mechanism of the <a>underlying source</a>.
+Consumers also have the ability to <dfn lt="cancel a readable stream">cancel</dfn> a readable stream, using its
+{{ReadableStream/cancel()}} method. This indicates that the consumer has lost interest in the stream, and will
+immediately close the stream, throw away any queued <a>chunks</a>, and execute any cancellation mechanism of the
+<a>underlying source</a>.
 
-Consumers can also <dfn lt="tee a readable stream">tee</dfn> a readable stream. This will
-<a lt="locked to a reader">lock</a> the stream, making it no longer directly usable; however, it will create two new
-streams, called <dfn lt="branches of a readable stream tee">branches</dfn>, which can be consumed independently.
+Consumers can also <dfn lt="tee a readable stream">tee</dfn> a readable stream using its {{ReadableStream/tee()}}
+method. This will <a lt="locked to a reader">lock</a> the stream, making it no longer directly usable; however, it will
+create two new streams, called <dfn lt="branches of a readable stream tee">branches</dfn>, which can be consumed
+independently.
 
 For streams representing bytes, an extended version of the <a>readable stream</a> is provided to handle bytes
 efficiently, in particular by minimizing copies. The <a>underlying source</a> for such a readable stream is called
 a <dfn>underlying byte source</dfn>. A readable stream whose underlying source is an underlying byte source is sometimes
-called a <dfn>readable byte stream</dfn>.
+called a <dfn>readable byte stream</dfn>. Consumers of a readable byte stream can acquire a <a>BYOB reader</a> using
+the stream's {{ReadableStream/getReader()}} method.
 
 <h3 id="ws-model">Writable Streams</h3>
 
 A <dfn>writable stream</dfn> represents a destination for data, into which you can write. In other words, data goes
-<em>in</em> to a writable stream.
+<em>in</em> to a writable stream. Concretely, a writable stream is an instance of the {{WritableStream}} class.
 
 Analogously to readable streams, most writable streams wrap a lower-level I/O sink, called the
 <dfn>underlying sink</dfn>. Writable streams work to abstract away some of the complexity of the underlying sink, by
 queuing subsequent writes and only delivering them to the underlying sink one by one.
 
 <a>Chunks</a> are written to the stream via its public interface, and are passed one at a time to the stream's
-<a>underlying sink</a>.
+<a>underlying sink</a>. The implementation details of the sink are provided by an object containing certain methods that
+is passed to the {{WritableStream()}} constructor.
 
 Code that writes into a writable stream using its public interface is known as a <dfn>producer</dfn>.
 
-Producers also have the ability to <dfn lt="abort a writable stream">abort</dfn> a writable stream. This indicates that
-the producer believes something has gone wrong, and that future writes should be discontinued. It puts the stream in an
-errored state, even without a signal from the <a>underlying sink</a>.
+Producers also have the ability to <dfn lt="abort a writable stream">abort</dfn> a writable stream, using its
+{{WritableStream/abort()}} method. This indicates that the producer believes something has gone wrong, and that future
+writes should be discontinued. It puts the stream in an errored state, even without a signal from the <a>underlying
+sink</a>.
 
 <h3 id="ts-model">Transform Streams</h3>
 
+<p class="warning">Transform streams are not yet fully developed. We are iterating on their design using a JavaScript
+reference implementation and test suite; you can follow that work <a
+href="https://github.com/whatwg/streams/labels/transform%20streams">on the issue tracker</a>. Until then, this section
+gives a brief overview of their intended design, even though the details of their API is not yet determined.</p>
+
 A <dfn>transform stream</dfn> consists of a pair of streams: a writable stream, and a readable stream.
 In a manner specific to the transform stream in question, writes to the writable side result in new data being made
-available for reading from the readable side.
+available for reading from the readable side. Concretely, any object with a <code>writable</code> property and a
+<code>readable</code> property can serve as a transform stream. However, we plan to provide a
+<code>TransformStream</code> class which makes it much easier to create such a pair that is properly entangled.
 
 Some examples of transform streams include:
 
@@ -175,24 +194,25 @@ Some examples of transform streams include:
 <h3 id="pipe-chains">Pipe Chains and Backpressure</h3>
 
 Streams are primarily used by <dfn>piping</dfn> them to each other. A readable stream can be piped directly to a
-writable stream, or it can be piped through one or more transform streams first.
+writable stream, using its {{ReadableStream/pipeTo()}} method, or it can be piped through one or more transform streams
+first, using its {{ReadableStream/pipeThrough()}} method.
 
 A set of streams piped together in this way is referred to as a <dfn>pipe chain</dfn>. In a pipe chain, the
 <dfn>original source</dfn> is the <a>underlying source</a> of the first readable stream in the chain; the
 <dfn>ultimate sink</dfn> is the <a>underlying sink</a> of the final writable stream in the chain.
 
-Once a pipe chain is constructed, it can be used to propagate signals regarding how fast <a>chunks</a> should flow
-through it. If any step in the chain cannot yet accept chunks, it propagates a signal backwards through the pipe chain,
-until eventually the original source is told to stop producing chunks so fast. This process of normalizing flow from
-the original source according to how fast the chain can process chunks is called <dfn>backpressure</dfn>.
+Once a pipe chain is constructed, it will propagate signals regarding how fast <a>chunks</a> should flow through it. If
+any step in the chain cannot yet accept chunks, it propagates a signal backwards through the pipe chain, until
+eventually the original source is told to stop producing chunks so fast. This process of normalizing flow from the
+original source according to how fast the chain can process chunks is called <dfn>backpressure</dfn>.
 
 When <a lt="tee a readable stream">teeing</a> a readable stream, the <a>backpressure</a> signals from its two
 <a lt="branches of a readable stream tee">branches</a> will aggregate, such that if neither branch is read from, a
 backpressure signal will be sent to the <a>underlying source</a> of the original stream.
 
-<!-- TODO when we have writable stream writers
-Piping a readable stream <a href="locked to a reader">locks</a> the readable stream, preventing it from being accessed
--->
+Piping <a>locks</a> the readable and writable streams, preventing them from being manipulated for the duration of the
+pipe operation. This allows the implementation to perform important optimizations, such as directly shuttling data from
+the underlying source to the underlying sink while bypassing many of the intermediate queues.
 
 <h3 id="queuing-strategies">Internal Queues and Queuing Strategies</h3>
 
@@ -212,36 +232,48 @@ For readable streams, an underlying source can use this desired size as a backpr
 generation so as to try to keep the desired size above or at zero. For writable streams, a producer can behave
 similarly, avoiding writes that would cause the desired size to go negative.
 
+Concretely, a queueing strategy is given by any JavaScript object with a <code>highWaterMark</code> property and a
+<code>size()</code> method. <!-- TODO: https://github.com/whatwg/streams/issues/427 -->
+
 <div class="example" id="example-simple-queuing-strategy">
   A simple example of a queuing strategy would be one that assigns a size of one to each chunk, and has a high water
   mark of three. This would mean that up to three chunks could be enqueued in a readable stream, or three chunks
   written to a writable stream, before the streams are considered to be applying backpressure.
+
+  In JavaScript, such a strategy could be written manually as <code>{ highWaterMark: 3, size() { return 1; }}</code>,
+  or using the built-in {{CountQueuingStrategy}} class, as <code>new CountQueuingStrategy({ highWaterMark: 3 })</code>.
 </div>
 
 <h3 id="locking">Locking</h3>
 
-A <dfn>readable stream reader</dfn>, or simply reader, is an object that allows direct reading of <a>chunks</a> from a
-<a>readable stream</a>. Without a reader, a <a>consumer</a> can only perform high-level operations on the readable
-stream: <a lt="cancel a readable stream">canceling</a> the stream, or <a>piping</a> the readable stream to a writable
-stream.
-
-Similarly, a <dfn>writable stream writer</dfn>, or simply writer, is an object that allows direct writing of
-<a>chunks</a> to a <a>writable stream</a>. Without a writer, a <a>producer</a> can only perform the high-level
-operations of <a lt="abort a writable stream">aborting</a> the stream or <a>piping</a> a readable stream to the writable
-stream.
-
-(Under the covers, these high-level operations actually use a reader or writer themselves.)
-
-A given readable or writable stream only has at most one reader or writer at a time. We say in this case the stream is
-<dfn lt="locked to a reader|locked to a writer">locked</dfn>, and that the reader or writer is <dfn
-lt="active|active reader|active writer">active</dfn>.
-
-A reader or writer also has the capability to <dfn lt="release a lock|release a read lock|release a write lock">release
-its lock</dfn>, which makes it no longer active, and allows further readers or writers to be acquired.
+A <dfn lt="reader|readable stream reader">readable stream reader</dfn>, or simply reader, is an object that allows
+direct reading of <a>chunks</a> from a <a>readable stream</a>. Without a reader, a <a>consumer</a> can only perform
+high-level operations on the readable stream: <a lt="cancel a readable stream">canceling</a> the stream, or
+<a>piping</a> the readable stream to a writable stream. A reader is acquired via the stream's
+{{ReadableStream/getReader()}} method.
 
 A <a>readable byte stream</a> has the ability to vend two types of readers: <dfn>default readers</dfn> and <dfn>BYOB
 readers</dfn>. BYOB ("bring your own buffer") readers allow reading into a developer-supplied buffer, thus minimizing
-copies.
+copies. A non-byte readable stream can only vend default readers. Default readers are instances of the
+{{ReadableStreamDefaultReader}} class, while BYOB readers are instances of {{ReadableStreamBYOBReader}}.
+
+Similarly, a <dfn lt="writer|writable stream writer">writable stream writer</dfn>, or simply writer, is an object that
+allows direct writing of <a>chunks</a> to a <a>writable stream</a>. Without a writer, a <a>producer</a> can only perform
+the high-level operations of <a lt="abort a writable stream">aborting</a> the stream or <a>piping</a> a readable stream
+to the writable stream. Writers are represented by the {{WritableStreamDefaultWriter}} class.
+
+<p class="note">Under the covers, these high-level operations actually use a reader or writer themselves.</p>
+
+A given readable or writable stream only has at most one reader or writer at a time. We say in this case the stream is
+<dfn lt="lock|locked to a reader|locked to a writer">locked</dfn>, and that the reader or writer is <dfn
+lt="active|active reader|active writer">active</dfn>. This state can be determined using the
+{{ReadableStream/locked|readableStream.locked}} or {{WritableStream/locked|writableStream.locked}} properties.
+
+A reader or writer also has the capability to <dfn lt="release a lock|release a read lock|release a write lock">release
+its lock</dfn>, which makes it no longer active, and allows further readers or writers to be acquired. This is done via
+the {{ReadableStreamDefaultReader/releaseLock()|defaultReader.releaseLock()}},
+{{ReadableStreamBYOBReader/releaseLock()|byobReader.releaseLock()}}, or
+{{WritableStreamDefaultWriter/releaseLock()|writer.releaseLock()}} method, as appropriate.
 
 <h2 id="rs">Readable Streams</h2>
 
@@ -282,9 +314,9 @@ copies.
 </div>
 
 <div class="example" id="example-manual-read">
-  Although readable streams will usually be used by piping them to a writable stream, you can also read them directly
-  by acquiring a <a lt="readable stream reader">reader</a> and using its <code>read()</code> method to get successive
-  chunks. For example, this code logs the next <a>chunk</a> in the stream, if available:
+  Although readable streams will usually be used by piping them to a writable stream, you can also read them directly by
+  acquiring a <a>reader</a> and using its <code>read()</code> method to get successive chunks. For example, this code
+  logs the next <a>chunk</a> in the stream, if available:
 
   <pre><code class="lang-javascript">
     const reader = readableStream.getReader();
@@ -2522,7 +2554,7 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
 </div>
 
 <div class="example" id="example-manual-write-batch">
-  You can also write directly to writable streams by acquiring a <a lt="writable stream writer">writer</a> and using its
+  You can also write directly to writable streams by acquiring a <a>writer</a> and using its
   {{WritableStreamDefaultWriter/write()}} and {{WritableStreamDefaultWriter/close()}} methods. Since writable streams
   queue any incoming writes, and take care internally to forward them to the <a>underlying sink</a> in sequence, you can
   indiscriminately write to a writable stream without much ceremony:
@@ -2756,9 +2788,9 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
 <h5 id="ws-get-writer" method for="WritableStream">getWriter()</h5>
 
 <div class="note">
-  The <code>getWriter</code> method creates a <a lt="writable stream writer">writer</a> (an instance of
-  {{WritableStreamDefaultWriter}}) and <a lt="locked to a writer">locks</a> the stream to the new writer. While the
-  stream is locked, no other writer can be acquired until this one is <a lt="release a write lock">released</a>.
+  The <code>getWriter</code> method creates a <a>writer</a> (an instance of {{WritableStreamDefaultWriter}}) and <a
+  lt="locked to a writer">locks</a> the stream to the new writer. While the stream is locked, no other writer can be
+  acquired until this one is <a lt="release a write lock">released</a>.
 
   This functionality is especially useful for creating abstractions that desire the ability to write to a stream without
   interruption or interleaving. By getting a writer for the stream, you can ensure nobody else can write at the same
@@ -4226,7 +4258,7 @@ The following function returns a <a>writable stream</a> that wraps a {{WebSocket
 any way to tell when a given chunk of data has been successfully sent (without awkward polling of
 {{WebSocket/bufferedAmount}}, which we leave as an exercise to the reader). As such, this writable stream has no ability
 to communicate accurate <a>backpressure</a> signals or write success/failure to its <a>producers</a>. That is, the
-promises returned by its <a lt="writable stream writer">writer</a>'s {{WritableStreamDefaultWriter/write()}} method and
+promises returned by its <a>writer</a>'s {{WritableStreamDefaultWriter/write()}} method and
 {{WritableStreamDefaultWriter/ready}} getter will always fulfill immediately.
 
 <pre><code class="lang-javascript">

--- a/index.bs
+++ b/index.bs
@@ -62,9 +62,9 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
 
 <h2 id="intro">Introduction</h2>
 
-<em>This section is non-normative.</em>
-
 <div class="non-normative">
+
+<em>This section is non-normative.</em>
 
 Large swathes of the web platform are built on streaming data: that is, data that is created, processed, and consumed
 in an incremental fashion, without ever reading all of it into memory. The Streams Standard provides a common set of
@@ -411,27 +411,29 @@ Instances of {{ReadableStream}} are created with the internal slots described in
   </thead>
   <tr>
     <td>\[[disturbed]]
-    <td>A boolean flag set to <emu-val>true</emu-val> when the stream has been read from or canceled
+    <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> when the stream has been read from or
+      canceled
   </tr>
   <tr>
     <td>\[[readableStreamController]]
-    <td>A {{ReadableStreamDefaultController}} or {{ReadableByteStreamController}} created with the ability to control
-    the state and queue of this stream; also used for the IsReadableStream brand check
+    <td class="non-normative">A {{ReadableStreamDefaultController}} or {{ReadableByteStreamController}} created with
+    the ability to control the state and queue of this stream; also used for the <a
+    href="#is-readable-stream">IsReadableStream</a> brand check
   </tr>
   <tr>
     <td>\[[reader]]
-    <td>A {{ReadableStreamDefaultReader}} or {{ReadableStreamBYOBReader}} instance, if the stream is <a>locked to a
-      reader</a>, or <emu-val>undefined</emu-val> if it is not
+    <td class="non-normative">A {{ReadableStreamDefaultReader}} or {{ReadableStreamBYOBReader}} instance, if the stream
+      is <a>locked to a reader</a>, or <emu-val>undefined</emu-val> if it is not
   </tr>
   <tr>
     <td>\[[state]]
-    <td>A string containing the stream's current state, used internally; one of <code>"readable"</code>,
-      <code>"closed"</code>, or <code>"errored"</code>
+    <td class="non-normative">A string containing the stream's current state, used internally; one of
+      <code>"readable"</code>, <code>"closed"</code>, or <code>"errored"</code>
   </tr>
   <tr>
     <td>\[[storedError]]
-    <td>A value indicating how the stream failed, to be given as a failure reason or exception when trying to operate
-      on an errored stream
+    <td class="non-normative">A value indicating how the stream failed, to be given as a failure reason or exception
+      when trying to operate on an errored stream
   </tr>
 </table>
 
@@ -1110,6 +1112,8 @@ The {{ReadableStreamDefaultReader}} class represents a <a>default reader</a> des
 
 <h4 id="default-reader-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{ReadableStreamDefaultReader}} class in something close to the syntax of [[!ECMASCRIPT]], it
@@ -1127,6 +1131,8 @@ would look like
   }
 </code></pre>
 
+</div>
+
 <h4 id="default-reader-internal-slots">Internal Slots</h4>
 
 Instances of {{ReadableStreamDefaultReader}} are created with the internal slots described in the following table:
@@ -1140,17 +1146,18 @@ Instances of {{ReadableStreamDefaultReader}} are created with the internal slots
   </thead>
   <tr>
     <td>\[[closedPromise]]
-    <td>A promise returned by the reader's {{ReadableStreamDefaultReader/closed}} getter
+    <td class="non-normative">A promise returned by the reader's {{ReadableStreamDefaultReader/closed}} getter
   </tr>
   <tr>
     <td>\[[ownerReadableStream]]
-    <td>A {{ReadableStream}} instance that owns this reader
+    <td class="non-normative">A {{ReadableStream}} instance that owns this reader
   </tr>
   <tr>
     <td>\[[readRequests]]
-    <td>A List of promises returned by calls to the reader's {{ReadableStreamDefaultReader/read()}} method that have
-      not yet been resolved, due to the <a>consumer</a> requesting <a>chunks</a> sooner than they are available; also
-      used for the <a href="#is-readable-stream-default-reader">IsReadableStreamDefaultReader</a> brand check
+    <td class="non-normative">A List of promises returned by calls to the reader's
+      {{ReadableStreamDefaultReader/read()}} method that have not yet been resolved, due to the <a>consumer</a>
+      requesting <a>chunks</a> sooner than they are available; also used for the <a
+      href="#is-readable-stream-default-reader">IsReadableStreamDefaultReader</a> brand check
   </tr>
 </table>
 
@@ -1246,6 +1253,8 @@ instance.
 
 <h4 id="byob-reader-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{ReadableStreamBYOBReader}} class in something close to the syntax of [[!ECMASCRIPT]], it
@@ -1263,6 +1272,8 @@ would look like
   }
 </code></pre>
 
+</div>
+
 <h4 id="byob-reader-internal-slots">Internal Slots</h4>
 
 Instances of {{ReadableStreamBYOBReader}} are created with the internal slots described in the following table:
@@ -1276,17 +1287,18 @@ Instances of {{ReadableStreamBYOBReader}} are created with the internal slots de
   </thead>
   <tr>
     <td>\[[closedPromise]]
-    <td>A promise returned by the reader's {{ReadableStreamBYOBReader/closed}} getter
+    <td class="non-normative">A promise returned by the reader's {{ReadableStreamBYOBReader/closed}} getter
   </tr>
   <tr>
     <td>\[[ownerReadableStream]]
-    <td>A {{ReadableStream}} instance that owns this reader
+    <td class="non-normative">A {{ReadableStream}} instance that owns this reader
   </tr>
   <tr>
     <td>\[[readIntoRequests]]
-    <td>A List of promises returned by calls to the reader's {{ReadableStreamBYOBReader/read(view)}} method that have
-      not yet been resolved, due to the <a>consumer</a> requesting <a>chunks</a> sooner than they are available; also
-      used for the <a href="#is-readable-stream-byob-reader">IsReadableStreamBYOBReader</a> brand check
+    <td class="non-normative">A List of promises returned by calls to the reader's
+      {{ReadableStreamBYOBReader/read(view)}} method that have not yet been resolved, due to the <a>consumer</a>
+      requesting <a>chunks</a> sooner than they are available; also used for the <a
+      href="#is-readable-stream-byob-reader">IsReadableStreamBYOBReader</a> brand check
   </tr>
 </table>
 
@@ -1472,6 +1484,8 @@ The {{ReadableStreamDefaultController}} class has methods that allow control of 
 
 <h4 id="rs-default-controller-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{ReadableStreamDefaultController}} class in something close to the syntax of [[!ECMASCRIPT]],
@@ -1489,6 +1503,8 @@ it would look like
   }
 </code></pre>
 
+</div>
+
 <h4 id="rs-default-controller-internal-slots">Internal Slots</h4>
 
 Instances of {{ReadableStreamDefaultController}} are created with the internal slots described in the following table:
@@ -1502,50 +1518,50 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
   </thead>
   <tr>
     <td>\[[closeRequested]]
-    <td>A boolean flag indicating whether the stream has been closed by its <a>underlying source</a>, but still has
-      <a>chunks</a> in its internal queue that have not yet been read
+    <td class="non-normative">A boolean flag indicating whether the stream has been closed by its <a>underlying
+      source</a>, but still has <a>chunks</a> in its internal queue that have not yet been read
   </tr>
   <tr>
     <td>\[[controlledReadableStream]]
-    <td>The {{ReadableStream}} instance controlled
+    <td class="non-normative">The {{ReadableStream}} instance controlled
   </tr>
   <tr>
     <td>\[[pullAgain]]
-    <td>A boolean flag set to <emu-val>true</emu-val> if the stream's mechanisms requested a call to the underlying
-      source's <code>pull</code> method to pull more data, but the pull could not yet be done since a previous call is
-      still executing
+    <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> if the stream's mechanisms requested a call
+      to the underlying source's <code>pull</code> method to pull more data, but the pull could not yet be done since a
+      previous call is still executing
   </tr>
   <tr>
     <td>\[[pulling]]
-    <td>A boolean flag set to <emu-val>true</emu-val> while the <a>underlying source</a>'s <code>pull</code> method is
-      executing and has not yet fulfilled, used to prevent reentrant calls
+    <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> while the <a>underlying source</a>'s
+      <code>pull</code> method is executing and has not yet fulfilled, used to prevent reentrant calls
   </tr>
   <tr>
     <td>\[[queue]]
-    <td>A List representing the stream's internal queue of <a>chunks</a>
+    <td class="non-normative">A List representing the stream's internal queue of <a>chunks</a>
   </tr>
   <tr>
     <td>\[[queueTotalSize]]
-    <td>The total size of all the chunks stored in \[[queue]] (see [[#queue-with-sizes]])
+    <td class="non-normative">The total size of all the chunks stored in \[[queue]] (see [[#queue-with-sizes]])
   </tr>
   <tr>
     <td>\[[started]]
-    <td>A boolean flag indicating whether the <a>underlying source</a> has finished starting
+    <td class="non-normative">A boolean flag indicating whether the <a>underlying source</a> has finished starting
   </tr>
   <tr>
     <td>\[[strategyHWM]]
-    <td>A number supplied to the constructor as part of the stream's <a>queuing strategy</a>, indicating the point at
-      which the stream will apply <a>backpressure</a> to its <a>underlying source</a>
+    <td class="non-normative">A number supplied to the constructor as part of the stream's <a>queuing strategy</a>,
+      indicating the point at which the stream will apply <a>backpressure</a> to its <a>underlying source</a>
   </tr>
   <tr>
     <td>\[[strategySize]]
-    <td>A function supplied to the constructor as part of the stream's <a>queuing strategy</a>, designed to calculate
-      the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default behavior
+    <td class="non-normative">A function supplied to the constructor as part of the stream's <a>queuing strategy</a>,
+      designed to calculate the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default behavior
   </tr>
   <tr>
     <td>\[[underlyingSource]]
-    <td>An object representation of the stream's <a>underlying source</a>; also
-      used for the <a href="#is-readable-stream-default-controller">IsReadableStreamDefaultController</a> brand check
+    <td class="non-normative">An object representation of the stream's <a>underlying source</a>; also used for the <a
+    href="#is-readable-stream-default-controller">IsReadableStreamDefaultController</a> brand check
   </tr>
 </table>
 
@@ -1811,6 +1827,8 @@ corresponding {{ReadableByteStreamController}} instance to manipulate.
 
 <h4 id="rbs-controller-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{ReadableByteStreamController}} class in something close to the syntax of [[!ECMASCRIPT]], it
@@ -1829,6 +1847,8 @@ would look like
   }
 </code></pre>
 
+</div>
+
 <h4 id="rbs-controller-internal-slots">Internal Slots</h4>
 
 Instances of {{ReadableByteStreamController}} are created with the internal slots described in the following table:
@@ -1842,57 +1862,57 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
   </thead>
   <tr>
     <td>\[[autoAllocateChunkSize]]
-    <td>A positive integer, when the automatic buffer allocation feature is enabled. In that case, this value
-      specifies the size of buffer to allocate. It is <emu-val>undefined</emu-val> otherwise.
+    <td class="non-normative">A positive integer, when the automatic buffer allocation feature is enabled. In that case,
+      this value specifies the size of buffer to allocate. It is <emu-val>undefined</emu-val> otherwise.
   </tr>
   <tr>
     <td>\[[closeRequested]]
-    <td>A boolean flag indicating whether the stream has been closed by its <a>underlying byte source</a>, but still has
-      <a>chunks</a> in its internal queue that have not yet been read
+    <td class="non-normative">A boolean flag indicating whether the stream has been closed by its <a>underlying byte
+      source</a>, but still has <a>chunks</a> in its internal queue that have not yet been read
   </tr>
   <tr>
     <td>\[[controlledReadableStream]]
-    <td>The {{ReadableStream}} instance controlled
+    <td class="non-normative">The {{ReadableStream}} instance controlled
   </tr>
   <tr>
     <td>\[[pullAgain]]
-    <td>A boolean flag set to <emu-val>true</emu-val> if the stream's mechanisms requested a call to the
-      <a>underlying byte source</a>'s <code>pull</code> method to pull more data, but the pull could not yet be done
-      since a previous call is still executing
+    <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> if the stream's mechanisms requested a call
+      to the <a>underlying byte source</a>'s <code>pull</code> method to pull more data, but the pull could not yet be
+      done since a previous call is still executing
   </tr>
   <tr>
     <td>\[[pulling]]
-    <td>A boolean flag set to <emu-val>true</emu-val> while the <a>underlying byte source</a>'s <code>pull</code>
-      method is executing and has not yet fulfilled, used to prevent reentrant calls
+    <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> while the <a>underlying byte source</a>'s
+      <code>pull</code> method is executing and has not yet fulfilled, used to prevent reentrant calls
   </tr>
   <tr>
     <td>\[[byobRequest]]
-    <td>A {{ReadableStreamBYOBRequest}} instance representing the current BYOB pull request
+    <td class="non-normative">A {{ReadableStreamBYOBRequest}} instance representing the current BYOB pull request
   </tr>
   <tr>
     <td>\[[pendingPullIntos]]
-    <td>A List of descriptors representing pending BYOB pull requests
+    <td class="non-normative">A List of descriptors representing pending BYOB pull requests
   </tr>
   <tr>
     <td>\[[queue]]
-    <td>A List representing the stream's internal queue of <a>chunks</a>
+    <td class="non-normative">A List representing the stream's internal queue of <a>chunks</a>
   </tr>
   <tr>
     <td>\[[queueTotalSize]]
-    <td>The total size (in bytes) of all the chunks stored in \[[queue]]
+    <td class="non-normative">The total size (in bytes) of all the chunks stored in \[[queue]]
   </tr>
   <tr>
     <td>\[[started]]
-    <td>A boolean flag indicating whether the <a>underlying source</a> has finished starting
+    <td class="non-normative">A boolean flag indicating whether the <a>underlying source</a> has finished starting
   </tr>
   <tr>
     <td>\[[strategyHWM]]
-    <td>A number supplied to the constructor as part of the stream's <a>queuing strategy</a>, indicating the point at
-      which the stream will apply <a>backpressure</a> to its <a>underlying byte source</a>
+    <td class="non-normative">A number supplied to the constructor as part of the stream's <a>queuing strategy</a>,
+      indicating the point at which the stream will apply <a>backpressure</a> to its <a>underlying byte source</a>
   </tr>
   <tr>
     <td>\[[underlyingByteSource]]
-    <td>An object representation of the stream's <a>underlying byte source</a>;
+    <td class="non-normative">An object representation of the stream's <a>underlying byte source</a>;
       also used for the <a href="#is-readable-byte-stream-controller">IsReadableByteStreamController</a> brand check
   </tr>
 </table>
@@ -2066,6 +2086,8 @@ The {{ReadableStreamBYOBRequest}} class represents a pull into request in a {{Re
 
 <h4 id="rs-byob-request-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{ReadableStreamBYOBRequest}} class in something close to the syntax of [[!ECMASCRIPT]], it
@@ -2082,6 +2104,8 @@ would look like
   }
 </code></pre>
 
+</div>
+
 <h4 id="rs-byob-request-internal-slots">Internal Slots</h4>
 
 Instances of {{ReadableStreamBYOBRequest}} are created with the internal slots described in the following table:
@@ -2095,11 +2119,12 @@ Instances of {{ReadableStreamBYOBRequest}} are created with the internal slots d
   </thead>
   <tr>
     <td>\[[associatedReadableByteStreamController]]
-    <td>The parent {{ReadableByteStreamController}} instance
+    <td class="non-normative">The parent {{ReadableByteStreamController}} instance
   </tr>
   <tr>
     <td>\[[view]]
-    <td>A <a>typed array</a> representing the destination region to which the controller may write generated data
+    <td class="non-normative">A <a>typed array</a> representing the destination region to which the controller can write
+      generated data
   </tr>
 </table>
 
@@ -2617,9 +2642,12 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
   writeRandomBytesForever(myWritableStream).catch(e => console.error("Something broke", e));
   </code></pre>
 </div>
+
 <h3 id="ws-class" interface lt="WritableStream">Class <code>WritableStream</code></h3>
 
 <h4 id="ws-class-definition">Class Definition</h4>
+
+<div class="non-normative">
 
 <em>This section is non-normative.</em>
 
@@ -2637,6 +2665,8 @@ like
   }
 </code></pre>
 
+</div>
+
 <h4 id="ws-internal-slots">Internal Slots</h4>
 
 Instances of {{WritableStream}} are created with the internal slots described in the following table:
@@ -2650,53 +2680,54 @@ Instances of {{WritableStream}} are created with the internal slots described in
   </thead>
   <tr>
     <td>\[[backpressure]]
-    <td>The backpressure signal set by the controller
+    <td class="non-normative">The backpressure signal set by the controller
   </tr>
   <tr>
     <td>\[[closeRequest]]
-    <td>The promise returned from the writer {{WritableStreamDefaultWriter/close()}} method
+    <td class="non-normative">The promise returned from the writer {{WritableStreamDefaultWriter/close()}} method
   </tr>
   <tr>
     <td>\[[inFlightWriteRequest]]
-    <td>A slot set to the promise for the current in-flight write operation while the <a>underlying sink</a>'s
-      <code>write</code> method is executing and has not yet fulfilled, used to prevent reentrant calls
+    <td class="non-normative">A slot set to the promise for the current in-flight write operation while the
+      <a>underlying sink</a>'s <code>write</code> method is executing and has not yet fulfilled, used to prevent
+      reentrant calls
   </tr>
   <tr>
     <td>\[[inFlightCloseRequest]]
-    <td>A slot set to the promise for the current in-flight close operation while the <a>underlying sink</a>'s
-      <code>close</code> method is executing and has not yet fulfilled, used to prevent the
+    <td class="non-normative">A slot set to the promise for the current in-flight close operation while the
+      <a>underlying sink</a>'s <code>close</code> method is executing and has not yet fulfilled, used to prevent the
       {{WritableStreamDefaultWriter/abort()}} method from interrupting close
   </tr>
   <tr>
     <td>\[[pendingAbortRequest]]
-    <td>A Record containing the promise returned from
+    <td class="non-normative">A Record containing the promise returned from
       {{WritableStreamDefaultWriter/abort()}} and the <var>reason</var> passed to
       {{WritableStreamDefaultWriter/abort()}}
   </tr>
   <tr>
     <td>\[[state]]
-    <td>A string containing the stream's current state, used internally; one of <code>"writable"</code>,
-    <code>"closed"</code>, or <code>"errored"</code>
+    <td class="non-normative">A string containing the stream's current state, used internally; one of
+      <code>"writable"</code>, <code>"closed"</code>, or <code>"errored"</code>
   </tr>
   <tr>
     <td>\[[storedError]]
-    <td>A value indicating how the stream failed, to be given as a failure reason or exception when trying to operate
-      on the stream while in the <code>"errored"</code> state
+    <td class="non-normative">A value indicating how the stream failed, to be given as a failure reason or exception
+      when trying to operate on the stream while in the <code>"errored"</code> state
   </tr>
   <tr>
     <td>\[[writableStreamController]]
-    <td>A {{WritableStreamDefaultController}} created with the ability to control the state and queue of this stream;
-    also used for the IsWritableStream brand check
+    <td class="non-normative">A {{WritableStreamDefaultController}} created with the ability to control the state and
+      queue of this stream; also used for the <a href="#is-writable-stream">IsWritableStream</a> brand check
   </tr>
   <tr>
     <td>\[[writer]]
-    <td>A {{WritableStreamDefaultWriter}} instance, if the stream is <a>locked to a writer</a>, or
-    <emu-val>undefined</emu-val> if it is not
+    <td class="non-normative">A {{WritableStreamDefaultWriter}} instance, if the stream is <a>locked to a writer</a>, or
+      <emu-val>undefined</emu-val> if it is not
   </tr>
   <tr>
     <td>\[[writeRequests]]
-    <td>A List of promises representing the stream's internal queue of write requests not yet processed by the
-      <a>underlying sink</a>.
+    <td class="non-normative">A List of promises representing the stream's internal queue of write requests not yet
+      processed by the <a>underlying sink</a>.
   </tr>
 </table>
 
@@ -3069,6 +3100,8 @@ The {{WritableStreamDefaultWriter}} class represents a <a>writable stream writer
 
 <h4 id="default-writer-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{WritableStreamDefaultWriter}} class in something close to the syntax of [[!ECMASCRIPT]], it
@@ -3089,6 +3122,8 @@ would look like
   }
 </code></pre>
 
+</div>
+
 <h4 id="default-writer-internal-slots">Internal Slots</h4>
 
 Instances of {{WritableStreamDefaultWriter}} are created with the internal slots described in the following table:
@@ -3102,15 +3137,15 @@ Instances of {{WritableStreamDefaultWriter}} are created with the internal slots
   </thead>
   <tr>
     <td>\[[closedPromise]]
-    <td>A promise returned by the writer's {{WritableStreamDefaultWriter/closed}} getter
+    <td class="non-normative">A promise returned by the writer's {{WritableStreamDefaultWriter/closed}} getter
   </tr>
   <tr>
     <td>\[[ownerWritableStream]]
-    <td>A {{WritableStream}} instance that owns this writer
+    <td class="non-normative">A {{WritableStream}} instance that owns this writer
   </tr>
   <tr>
     <td>\[[readyPromise]]
-    <td>A promise returned by the writer's {{WritableStreamDefaultWriter/ready}} getter
+    <td class="non-normative">A promise returned by the writer's {{WritableStreamDefaultWriter/ready}} getter
   </tr>
 </table>
 
@@ -3404,6 +3439,8 @@ constructing a {{WritableStream}}, the <a>underlying sink</a> is given a corresp
 
 <h4 id="ws-default-controller-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{WritableStreamDefaultController}} class in something close to the syntax of [[!ECMASCRIPT]],
@@ -3416,6 +3453,8 @@ it would look like
     error(e)
   }
 </code></pre>
+
+</div>
 
 <h4 id="ws-default-controller-internal-slots">Internal Slots</h4>
 
@@ -3430,34 +3469,35 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
   </thead>
   <tr>
     <td>\[[controlledWritableStream]]
-    <td>The {{WritableStream}} instance controlled
+    <td class="non-normative">The {{WritableStream}} instance controlled
   </tr>
   <tr>
     <td>\[[queue]]
-    <td>A List representing the stream's internal queue of <a>chunks</a>
+    <td class="non-normative">A List representing the stream's internal queue of <a>chunks</a>
   </tr>
   <tr>
     <td>\[[queueTotalSize]]
-    <td>The total size of all the chunks stored in \[[queue]] (see [[#queue-with-sizes]])
+    <td class="non-normative">The total size of all the chunks stored in \[[queue]] (see [[#queue-with-sizes]])
   </tr>
   <tr>
     <td>\[[started]]
-    <td>A boolean flag indicating whether the <a>underlying sink</a> has finished starting
+    <td class="non-normative">A boolean flag indicating whether the <a>underlying sink</a> has finished starting
   </tr>
   <tr>
     <td>\[[strategyHWM]]
-    <td>A number supplied to the constructor as part of the stream's <a>queuing strategy</a>, indicating the point at
-      which the stream will apply <a>backpressure</a> to its <a>underlying sink</a>
+    <td class="non-normative">A number supplied to the constructor as part of the stream's <a>queuing strategy</a>,
+      indicating the point at which the stream will apply <a>backpressure</a> to its <a>underlying sink</a>
   </tr>
   <tr>
     <td>\[[strategySize]]
-    <td>A function supplied to the constructor as part of the stream's <a>queuing strategy</a>, designed to calculate
-      the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default behavior
+    <td class="non-normative">A function supplied to the constructor as part of the stream's <a>queuing strategy</a>,
+      designed to calculate the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default
+      behavior
   </tr>
   <tr>
     <td>\[[underlyingSink]]
-    <td>An object representation of the stream's <a>underlying sink</a>; also
-      used for the <a href="#is-writable-stream-default-controller">IsWritableStreamDefaultController</a> brand check
+    <td class="non-normative">An object representation of the stream's <a>underlying sink</a>; also used for the <a
+    href="#is-writable-stream-default-controller">IsWritableStreamDefaultController</a> brand check
   </tr>
 </table>
 
@@ -3723,6 +3763,8 @@ properties of the incoming <a>chunks</a> reaches a specified high-water mark. As
 
 <h4 id="blqs-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{ByteLengthQueuingStrategy}} class in something close to the syntax of [[!ECMASCRIPT]], it
@@ -3737,6 +3779,8 @@ would look like
 
 Each {{ByteLengthQueuingStrategy}} instance will additionally have an own data property
 <code>highWaterMark</code> set by its constructor.
+
+</div>
 
 <h4 id="blqs-constructor" constructor for="ByteLengthQueuingStrategy" lt="ByteLengthQueuingStrategy(options)">new
 ByteLengthQueuingStrategy({ <var>highWaterMark</var> })</h4>
@@ -3798,6 +3842,8 @@ strategy is also provided out of the box.
 
 <h4 id="cqs-class-definition">Class Definition</h4>
 
+<div class="non-normative">
+
 <em>This section is non-normative.</em>
 
 If one were to write the {{CountQueuingStrategy}} class in something close to the syntax of [[!ECMASCRIPT]], it would
@@ -3812,6 +3858,8 @@ look like
 
 Each {{CountQueuingStrategy}} instance will additionally have an own data property <code>highWaterMark</code>
 set by its constructor.
+
+</div>
 
 <h4 id="cqs-constructor" constructor for="CountQueuingStrategy" lt="CountQueuingStrategy(options)">new
 CountQueuingStrategy({ <var>highWaterMark</var> })</h4>
@@ -3998,6 +4046,8 @@ The attributes of these properties must be { \[[Writable]]: <emu-val>true</emu-v
 </div>
 
 <h2 id="creating-examples">Examples of Creating Streams</h2>
+
+<div class="non-normative">
 
 <em>This section, and all its subsections, are non-normative.</em>
 
@@ -4368,7 +4418,8 @@ We can then use this function to create a writable stream for a file, and write 
 Note that if a particular call to <code>fs.write</code> takes a longer time, the returned promise will fulfill later.
 In the meantime, additional writes can be queued up, which are stored in the stream's internal queue. The accumulation
 of chunks in this queue can change the stream to return a pending promise from the {{WritableStreamDefaultWriter/ready}}
-getter, which is a signal to <a>producers</a> that they should back off and stop writing if possible.
+getter, which is a signal to <a>producers</a> that they would benefit from backing off and stopping writing, if
+possible.
 
 The way in which the writable stream queues up writes is especially important in this case, since as stated in
 <a href="https://nodejs.org/api/fs.html#fs_fs_write_fd_data_position_encoding_callback">the documentation for
@@ -4477,6 +4528,8 @@ APIs:
 
 Note how in this setup canceling the <code>readable</code> side will implicitly close the <code>writable</code> side,
 and similarly, closing or aborting the <code>writable</code> side will implicitly close the <code>readable</code> side.
+
+</div>
 
 <h2 id="conventions" class="no-num">Conventions</h2>
 


### PR DESCRIPTION
Making the abstract shorter fixes #769. The introduction incorporates some of its former content, and also was updated in light of how streams and their usage have evolved over time. Finally, it also includes a brief bit about web-developer-created streams, which was curiously absent.

The model section was updated to tie the abstract concepts there to concrete JavaScript classes. Back when it was written, there was some idea of using duck-typing, but that has been abandoned, and this is much more helpful.