### PR TITLE
Remove TransformStreamDefaultSinkDefaultTransform

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -54,6 +54,8 @@ function Call(F, V, args) {
   return Function.prototype.apply.call(F, V, args);
 }
 
+exports.Call = Call;
+
 exports.InvokeOrNoop = (O, P, args) => {
   assert(O !== undefined);
   assert(IsPropertyKey(P));
@@ -75,30 +77,6 @@ exports.PromiseInvokeOrNoop = (O, P, args) => {
     return Promise.resolve(exports.InvokeOrNoop(O, P, args));
   } catch (returnValueE) {
     return Promise.reject(returnValueE);
-  }
-};
-
-exports.PromiseInvokeOrPerformFallback = (O, P, args, F, argsF) => {
-  assert(O !== undefined);
-  assert(IsPropertyKey(P));
-  assert(Array.isArray(args));
-  assert(Array.isArray(argsF));
-
-  let method;
-  try {
-    method = O[P];
-  } catch (methodE) {
-    return Promise.reject(methodE);
-  }
-
-  if (method === undefined) {
-    return F(...argsF);
-  }
-
-  try {
-    return Promise.resolve(Call(method, O, args));
-  } catch (e) {
-    return Promise.reject(e);
   }
 };
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -299,14 +299,14 @@ function TransformStreamDefaultSinkInvokeTransform(stream, chunk) {
   const controller = stream._transformStreamController;
   const transformer = stream._transformer;
 
-  const method = transformer.transform; // throws
+  const method = transformer.transform; // can throw
 
   if (method === undefined) {
-    TransformStreamDefaultControllerEnqueue(controller, chunk); // throws
-    return undefined; // explicit "undefined" to keep eslint happy.
+    TransformStreamDefaultControllerEnqueue(controller, chunk); // can throw
+    return undefined;
   }
 
-  return Call(method, transformer, [chunk, controller]); // throws
+  return Call(method, transformer, [chunk, controller]); // can throw
 }
 
 function TransformStreamDefaultSinkTransform(sink, chunk) {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const { InvokeOrNoop, PromiseInvokeOrPerformFallback, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
+const { Call, InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
 const { ReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -295,9 +295,18 @@ class TransformStreamDefaultSink {
   }
 }
 
-function TransformStreamDefaultSinkDefaultTransform(chunk, controller) {
-  TransformStreamDefaultControllerEnqueue(controller, chunk);
-  return Promise.resolve();
+function TransformStreamDefaultSinkInvokeTransform(stream, chunk) {
+  const controller = stream._transformStreamController;
+  const transformer = stream._transformer;
+
+  const method = transformer.transform; // throws
+
+  if (method === undefined) {
+    TransformStreamDefaultControllerEnqueue(controller, chunk); // throws
+    return undefined; // explicit "undefined" to keep eslint happy.
+  }
+
+  return Call(method, transformer, [chunk, controller]); // throws
 }
 
 function TransformStreamDefaultSinkTransform(sink, chunk) {
@@ -308,17 +317,20 @@ function TransformStreamDefaultSinkTransform(sink, chunk) {
   assert(stream._readable._state !== 'errored');
   assert(stream._backpressure === false);
 
-  const controller = stream._transformStreamController;
+  let transformPromise;
+  try {
+    // TransformStreamDefaultSinkInvokeTransform is a separate operation to permit consolidating the abrupt completion
+    // handling in one place in the text of the standard.
+    const transformResult = TransformStreamDefaultSinkInvokeTransform(stream, chunk);
+    transformPromise = Promise.resolve(transformResult);
+  } catch (e) {
+    transformPromise = Promise.reject(e);
+  }
 
-  const transformPromise = PromiseInvokeOrPerformFallback(stream._transformer, 'transform', [chunk, controller],
-                             TransformStreamDefaultSinkDefaultTransform, [chunk, controller]);
-
-  return transformPromise.then(
-      undefined,
-      e => {
-        TransformStreamError(stream, e);
-        throw e;
-      });
+  return transformPromise.catch(e => {
+    TransformStreamError(stream, e);
+    throw e;
+  });
 }
 
 // Class TransformStreamDefaultSource


### PR DESCRIPTION
TransformStreamDefaultSinkDefaultTransform was confusing and not very
useful. Replace it with TransformStreamDefaultSinkInvokeTransform, which
replaces the functionality of both that and
PromiseInvokeOrPerformFallback. Modify
TransformStreamDefaultSinkTransform to call the new function inside a try
block.

Remove PromiseInvokeOrPerformFallback as it no longer has any callers.

No semantic changes.