### PR TITLE
Test that transform() can be called synchronously

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/general.js
@@ -345,4 +345,19 @@ promise_test(t => {
   });
 }, 'TransformStream start, transform, and flush should be strictly ordered');
 
+promise_test(() => {
+  let transformCalled = false;
+  const ts = new TransformStream({
+    transform() {
+      transformCalled = true;
+    }
+  }, undefined, { highWaterMark: Infinity });
+  // transform() is only called synchronously when there is no backpressure and all microtasks have run.
+  return delay(0).then(() => {
+    const writePromise = ts.writable.getWriter().write();
+    assert_true(transformCalled, 'transform() should have been called');
+    return writePromise;
+  });
+}, 'it should be possible to call transform() synchronously');
+
 done();


### PR DESCRIPTION
When there is no backpressure and all microtasks have completed it is possible
for transform() to be called synchronously from write(). This is important for
optimising chains of transforms in a pipe, so explicitly test that it works.