### PR TITLE
TransformStream: Verify behaviour of abort() during write()

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/errors.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/errors.js
@@ -308,4 +308,19 @@ promise_test(t => {
   });
 }, 'erroring during write with backpressure should result in the write failing');
 
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+  return delay(0).then(() => {
+    const writer = ts.writable.getWriter();
+    // write should start synchronously
+    const writePromise = writer.write(0);
+    const abortPromise = writer.abort();
+    return promise_rejects(t, new TypeError(), ts.readable.getReader().read(), 'read() should reject')
+        .then(() => Promise.all([
+          promise_rejects(t, new TypeError(), writePromise, 'write() should reject'),
+          abortPromise
+        ]));
+  });
+}, 'a write() that was waiting for backpressure should reject if the writable is aborted');
+
 done();


### PR DESCRIPTION
A writer.write() call that was waiting for backpressure should reject if
the writable is aborted via abort() before it completes. Add a test to
verify this.