### PR TITLE
Add a local variable to TransformStreamDefaultSink abort()

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -267,7 +267,8 @@ class TransformStreamDefaultSink {
   abort() {
     // abort() is not called synchronously, so it is possible for abort() to be called when the stream is already
     // errored.
-    TransformStreamError(this._ownerTransformStream, new TypeError('Writable side aborted'));
+    const e = new TypeError('Writable side aborted');
+    TransformStreamError(this._ownerTransformStream, e);
   }
 
   close() {


### PR DESCRIPTION
In standard text it is awkward to create an exception object and pass it to an
internal operation in a single step. Add a local to abort() in which the
newly-created TypeError will be placed. This will make the standard text clearer.