### PR TITLE
Test that TransformStream strategies are used correctly

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/strategies.html
+++ b/reference-implementation/to-upstream-wpts/transform-streams/strategies.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>strategies.js browser context wrapper file</title>
+
+<!-- This is a placeholder file until the tests are upstreamed. -->
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+
+<script src="strategies.js"></script>

--- a/reference-implementation/to-upstream-wpts/transform-streams/strategies.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/strategies.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Here we just test that the strategies are correctly passed to the readable and writable sides. We assume that
+// ReadableStream and WritableStream will correctly apply the strategies when they are being used by a TransformStream
+// and so it isn't necessary to repeat their tests here.
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/recording-streams.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+test(() => {
+  const ts = new TransformStream({}, { highWaterMark: 17 });
+  assert_equals(ts.writable.getWriter().desiredSize, 17, 'desiredSize should be 17');
+}, 'writableStrategy highWaterMark works');
+
+promise_test(() => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 9 });
+  const writer = ts.writable.getWriter();
+  for (let i = 0; i < 10; ++i) {
+    writer.write(i);
+  }
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, ['transform', 0, 'transform', 1, 'transform', 2, 'transform', 3, 'transform', 4,
+                                    'transform', 5, 'transform', 6, 'transform', 7, 'transform', 8],
+                        'transform() should have been called 9 times');
+  });
+}, 'readableStrategy highWaterMark works');
+
+promise_test(t => {
+  let writableSizeCalled = false;
+  let readableSizeCalled = false;
+  const ts = new TransformStream(
+    {
+      transform(chunk, controller) {
+        t.step(() => {
+          assert_true(writableSizeCalled, 'writableStrategy.size() should have been called');
+          assert_false(readableSizeCalled, 'readableStrategy.size() should not have been called');
+          controller.enqueue(chunk);
+          assert_true(readableSizeCalled, 'readableStrategy.size() should have been called');
+        });
+      }
+    },
+    {
+      size() {
+        writableSizeCalled = true;
+        return 1;
+      }
+    },
+    {
+      size() {
+        readableSizeCalled = true;
+        return 1;
+      },
+      highWaterMark: Infinity
+    });
+  return ts.writable.getWriter().write();
+}, 'writable has the correct size() function');
+
+done();

--- a/reference-implementation/to-upstream-wpts/transform-streams/strategies.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/strategies.js
@@ -22,8 +22,9 @@ promise_test(() => {
     writer.write(i);
   }
   return delay(0).then(() => {
-    assert_array_equals(ts.events, ['transform', 0, 'transform', 1, 'transform', 2, 'transform', 3, 'transform', 4,
-                                    'transform', 5, 'transform', 6, 'transform', 7, 'transform', 8],
+    assert_array_equals(ts.events, [
+      'transform', 0, 'transform', 1, 'transform', 2, 'transform', 3, 'transform', 4,
+      'transform', 5, 'transform', 6, 'transform', 7, 'transform', 8],
                         'transform() should have been called 9 times');
   });
 }, 'readableStrategy highWaterMark works');
@@ -31,10 +32,12 @@ promise_test(() => {
 promise_test(t => {
   let writableSizeCalled = false;
   let readableSizeCalled = false;
+  let transformCalled = false;
   const ts = new TransformStream(
     {
       transform(chunk, controller) {
         t.step(() => {
+          transformCalled = true;
           assert_true(writableSizeCalled, 'writableStrategy.size() should have been called');
           assert_false(readableSizeCalled, 'readableStrategy.size() should not have been called');
           controller.enqueue(chunk);
@@ -55,7 +58,9 @@ promise_test(t => {
       },
       highWaterMark: Infinity
     });
-  return ts.writable.getWriter().write();
+  return ts.writable.getWriter().write().then(() => {
+    assert_true(transformCalled, 'transform() should be called');
+  });
 }, 'writable has the correct size() function');
 
 done();


### PR DESCRIPTION
Verify that the writableStrategy is used to configure the writable side and the
readableStrategy is used to configure the readable side.