### PR TITLE
Remove TransformStream's writableDone member

### DIFF
--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -90,7 +90,7 @@ module.exports = {
   IsWritableStreamLocked,
   WritableStream,
   WritableStreamAbort,
-  WritableStreamDefaultControllerError,
+  WritableStreamDefaultControllerErrorIfNeeded,
   WritableStreamDefaultWriterCloseWithErrorPropagation,
   WritableStreamDefaultWriterRelease,
   WritableStreamDefaultWriterWrite,


### PR DESCRIPTION
The [[writableDone]] slot was only used to avoid calling
WritableStreamDefaultControllerError when the stream wasn't writable. This is
exactly the semantics that WritableStreamDefaultControllerErrorIfNeeded has, so
use that instead.

If abort() is called on the writable then cancel() is called on the readable(),
the reason passed to abort() should be the one that errors the writable. Add
tests to verify this behaviour.

Fix a bug where a call to the underlying sink abort() method after the
TransformStream was errored would cause an assert.