### PR TITLE
Add brand check to ReadableStreamBYOBRequest constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2145,6 +2145,7 @@ lt="ReadableStreamBYOBRequest(controller, view)">new
 ReadableStreamBYOBRequest(<var>controller</var>, <var>view</var>)</h4>
 
 <emu-alg>
+  1. If ! IsReadableByteStreamController(_controller_) is *false*, throw a *TypeError* exception.
   1. Set *this*.[[associatedReadableByteStreamController]] to _controller_.
   1. Set *this*.[[view]] to _view_.
 </emu-alg>

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1153,11 +1153,19 @@ function ReadableStreamDefaultControllerHasBackpressure(controller) {
 
 class ReadableStreamBYOBRequest {
   constructor(controller, view) {
+    if (IsReadableByteStreamController(controller) === false) {
+      throw new TypeError('Cannot construct a ReadableStreamBYOBRequest without a ReadableByteStreamController');
+    }
+
     this._associatedReadableByteStreamController = controller;
     this._view = view;
   }
 
   get view() {
+    if (IsReadableStreamBYOBRequest(this) === false) {
+      throw byobRequestBrandCheckException('view');
+    }
+
     return this._view;
   }
 


### PR DESCRIPTION
Also add a brand check to the get accessor in the reference implementation that
was already present in the standard text.

Fixes #780.