### PR TITLE
Fix access to removed _errored and _storedError slots

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -290,9 +290,12 @@ class TransformStreamDefaultSink {
     if (transformStream._backpressure === true) {
       return transformStream._backpressureChangePromise
           .then(() => {
-            if (transformStream._errored === true) {
-              return Promise.reject(transformStream._storedError);
+            const writable = transformStream._writable;
+            const state = writable._state;
+            if (state === 'erroring') {
+              return Promise.reject(writable._storedError);
             }
+            assert(state === 'writable', 'state is `"writable"`');
             return TransformStreamTransform(transformStream, chunk);
           });
     }


### PR DESCRIPTION
Due to a merge error with https://github.com/whatwg/streams/pull/799 references
to the removed [[errored]] and [[storedError]] slots were mistakenly
re-introduced. Remove them.