### PR TITLE
Add "controller" local to TransformStream constructor

### DIFF
--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -35,7 +35,8 @@ class TransformStream {
       throw new RangeError('Invalid writable type specified');
     }
 
-    this._transformStreamController = new TransformStreamDefaultController(this);
+    const controller = new TransformStreamDefaultController(this);
+    this._transformStreamController = controller;
 
     let startPromise_resolve;
     const startPromise = new Promise(resolve => {
@@ -52,7 +53,7 @@ class TransformStream {
 
     TransformStreamSetBackpressure(this, true);
 
-    const startResult = InvokeOrNoop(transformer, 'start', [this._transformStreamController]);
+    const startResult = InvokeOrNoop(transformer, 'start', [controller]);
     startPromise_resolve(startResult);
   }
 


### PR DESCRIPTION
The TransformStream constructor read the value of the controller back from the
this object after storing it there. Store it in a local variable instead to
avoid the redundant lookup.