### PR TITLE
Remove the check of the resolved value of _backpressurePromise

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -95,17 +95,11 @@ function TransformStreamSetBackpressure(stream, backpressure) {
          'TransformStreamSetBackpressure() should be called only when backpressure is changed');
 
   if (stream._backpressureChangePromise !== undefined) {
-    // The fulfillment value is just for a sanity check.
-    stream._backpressureChangePromise_resolve(backpressure);
+    stream._backpressureChangePromise_resolve();
   }
 
   stream._backpressureChangePromise = new Promise(resolve => {
     stream._backpressureChangePromise_resolve = resolve;
-  });
-
-  stream._backpressureChangePromise.then(resolution => {
-    assert(resolution !== backpressure,
-           '_backpressureChangePromise should be fulfilled only when backpressure is changed');
   });
 
   stream._backpressure = backpressure;


### PR DESCRIPTION
TransformStreamSetBackpressure would resolve _backpressurePromise with the
new value of `backpressure`, then a fulfillment handler would verify that this
is not equal to the old value. Since this is already guaranteed by the other
logic inside of TransformStreamSetBackpressure the benefit of this check is
small. On the other hand, the cost, in terms of having an additional fulfillment
handler, is high.

Remove this redundant sanity check.