### PR TITLE
Change the default highWaterMark for readableStrategy to 0

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -10,7 +10,7 @@ const { WritableStream, WritableStreamDefaultControllerErrorIfNeeded } = require
 // Class TransformStream
 
 class TransformStream {
-  constructor(transformer = {}, writableStrategy = undefined, { size, highWaterMark } = {}) {
+  constructor(transformer = {}, writableStrategy = undefined, { size, highWaterMark = 0 } = {}) {
     this._transformer = transformer;
 
     this._writableController = undefined;
@@ -20,11 +20,6 @@ class TransformStream {
     this._backpressure = undefined;
     this._backpressureChangePromise = undefined;
     this._backpressureChangePromise_resolve = undefined;
-
-    // Force default highWaterMark for readableStrategy to 0.
-    if (highWaterMark === undefined) {
-      highWaterMark = 0;
-    }
 
     this._transformStreamController = new TransformStreamDefaultController(this);
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -10,7 +10,7 @@ const { WritableStream, WritableStreamDefaultControllerErrorIfNeeded } = require
 // Class TransformStream
 
 class TransformStream {
-  constructor(transformer = {}, writableStrategy = undefined, readableStrategy = undefined) {
+  constructor(transformer = {}, writableStrategy = undefined, { size, highWaterMark } = {}) {
     this._transformer = transformer;
 
     this._writableController = undefined;
@@ -21,6 +21,11 @@ class TransformStream {
     this._backpressureChangePromise = undefined;
     this._backpressureChangePromise_resolve = undefined;
 
+    // Force default highWaterMark for readableStrategy to 0.
+    if (highWaterMark === undefined) {
+      highWaterMark = 0;
+    }
+
     this._transformStreamController = new TransformStreamDefaultController(this);
 
     let startPromise_resolve;
@@ -30,7 +35,7 @@ class TransformStream {
 
     const source = new TransformStreamDefaultSource(this, startPromise);
 
-    this._readable = new ReadableStream(source, readableStrategy);
+    this._readable = new ReadableStream(source, { size, highWaterMark });
 
     const sink = new TransformStreamDefaultSink(this, startPromise);
 

--- a/reference-implementation/to-upstream-wpts/transform-streams/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/errors.js
@@ -218,7 +218,7 @@ promise_test(t => {
     transform() {
       return transformPromise;
     }
-  }, { highWaterMark: 2 });
+  }, undefined, { highWaterMark: 2 });
   const writer = ts.writable.getWriter();
   return delay(0).then(() => {
     const writePromise = writer.write();

--- a/reference-implementation/to-upstream-wpts/transform-streams/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/errors.js
@@ -186,7 +186,7 @@ promise_test(t => {
       controller.close();
       throw thrownError;
     }
-  });
+  }, undefined, { highWaterMark: 1 });
   const writePromise = ts.writable.getWriter().write('a');
   const closedPromise = ts.readable.getReader().closed;
   return Promise.all([

--- a/reference-implementation/to-upstream-wpts/transform-streams/strategies.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/strategies.js
@@ -13,7 +13,7 @@ if (self.importScripts) {
 test(() => {
   const ts = new TransformStream({}, { highWaterMark: 17 });
   assert_equals(ts.writable.getWriter().desiredSize, 17, 'desiredSize should be 17');
-}, 'writableStrategy highWaterMark works');
+}, 'writableStrategy highWaterMark should work');
 
 promise_test(() => {
   const ts = recordingTransformStream({}, undefined, { highWaterMark: 9 });
@@ -27,7 +27,7 @@ promise_test(() => {
       'transform', 5, 'transform', 6, 'transform', 7, 'transform', 8],
                         'transform() should have been called 9 times');
   });
-}, 'readableStrategy highWaterMark works');
+}, 'readableStrategy highWaterMark should work');
 
 promise_test(t => {
   let writableSizeCalled = false;
@@ -61,6 +61,32 @@ promise_test(t => {
   return ts.writable.getWriter().write().then(() => {
     assert_true(transformCalled, 'transform() should be called');
   });
-}, 'writable has the correct size() function');
+}, 'writable should have the correct size() function');
+
+test(() => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'default writable HWM is 1');
+  // There should be no size function, but a size function that always returns 1 is indistinguishable.
+  writer.write(undefined);
+  assert_equals(writer.desiredSize, 0, 'default chunk size is 1');
+}, 'default writable strategy should be equivalent to { highWaterMark: 1 }');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      return t.step(() => {
+        assert_equals(controller.desiredSize, 0, 'desiredSize should be 0');
+        controller.enqueue(undefined);
+        // The first chunk enqueued is consumed by the pending read().
+        assert_equals(controller.desiredSize, 0, 'desiredSize should still be 0');
+        controller.enqueue(undefined);
+        assert_equals(controller.desiredSize, -1, 'desiredSize should be -1');
+      });
+    }
+  });
+  const writePromise = ts.writable.getWriter().write();
+  return ts.readable.getReader().read().then(() => writePromise);
+}, 'default readable strategy should be equivalent to { highWaterMark: 0 }');
 
 done();


### PR DESCRIPTION
The reduces "buffer bloat" in pipes. The most significant change is that
now be default transform() is called until something is read. In normal
use, TransformStream will be used in a pipe and a transform() will be
triggered immediately to fill the queue in the following writable. So the
difference from the point of view of everyday use is minimal.

If the highWaterMark passed to the TransformStream constructor is
undefined (or not present) it will be changed to zero before passing it
on to the ReadableStream constructor.

Some tests assumed that transform() would be called without anything
being read and so have been fixed. In most cases the tests were fixed by
supplying an explicit highWaterMark to the constructor.

Verify that default strategies have the expected values.

Closes #777.