### PR TITLE
Test terminate() and error() inside flush()

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/flush.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/flush.js
@@ -115,4 +115,16 @@ promise_test(() => {
   ]);
 }, 'TransformStream flush gets a chance to enqueue more into the readable, and can then async close');
 
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    flush(controller) {
+      controller.error(error1);
+    }
+  });
+  return promise_rejects(t, error1, ts.writable.getWriter().close(), 'close() should reject');
+}, 'error() during flush should cause writer.close() to reject');
+
 done();

--- a/reference-implementation/to-upstream-wpts/transform-streams/terminate.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/terminate.js
@@ -83,4 +83,18 @@ test(() => {
   });
 }, 'controller.error() after controller.terminate() without queued chunk should throw');
 
+promise_test(() => {
+  const ts = new TransformStream({
+    flush(controller) {
+      controller.terminate();
+    }
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([
+    writer.close(),
+    writer.closed,
+    ts.readable.getReader().closed
+  ]);
+}, 'controller.terminate() inside flush() should not prevent writer.close() from succeeding');
+
 done();


### PR DESCRIPTION
controller.terminate() and controller.error() were not tested inside the
transformer flush() method. Test them.