### PR TITLE
Fix brand check exception message from terminate() method

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -164,7 +164,7 @@ class TransformStreamDefaultController {
 
   terminate() {
     if (IsTransformStreamDefaultController(this) === false) {
-      throw defaultControllerBrandCheckException('close');
+      throw defaultControllerBrandCheckException('terminate');
     }
 
     TransformStreamDefaultControllerTerminate(this);


### PR DESCRIPTION
TransformStreamDefaultController.prototype.terminate() still mentioned "close"
in its brand check exception message. Change it to "terminate".