### PR TITLE
Remove inaccurate note about ReadableStreamDefaultControllerEnqueue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1851,6 +1851,13 @@ nothrow>ReadableStreamDefaultControllerCanCloseOrEnqueue ( <var>controller</var>
   1. Otherwise, return *false*.
 </emu-alg>
 
+<div class="note">
+  The case where <var>stream</var>.\[[closeRequested]] is <emu-val>false</emu-val>, but <var>stream</var>.\[[state]] is
+  not <code>"readable"</code>, happens when the stream is errored via {{ReadableStreamDefaultController/error(e)}}, or
+  when it is closed without its controller's <code>close</code> method ever being called: e.g., if the stream was closed
+  by a call to {{ReadableStream/cancel(reason)}}.
+</div>
+
 <h3 id="rbs-controller-class" interface lt="ReadableByteStreamController">Class
 <code>ReadableByteStreamController</code></h3>
 

--- a/index.bs
+++ b/index.bs
@@ -1793,14 +1793,6 @@ asserts).
   1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
 </emu-alg>
 
-<div class="note">
-  The case where <var>stream</var>.\[[state]] is <code>"closed"</code>, but <var>stream</var>.\[[closeRequested]]
-  is <emu-val>false</emu-val>, will happen if the stream was closed without its controller's close method ever being
-  called: i.e., if the stream was closed by a call to {{ReadableStream/cancel(reason)}}. In this case we allow the
-  controller's <code>enqueue</code> method to be called and silently do nothing, since the cancelation was outside the
-  control of the underlying source.
-</div>
-
 <h4 id="readable-stream-default-controller-error" aoid="ReadableStreamDefaultControllerError" nothrow
 export>ReadableStreamDefaultControllerError ( <var>controller</var>, <var>e</var> )</h4>
 


### PR DESCRIPTION
ReadableStreamDefaultControllerEnqueue has a note indicating that it
could be called when the stream was closed without an exception being
thrown. This hasn't been true since December 2015. Remove the inaccurate
note.

Fixes #824.