### PR TITLE
Add an extension point for byte transform streams

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -19,6 +19,18 @@ class TransformStream {
     this._backpressureChangePromise = undefined;
     this._backpressureChangePromise_resolve = undefined;
 
+    const readableType = transformer.readableType;
+
+    if (readableType !== undefined) {
+      throw new RangeError('Invalid readable type specified');
+    }
+
+    const writableType = transformer.writableType;
+
+    if (writableType !== undefined) {
+      throw new RangeError('Invalid writable type specified');
+    }
+
     this._transformStreamController = new TransformStreamDefaultController(this);
 
     let startPromise_resolve;

--- a/reference-implementation/to-upstream-wpts/transform-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/general.js
@@ -427,4 +427,12 @@ promise_test(() => {
   });
 }, 'start() should not be called twice');
 
+test(() => {
+  assert_throws(new RangeError(), new TransformStream({ readableType: 'bytes' }), 'constructor should throw');
+}, 'specifying a defined readableType should throw');
+
+test(() => {
+  assert_throws(new RangeError(), new TransformStream({ writableType: 'bytes' }), 'constructor should throw');
+}, 'specifying a defined writableType should throw');
+
 done();

--- a/reference-implementation/to-upstream-wpts/transform-streams/general.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/general.js
@@ -428,11 +428,11 @@ promise_test(() => {
 }, 'start() should not be called twice');
 
 test(() => {
-  assert_throws(new RangeError(), new TransformStream({ readableType: 'bytes' }), 'constructor should throw');
+  assert_throws(new RangeError(), () => new TransformStream({ readableType: 'bytes' }), 'constructor should throw');
 }, 'specifying a defined readableType should throw');
 
 test(() => {
-  assert_throws(new RangeError(), new TransformStream({ writableType: 'bytes' }), 'constructor should throw');
+  assert_throws(new RangeError(), () => new TransformStream({ writableType: 'bytes' }), 'constructor should throw');
 }, 'specifying a defined writableType should throw');
 
 done();


### PR DESCRIPTION
Prohibit non-undefined values of readableType and writableType properties
on the transformer to reserve them for future use defining byte
transforms.