### PR TITLE
Switch from "assert" to "better-assert" in reference implementation

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('better-assert');
 
 const isFakeDetached = Symbol('is "detached" for our purposes');
 

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('better-assert');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
 exports.DequeueValue = container => {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('better-assert');
 const { ArrayBufferCopy, CreateIterResultObject, IsFiniteNonNegativeNumber, InvokeOrNoop, IsDetachedBuffer,
         PromiseInvokeOrNoop, TransferArrayBuffer, ValidateAndNormalizeQueuingStrategy,
         ValidateAndNormalizeHighWaterMark } = require('./helpers.js');

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('better-assert');
 const { Call, InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
 const { ReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,

--- a/reference-implementation/lib/utils.js
+++ b/reference-implementation/lib/utils.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('better-assert');
 
 exports.rethrowAssertionErrorRejection = e => {
   // Used throughout the reference implementation, as `.catch(rethrowAssertionErrorRejection)`, to ensure any errors

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('better-assert');
 const { InvokeOrNoop, PromiseInvokeOrNoop, ValidateAndNormalizeQueuingStrategy, typeIsObject } =
   require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "(CC0-1.0 OR MIT)",
   "devDependencies": {
+    "better-assert": "^1.0.2",
     "eslint": "^3.2.2",
     "glob": "^7.0.3",
     "minimatch": "^3.0.3",


### PR DESCRIPTION
The "better-assert" implementation of assert() includes the failed
predicate and stack trace in the output. This makes it much easier to
track down assertion failures.

No functional changes.

Resolves #807.