### PR TITLE
Detect if the TransformStream errored inside write() and reject

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -318,7 +318,12 @@ class TransformStreamDefaultSink {
 
     if (transformStream._backpressure === true) {
       return transformStream._backpressureChangePromise
-          .then(() => TransformStreamTransform(transformStream, chunk));
+          .then(() => {
+            if (transformStream._errored === true) {
+              return Promise.reject(transformStream._storedError);
+            }
+            return TransformStreamTransform(transformStream, chunk);
+          });
     }
 
     return TransformStreamTransform(transformStream, chunk);


### PR DESCRIPTION
If a TransformStream errored while the TransformStreamDefaultSink write() method
was waiting for backpressure to be relieved, it would assert inside
the TransformStreamStream operation.

Since it is not useful to call transform() once the stream is errored, return a
rejection from the write() method instead.

Also add a test for this case.