### PR TITLE
Add a local variable to TransformStreamDefaultControllerTerminate

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -229,8 +229,8 @@ function TransformStreamDefaultControllerTerminate(controller) {
     ReadableStreamDefaultControllerClose(readableController);
   }
 
-  WritableStreamDefaultControllerErrorIfNeeded(stream._writable._writableStreamController,
-                                               new TypeError('TransformStream terminated'));
+  const error = new TypeError('TransformStream terminated');
+  WritableStreamDefaultControllerErrorIfNeeded(stream._writable._writableStreamController, error);
   if (stream._backpressure === true) {
     // Permit any pending write() or start() calls to complete.
     TransformStreamSetBackpressure(stream, false);


### PR DESCRIPTION
In standard text it is awkward to create an exception object and pass it
to an internal operation in a single step. Add a local to
TransformStreamDefaultControllerTerminate in which the newly-created
TypeError will be placed. This makes the standard text clearer.