### PR TITLE
Remove assert() descriptions

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -82,7 +82,7 @@ exports.PromiseInvokeOrNoop = (O, P, args) => {
 
 // Not implemented correctly
 exports.TransferArrayBuffer = O => {
-  assert(!exports.IsDetachedBuffer(O), 'Cannot transfer a previously detached ArrayBuffer');
+  assert(!exports.IsDetachedBuffer(O));
   const transferredIshVersion = O.slice();
 
   // This is specifically to fool tests that test "is transferred" by taking a non-zero-length

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -3,9 +3,8 @@ const assert = require('better-assert');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
 exports.DequeueValue = container => {
-  assert('_queue' in container && '_queueTotalSize' in container,
-    'Spec-level failure: DequeueValue should only be used on containers with [[queue]] and [[queueTotalSize]].');
-  assert(container._queue.length > 0, 'Spec-level failure: should never dequeue from an empty queue.');
+  assert('_queue' in container && '_queueTotalSize' in container);
+  assert(container._queue.length > 0);
 
   const pair = container._queue.shift();
   container._queueTotalSize -= pair.size;
@@ -17,9 +16,7 @@ exports.DequeueValue = container => {
 };
 
 exports.EnqueueValueWithSize = (container, value, size) => {
-  assert('_queue' in container && '_queueTotalSize' in container,
-    'Spec-level failure: EnqueueValueWithSize should only be used on containers with [[queue]] and ' +
-    '[[queueTotalSize]].');
+  assert('_queue' in container && '_queueTotalSize' in container);
 
   size = Number(size);
   if (!IsFiniteNonNegativeNumber(size)) {
@@ -31,17 +28,15 @@ exports.EnqueueValueWithSize = (container, value, size) => {
 };
 
 exports.PeekQueueValue = container => {
-  assert('_queue' in container && '_queueTotalSize' in container,
-    'Spec-level failure: PeekQueueValue should only be used on containers with [[queue]] and [[queueTotalSize]].');
-  assert(container._queue.length > 0, 'Spec-level failure: should never peek at an empty queue.');
+  assert('_queue' in container && '_queueTotalSize' in container);
+  assert(container._queue.length > 0);
 
   const pair = container._queue[0];
   return pair.value;
 };
 
 exports.ResetQueue = container => {
-  assert('_queue' in container && '_queueTotalSize' in container,
-    'Spec-level failure: ResetQueue should only be used on containers with [[queue]] and [[queueTotalSize]].');
+  assert('_queue' in container && '_queueTotalSize' in container);
 
   container._queue = [];
   container._queueTotalSize = 0;

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -302,13 +302,13 @@ function IsReadableStream(x) {
 }
 
 function IsReadableStreamDisturbed(stream) {
-  assert(IsReadableStream(stream) === true, 'IsReadableStreamDisturbed should only be used on known readable streams');
+  assert(IsReadableStream(stream) === true);
 
   return stream._disturbed;
 }
 
 function IsReadableStreamLocked(stream) {
-  assert(IsReadableStream(stream) === true, 'IsReadableStreamLocked should only be used on known readable streams');
+  assert(IsReadableStream(stream) === true);
 
   if (stream._reader === undefined) {
     return false;
@@ -525,8 +525,8 @@ function ReadableStreamClose(stream) {
 }
 
 function ReadableStreamError(stream, e) {
-  assert(IsReadableStream(stream) === true, 'stream must be ReadableStream');
-  assert(stream._state === 'readable', 'state must be readable');
+  assert(IsReadableStream(stream) === true);
+  assert(stream._state === 'readable');
 
   stream._state = 'errored';
   stream._storedError = e;
@@ -544,7 +544,7 @@ function ReadableStreamError(stream, e) {
 
     reader._readRequests = [];
   } else {
-    assert(IsReadableStreamBYOBReader(reader), 'reader must be ReadableStreamBYOBReader');
+    assert(IsReadableStreamBYOBReader(reader));
 
     for (const readIntoRequest of reader._readIntoRequests) {
       readIntoRequest._reject(e);
@@ -791,7 +791,7 @@ function ReadableStreamReaderGenericInitialize(reader, stream) {
   } else if (stream._state === 'closed') {
     defaultReaderClosedPromiseInitializeAsResolved(reader);
   } else {
-    assert(stream._state === 'errored', 'state must be errored');
+    assert(stream._state === 'errored');
 
     defaultReaderClosedPromiseInitializeAsRejected(reader, stream._storedError);
     reader._closedPromise.catch(() => {});
@@ -1479,7 +1479,7 @@ function ReadableByteStreamControllerClearPendingPullIntos(controller) {
 }
 
 function ReadableByteStreamControllerCommitPullIntoDescriptor(stream, pullIntoDescriptor) {
-  assert(stream._state !== 'errored', 'state must not be errored');
+  assert(stream._state !== 'errored');
 
   let done = false;
   if (stream._state === 'closed') {
@@ -1553,7 +1553,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
   }
 
   if (ready === false) {
-    assert(controller._queueTotalSize === 0, 'queue must be empty');
+    assert(controller._queueTotalSize === 0);
     assert(pullIntoDescriptor.bytesFilled > 0);
     assert(pullIntoDescriptor.bytesFilled < pullIntoDescriptor.elementSize);
   }
@@ -1671,7 +1671,7 @@ function ReadableByteStreamControllerPullInto(controller, view) {
 function ReadableByteStreamControllerRespondInClosedState(controller, firstDescriptor) {
   firstDescriptor.buffer = TransferArrayBuffer(firstDescriptor.buffer);
 
-  assert(firstDescriptor.bytesFilled === 0, 'bytesFilled must be 0');
+  assert(firstDescriptor.bytesFilled === 0);
 
   const stream = controller._controlledReadableStream;
   if (ReadableStreamHasBYOBReader(stream) === true) {
@@ -1816,7 +1816,7 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
     ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
   } else {
-    assert(IsReadableStreamLocked(stream) === false, 'stream must not be locked');
+    assert(IsReadableStreamLocked(stream) === false);
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
   }
 }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -103,8 +103,7 @@ function TransformStreamSetBackpressure(stream, backpressure) {
   // console.log(`TransformStreamSetBackpressure(${backpressure})`);
 
   // Passes also when called during construction.
-  assert(stream._backpressure !== backpressure,
-         'TransformStreamSetBackpressure() should be called only when backpressure is changed');
+  assert(stream._backpressure !== backpressure);
 
   if (stream._backpressureChangePromise !== undefined) {
     stream._backpressureChangePromise_resolve();
@@ -223,7 +222,7 @@ function TransformStreamDefaultControllerEnqueue(controller, chunk) {
 
   const backpressure = ReadableStreamDefaultControllerHasBackpressure(readableController);
   if (backpressure !== stream._backpressure) {
-    assert(backpressure === true, 'backpressure is *true*');
+    assert(backpressure === true);
     TransformStreamSetBackpressure(stream, true);
   }
 }
@@ -250,11 +249,11 @@ class TransformStreamDefaultSink {
     // console.log('TransformStreamDefaultSink.write()');
 
     const stream = this._ownerTransformStream;
-    assert(stream._writable._state === 'writable', 'stream.[[writable]].[[state]] is `"writable"`');
+    assert(stream._writable._state === 'writable');
 
     if (stream._backpressure === true) {
       const backpressureChangePromise = stream._backpressureChangePromise;
-      assert(backpressureChangePromise !== undefined, '_backpressureChangePromise should have been initialized');
+      assert(backpressureChangePromise !== undefined);
       return backpressureChangePromise
           .then(() => {
             const writable = stream._writable;
@@ -262,7 +261,7 @@ class TransformStreamDefaultSink {
             if (state === 'erroring') {
               throw writable._storedError;
             }
-            assert(state === 'writable', 'state is `"writable"`');
+            assert(state === 'writable');
             return TransformStreamDefaultSinkTransform(this, chunk);
           });
     }
@@ -358,10 +357,9 @@ class TransformStreamDefaultSource {
     const stream = this._ownerTransformStream;
 
     // Invariant. Enforced by the promises returned by start() and pull().
-    assert(stream._backpressure === true, 'pull() should be never called while _backpressure is false');
+    assert(stream._backpressure === true);
 
-    assert(stream._backpressureChangePromise !== undefined,
-           '_backpressureChangePromise should have been initialized');
+    assert(stream._backpressureChangePromise !== undefined);
 
     TransformStreamSetBackpressure(stream, false);
 

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -116,7 +116,7 @@ function IsWritableStream(x) {
 }
 
 function IsWritableStreamLocked(stream) {
-  assert(IsWritableStream(stream) === true, 'IsWritableStreamLocked should only be used on known writable streams');
+  assert(IsWritableStream(stream) === true);
 
   if (stream._writer === undefined) {
     return false;
@@ -138,7 +138,7 @@ function WritableStreamAbort(stream, reason) {
     return Promise.reject(error);
   }
 
-  assert(state === 'writable' || state === 'erroring', 'state must be writable or erroring');
+  assert(state === 'writable' || state === 'erroring');
 
   let wasAlreadyErroring = false;
   if (state === 'erroring') {
@@ -194,11 +194,11 @@ function WritableStreamDealWithRejection(stream, error) {
 }
 
 function WritableStreamStartErroring(stream, reason) {
-  assert(stream._storedError === undefined, 'stream._storedError === undefined');
-  assert(stream._state === 'writable', 'state must be writable');
+  assert(stream._storedError === undefined);
+  assert(stream._state === 'writable');
 
   const controller = stream._writableStreamController;
-  assert(controller !== undefined, 'controller must not be undefined');
+  assert(controller !== undefined);
 
   stream._state = 'erroring';
   stream._storedError = reason;
@@ -213,9 +213,8 @@ function WritableStreamStartErroring(stream, reason) {
 }
 
 function WritableStreamFinishErroring(stream) {
-  assert(stream._state === 'erroring', 'stream._state === erroring');
-  assert(WritableStreamHasOperationMarkedInFlight(stream) === false,
-         'WritableStreamHasOperationMarkedInFlight(stream) === false');
+  assert(stream._state === 'erroring');
+  assert(WritableStreamHasOperationMarkedInFlight(stream) === false);
   stream._state = 'errored';
   stream._writableStreamController[ErrorSteps]();
 
@@ -292,8 +291,8 @@ function WritableStreamFinishInFlightClose(stream) {
     defaultWriterClosedPromiseResolve(writer);
   }
 
-  assert(stream._pendingAbortRequest === undefined, 'stream._pendingAbortRequest === undefined');
-  assert(stream._storedError === undefined, 'stream._storedError === undefined');
+  assert(stream._pendingAbortRequest === undefined);
+  assert(stream._storedError === undefined);
 }
 
 function WritableStreamFinishInFlightCloseWithError(stream, error) {
@@ -336,13 +335,13 @@ function WritableStreamMarkCloseRequestInFlight(stream) {
 }
 
 function WritableStreamMarkFirstWriteRequestInFlight(stream) {
-  assert(stream._inFlightWriteRequest === undefined, 'there must be no pending write request');
-  assert(stream._writeRequests.length !== 0, 'writeRequests must not be empty');
+  assert(stream._inFlightWriteRequest === undefined);
+  assert(stream._writeRequests.length !== 0);
   stream._inFlightWriteRequest = stream._writeRequests.shift();
 }
 
 function WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
-  assert(stream._state === 'errored', '_stream_.[[state]] is `"errored"`');
+  assert(stream._state === 'errored');
   if (stream._closeRequest !== undefined) {
     assert(stream._inFlightCloseRequest === undefined);
 
@@ -404,7 +403,7 @@ class WritableStreamDefaultWriter {
       defaultWriterReadyPromiseInitializeAsResolved(this);
       defaultWriterClosedPromiseInitializeAsResolved(this);
     } else {
-      assert(state === 'errored', 'state must be errored');
+      assert(state === 'errored');
 
       const storedError = stream._storedError;
       defaultWriterReadyPromiseInitializeAsRejected(this, storedError);
@@ -837,7 +836,7 @@ function WritableStreamDefaultControllerProcessClose(controller) {
   WritableStreamMarkCloseRequestInFlight(stream);
 
   DequeueValue(controller);
-  assert(controller._queue.length === 0, 'queue must be empty once the final write record is dequeued');
+  assert(controller._queue.length === 0);
 
   const sinkClosePromise = PromiseInvokeOrNoop(controller._underlyingSink, 'close', []);
   sinkClosePromise.then(
@@ -935,9 +934,9 @@ function defaultWriterClosedPromiseInitializeAsResolved(writer) {
 }
 
 function defaultWriterClosedPromiseReject(writer, reason) {
-  assert(writer._closedPromise_resolve !== undefined, 'writer._closedPromise_resolve !== undefined');
-  assert(writer._closedPromise_reject !== undefined, 'writer._closedPromise_reject !== undefined');
-  assert(writer._closedPromiseState === 'pending', 'writer._closedPromiseState is pending');
+  assert(writer._closedPromise_resolve !== undefined);
+  assert(writer._closedPromise_reject !== undefined);
+  assert(writer._closedPromiseState === 'pending');
 
   writer._closedPromise_reject(reason);
   writer._closedPromise_resolve = undefined;
@@ -946,18 +945,18 @@ function defaultWriterClosedPromiseReject(writer, reason) {
 }
 
 function defaultWriterClosedPromiseResetToRejected(writer, reason) {
-  assert(writer._closedPromise_resolve === undefined, 'writer._closedPromise_resolve === undefined');
-  assert(writer._closedPromise_reject === undefined, 'writer._closedPromise_reject === undefined');
-  assert(writer._closedPromiseState !== 'pending', 'writer._closedPromiseState is not pending');
+  assert(writer._closedPromise_resolve === undefined);
+  assert(writer._closedPromise_reject === undefined);
+  assert(writer._closedPromiseState !== 'pending');
 
   writer._closedPromise = Promise.reject(reason);
   writer._closedPromiseState = 'rejected';
 }
 
 function defaultWriterClosedPromiseResolve(writer) {
-  assert(writer._closedPromise_resolve !== undefined, 'writer._closedPromise_resolve !== undefined');
-  assert(writer._closedPromise_reject !== undefined, 'writer._closedPromise_reject !== undefined');
-  assert(writer._closedPromiseState === 'pending', 'writer._closedPromiseState is pending');
+  assert(writer._closedPromise_resolve !== undefined);
+  assert(writer._closedPromise_reject !== undefined);
+  assert(writer._closedPromiseState === 'pending');
 
   writer._closedPromise_resolve(undefined);
   writer._closedPromise_resolve = undefined;
@@ -988,8 +987,8 @@ function defaultWriterReadyPromiseInitializeAsResolved(writer) {
 }
 
 function defaultWriterReadyPromiseReject(writer, reason) {
-  assert(writer._readyPromise_resolve !== undefined, 'writer._readyPromise_resolve !== undefined');
-  assert(writer._readyPromise_reject !== undefined, 'writer._readyPromise_reject !== undefined');
+  assert(writer._readyPromise_resolve !== undefined);
+  assert(writer._readyPromise_reject !== undefined);
 
   writer._readyPromise_reject(reason);
   writer._readyPromise_resolve = undefined;
@@ -998,8 +997,8 @@ function defaultWriterReadyPromiseReject(writer, reason) {
 }
 
 function defaultWriterReadyPromiseReset(writer) {
-  assert(writer._readyPromise_resolve === undefined, 'writer._readyPromise_resolve === undefined');
-  assert(writer._readyPromise_reject === undefined, 'writer._readyPromise_reject === undefined');
+  assert(writer._readyPromise_resolve === undefined);
+  assert(writer._readyPromise_reject === undefined);
 
   writer._readyPromise = new Promise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
@@ -1009,16 +1008,16 @@ function defaultWriterReadyPromiseReset(writer) {
 }
 
 function defaultWriterReadyPromiseResetToRejected(writer, reason) {
-  assert(writer._readyPromise_resolve === undefined, 'writer._readyPromise_resolve === undefined');
-  assert(writer._readyPromise_reject === undefined, 'writer._readyPromise_reject === undefined');
+  assert(writer._readyPromise_resolve === undefined);
+  assert(writer._readyPromise_reject === undefined);
 
   writer._readyPromise = Promise.reject(reason);
   writer._readyPromiseState = 'rejected';
 }
 
 function defaultWriterReadyPromiseResolve(writer) {
-  assert(writer._readyPromise_resolve !== undefined, 'writer._readyPromise_resolve !== undefined');
-  assert(writer._readyPromise_reject !== undefined, 'writer._readyPromise_reject !== undefined');
+  assert(writer._readyPromise_resolve !== undefined);
+  assert(writer._readyPromise_reject !== undefined);
 
   writer._readyPromise_resolve(undefined);
   writer._readyPromise_resolve = undefined;


### PR DESCRIPTION
With the change to better-assert in #830 assertions are now
self-documenting. There is no longer any need for a description to track
down what failed.

Assertion descriptions were never included in the standard text so this
change removes a discrepancy between the reference implementation and the
standard.