### PR TITLE
Initialise readableStrategy without using an object literal

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -43,8 +43,10 @@ class TransformStream {
     });
 
     const source = new TransformStreamDefaultSource(this, startPromise);
-
-    this._readable = new ReadableStream(source, { size, highWaterMark });
+    const readableStrategy = {};
+    readableStrategy.size = size;
+    readableStrategy.highWaterMark = highWaterMark;
+    this._readable = new ReadableStream(source, readableStrategy);
 
     const sink = new TransformStreamDefaultSink(this, startPromise);
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -4,7 +4,7 @@ const assert = require('better-assert');
 // Calls to verbose() are purely for debugging the reference implementation and tests. They are not part of the standard
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:transform-stream:verbose');
-const { Call, InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject } = require('./helpers.js');
+const { Call, InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject, createDataProperty } = require('./helpers.js');
 const { ReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -44,8 +44,8 @@ class TransformStream {
 
     const source = new TransformStreamDefaultSource(this, startPromise);
     const readableStrategy = {};
-    readableStrategy.size = size;
-    readableStrategy.highWaterMark = highWaterMark;
+    createDataProperty(readableStrategy, 'size', size);
+    createDataProperty(readableStrategy, 'highWaterMark', highWaterMark);
     this._readable = new ReadableStream(source, readableStrategy);
 
     const sink = new TransformStreamDefaultSink(this, startPromise);

--- a/reference-implementation/to-upstream-wpts/transform-streams/patched-global.html
+++ b/reference-implementation/to-upstream-wpts/transform-streams/patched-global.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>patched-global.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="patched-global.js"></script>

--- a/reference-implementation/to-upstream-wpts/transform-streams/patched-global.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/patched-global.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Tests which patch the global environment are kept separate to avoid interfering with other tests.
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+// eslint-disable-next-line no-extend-native, accessor-pairs
+Object.defineProperty(Object.prototype, 'highWaterMark', {
+  set() { throw new Error('highWaterMark setter called'); }
+});
+
+// eslint-disable-next-line no-extend-native, accessor-pairs
+Object.defineProperty(Object.prototype, 'size', {
+  set() { throw new Error('size setter called'); }
+});
+
+test(() => {
+  assert_not_equals(new TransformStream(), null, 'constructor should work');
+}, 'TransformStream constructor should not call setters for highWaterMark or size');
+
+done();


### PR DESCRIPTION
The strategy argument passed to the ReadableStream constructor within the
TransformStream argument used an object literal. The standard text only
uses object literal syntax in default arguments. In order to align the
reference implementation with the standard text, create the
`readableStrategy` object in explicit algorithm steps before passing it
to the constructor.

No functional changes.