### PR TITLE
Include "erroring" in the list of states for WritableStream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2746,7 +2746,7 @@ Instances of {{WritableStream}} are created with the internal slots described in
   <tr>
     <td>\[[state]]
     <td class="non-normative">A string containing the stream's current state, used internally; one of
-      <code>"writable"</code>, <code>"closed"</code>, or <code>"errored"</code>
+      <code>"writable"</code>, <code>"closed"</code>, <code>"erroring"</code>, or <code>"errored"</code>
   </tr>
   <tr>
     <td>\[[storedError]]
@@ -2766,7 +2766,7 @@ Instances of {{WritableStream}} are created with the internal slots described in
   <tr>
     <td>\[[writeRequests]]
     <td class="non-normative">A List of promises representing the stream's internal queue of write requests not yet
-      processed by the <a>underlying sink</a>.
+      processed by the <a>underlying sink</a>
   </tr>
 </table>
 


### PR DESCRIPTION
An "erroring" state was added to WritableStream in
e7bf9293 (https://github.com/whatwg/streams/pull/721) but was not included in
the description of the [[state]] slot. Add it.

Also remove a stray '.' from the description of the [[writeRequests]] slot.