### PR TITLE
Remove assertion that RSDefaultControllerClose doesn't throw

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -106,11 +106,7 @@ function TransformStreamCloseReadableInternal(transformStream) {
   assert(transformStream._errored === false);
   assert(ReadableStreamDefaultControllerCanCloseOrEnqueue(transformStream._readableController) === true);
 
-  try {
-    ReadableStreamDefaultControllerClose(transformStream._readableController);
-  } catch (e) {
-    assert(false);
-  }
+  ReadableStreamDefaultControllerClose(transformStream._readableController);
 }
 
 function TransformStreamDefaultTransform(chunk, transformStreamController) {


### PR DESCRIPTION
ReadableStreamDefaultControllerClose is defined in the standard as "nothrow" but
TransformStreamCloseReadableInternal contains an assert that it doesn't
throw. The assertion that it doesn't throw is already implied by the "nothrow"
annotation. Since it is good to aim for a 1:1 relationship between the reference
implementation and the standard text, the reference implementation shouldn't
contain this assert either.

Removed.