### PR TITLE
Use "debug" package for logging

### DIFF
--- a/reference-implementation/README.md
+++ b/reference-implementation/README.md
@@ -22,7 +22,7 @@ Diagnostic output is provided using the [debug](https://www.npmjs.com/package/de
 DEBUG=streams:* npm test
 ```
 
-See [lib/transform-stream.js](https://github.com/whatwg/streams/blob/master/reference-implementation/lib/transform-stream.js) for examples of how debug statements are used. Diagnostic coverage is sparse at the moment; we expect to add more diagnostics in an ad hoc manner as they are needed.
+See [lib/transform-stream.js](lib/transform-stream.js) for examples of how debug statements are used. Diagnostic coverage is sparse at the moment; we expect to add more diagnostics in an ad hoc manner as they are needed.
 
 ### Web platform tests
 

--- a/reference-implementation/README.md
+++ b/reference-implementation/README.md
@@ -14,16 +14,6 @@ You can check the test coverage at any time by running `npm run coverage` in thi
 
 To run all tests (and the lint step), run `npm test` in this folder.
 
-## Diagnostics
-
-Diagnostic output is provided using the [debug](https://www.npmjs.com/package/debug) package. It is useful to understand the behaviour of the reference implementation, particularly in tests that exercise asynchronous behaviour. To enable, set the DEBUG environment variable. For example, in Bash,
-
-```bash
-DEBUG=streams:* npm test
-```
-
-See [lib/transform-stream.js](lib/transform-stream.js) for examples of how debug statements are used. Diagnostic coverage is sparse at the moment; we expect to add more diagnostics in an ad hoc manner as they are needed.
-
 ### Web platform tests
 
 The test suite for this standard is written in [web platform tests](https://github.com/w3c/web-platform-tests) format.
@@ -60,3 +50,13 @@ Note that when creating a new test file, you should generate the four wrapper en
 ```
 node web-platform-tests/streams/generate-test-wrappers.js to-upstream-wpts/my-test-file.js
 ```
+
+## Diagnostics
+
+Diagnostic output is provided using the [debug](https://www.npmjs.com/package/debug) package. It is useful to understand the behaviour of the reference implementation, particularly in tests that exercise asynchronous behaviour. To enable, set the DEBUG environment variable. For example, in Bash,
+
+```bash
+DEBUG=streams:* npm test
+```
+
+See [lib/transform-stream.js](lib/transform-stream.js) for examples of how debug statements are used. Diagnostic coverage is sparse at the moment; we expect to add more diagnostics in an ad-hoc manner as they are needed.

--- a/reference-implementation/README.md
+++ b/reference-implementation/README.md
@@ -14,6 +14,16 @@ You can check the test coverage at any time by running `npm run coverage` in thi
 
 To run all tests (and the lint step), run `npm test` in this folder.
 
+## Diagnostics
+
+Diagnostic output is provided using the [debug](https://www.npmjs.com/package/debug) package. It is useful to understand the behaviour of the reference implementation, particularly in tests that exercise asynchronous behaviour. To enable, set the DEBUG environment variable. For example, in Bash,
+
+```bash
+DEBUG=streams:* npm test
+```
+
+See [lib/transform-stream.js](https://github.com/whatwg/streams/blob/master/reference-implementation/lib/transform-stream.js) for examples of how debug statements are used. Diagnostic coverage is sparse at the moment; we expect to add more diagnostics in an ad hoc manner as they are needed.
+
 ### Web platform tests
 
 The test suite for this standard is written in [web platform tests](https://github.com/w3c/web-platform-tests) format.

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,5 +1,9 @@
 'use strict';
 const assert = require('better-assert');
+
+// Calls to verbose() are purely for debugging the reference implementation and tests. They are not part of the standard
+// and do not appear in the standard text.
+const verbose = require('debug')('streams:transform-stream:verbose');
 const { Call, InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
 const { ReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
@@ -85,7 +89,7 @@ function IsTransformStream(x) {
 
 // This is a no-op if both sides are already errored.
 function TransformStreamError(stream, e) {
-  // console.log('TransformStreamError()');
+  verbose('TransformStreamError()');
 
   WritableStreamDefaultControllerErrorIfNeeded(stream._writable._writableStreamController, e);
   if (stream._readable._state === 'readable') {
@@ -100,7 +104,7 @@ function TransformStreamError(stream, e) {
 }
 
 function TransformStreamSetBackpressure(stream, backpressure) {
-  // console.log(`TransformStreamSetBackpressure(${backpressure})`);
+  verbose(`TransformStreamSetBackpressure(${backpressure})`);
 
   // Passes also when called during construction.
   assert(stream._backpressure !== backpressure);
@@ -182,7 +186,7 @@ function IsTransformStreamDefaultController(x) {
 }
 
 function TransformStreamDefaultControllerTerminate(controller) {
-  // console.log('TransformStreamDefaultControllerTerminate()');
+  verbose('TransformStreamDefaultControllerTerminate()');
 
   const stream = controller._controlledTransformStream;
   const readableController = stream._readable._readableStreamController;
@@ -200,7 +204,7 @@ function TransformStreamDefaultControllerTerminate(controller) {
 }
 
 function TransformStreamDefaultControllerEnqueue(controller, chunk) {
-  // console.log('TransformStreamDefaultControllerEnqueue()');
+  verbose('TransformStreamDefaultControllerEnqueue()');
 
   const stream = controller._controlledTransformStream;
   const readableController = stream._readable._readableStreamController;
@@ -246,7 +250,7 @@ class TransformStreamDefaultSink {
   }
 
   write(chunk) {
-    // console.log('TransformStreamDefaultSink.write()');
+    verbose('TransformStreamDefaultSink.write()');
 
     const stream = this._ownerTransformStream;
     assert(stream._writable._state === 'writable');
@@ -277,7 +281,7 @@ class TransformStreamDefaultSink {
   }
 
   close() {
-    // console.log('TransformStreamDefaultSink.close()');
+    verbose('TransformStreamDefaultSink.close()');
 
     const stream = this._ownerTransformStream;
 
@@ -316,7 +320,7 @@ function TransformStreamDefaultSinkInvokeTransform(stream, chunk) {
 }
 
 function TransformStreamDefaultSinkTransform(sink, chunk) {
-  // console.log('TransformStreamDefaultSinkTransform()');
+  verbose('TransformStreamDefaultSinkTransform()');
 
   const stream = sink._ownerTransformStream;
 
@@ -334,9 +338,9 @@ function TransformStreamDefaultSinkTransform(sink, chunk) {
   }
 
   return transformPromise.catch(e => {
-    TransformStreamError(stream, e);
-    throw e;
-  });
+        TransformStreamError(stream, e);
+        throw e;
+      });
 }
 
 // Class TransformStreamDefaultSource
@@ -352,7 +356,7 @@ class TransformStreamDefaultSource {
   }
 
   pull() {
-    // console.log('TransformStreamDefaultSource.pull()');
+    verbose('TransformStreamDefaultSource.pull()');
 
     const stream = this._ownerTransformStream;
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -338,9 +338,9 @@ function TransformStreamDefaultSinkTransform(sink, chunk) {
   }
 
   return transformPromise.catch(e => {
-        TransformStreamError(stream, e);
-        throw e;
-      });
+    TransformStreamError(stream, e);
+    throw e;
+  });
 }
 
 // Class TransformStreamDefaultSource

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -104,7 +104,7 @@ function TransformStreamError(stream, e) {
 }
 
 function TransformStreamSetBackpressure(stream, backpressure) {
-  verbose(`TransformStreamSetBackpressure(${backpressure})`);
+  verbose(`TransformStreamSetBackpressure() [backpressure = ${backpressure}]`);
 
   // Passes also when called during construction.
   assert(stream._backpressure !== backpressure);
@@ -250,7 +250,7 @@ class TransformStreamDefaultSink {
   }
 
   write(chunk) {
-    verbose('TransformStreamDefaultSink.write()');
+    verbose('TransformStreamDefaultSink.prototype.write()');
 
     const stream = this._ownerTransformStream;
     assert(stream._writable._state === 'writable');
@@ -281,7 +281,7 @@ class TransformStreamDefaultSink {
   }
 
   close() {
-    verbose('TransformStreamDefaultSink.close()');
+    verbose('TransformStreamDefaultSink.prototype.close()');
 
     const stream = this._ownerTransformStream;
 
@@ -356,7 +356,7 @@ class TransformStreamDefaultSource {
   }
 
   pull() {
-    verbose('TransformStreamDefaultSource.pull()');
+    verbose('TransformStreamDefaultSource.prototype.pull()');
 
     const stream = this._ownerTransformStream;
 

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -12,6 +12,7 @@
   "license": "(CC0-1.0 OR MIT)",
   "devDependencies": {
     "better-assert": "^1.0.2",
+    "debug": "^3.1.0",
     "eslint": "^3.2.2",
     "minimatch": "^3.0.4",
     "nyc": "^11.2.1",


### PR DESCRIPTION
Use the "debug" package https://www.npmjs.com/package/debug for logging.

Debugging can be enabled by setting the DEBUG environment variable, for example

  DEBUG=streams:* npm test

This change converts existed commented-out log statements in
transform-streams.js to use the debug package. No new logging statements are
included in this change.

It is anticipated that new logging statements will be added as and when a need
for them is found.

Closes #499.