### PR TITLE
Make error() and terminate() do nothing when stream is errored

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -152,10 +152,6 @@ class TransformStreamDefaultController {
       throw defaultControllerBrandCheckException('error');
     }
 
-    if (this._controlledTransformStream._readable._state !== 'readable') {
-      throw new TypeError('TransformStream is not in a state that can be errored');
-    }
-
     TransformStreamDefaultControllerError(this, reason);
   }
 }
@@ -179,11 +175,11 @@ function TransformStreamDefaultControllerTerminate(controller) {
 
   const stream = controller._controlledTransformStream;
   const readableController = stream._readable._readableStreamController;
-  if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === false) {
-    throw new TypeError('Readable side is not in a state that can be closed');
+
+  if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === true) {
+    ReadableStreamDefaultControllerClose(readableController);
   }
 
-  ReadableStreamDefaultControllerClose(readableController);
   WritableStreamDefaultControllerErrorIfNeeded(stream._writable._writableStreamController,
                                                new TypeError('TransformStream terminated'));
   if (stream._backpressure === true) {
@@ -222,8 +218,6 @@ function TransformStreamDefaultControllerEnqueue(controller, chunk) {
 
 function TransformStreamDefaultControllerError(controller, e) {
   const stream = controller._controlledTransformStream;
-
-  assert(stream._readable._state === 'readable', 'stream.[[readable]].[[state]] is "readable"');
 
   TransformStreamError(stream, e);
 }

--- a/reference-implementation/to-upstream-wpts/transform-streams/terminate.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/terminate.js
@@ -74,13 +74,18 @@ promise_test(t => {
   ]);
 }, 'controller.error() after controller.terminate() with queued chunk should error the readable');
 
-test(() => {
-  new TransformStream({
+promise_test(t => {
+  const ts = new TransformStream({
     start(controller) {
       controller.terminate();
-      assert_throws(new TypeError(), () => controller.error(error1), 'error() should throw');
+      controller.error(error1);
     }
   });
-}, 'controller.error() after controller.terminate() without queued chunk should throw');
+  return Promise.all([
+    promise_rejects(t, new TypeError(), ts.writable.abort(), 'abort() should reject with a TypeError'),
+    ts.readable.cancel(),
+    ts.readable.getReader().closed
+  ]);
+}, 'controller.error() after controller.terminate() without queued chunk should do nothing');
 
 done();


### PR DESCRIPTION
Previously error() and terminate() would throw an exception if the
readable was closed, errored or pending close. This wasn't useful, so
make them just do nothing in those cases instead.

Closes #822.