### PR TITLE
Permit closing the writable to close the readable, even with HWM 0

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/general.js
@@ -360,4 +360,13 @@ promise_test(() => {
   });
 }, 'it should be possible to call transform() synchronously');
 
+promise_test(() => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+
+  const writer = ts.writable.getWriter();
+  writer.close();
+
+  return Promise.all([writer.closed, ts.readable.getReader().closed]);
+}, 'closing the writable should closes the readable when there are no queued chunks, even with backpressure');
+
 done();


### PR DESCRIPTION
Previously a call to writer.close() on a TransformStream with
readableStrategy.highWaterMark 0 and no chunks queued would not result
in the readable side being closed. This was because the backpressure
would mean that the promises returned by start() or write() would never
settle.

Instead of waiting for backpressure to clear at the end of every call to
sink start() and write(), instead wait for it to clear at the start of a
call to sink write(), before calling transformer.transform().

When there is no backpressure, write() will still call transform()
synchronously.

The results of only one test changed as a result of this. It has been
updated. A new test has been added to verify that writer.close() now
results in the readable being closed with HWM 0.