### PR TITLE
Meta: Make local-watch.js more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /npm-debug.log
 /streams.spec.whatwg.org/
 /index.html
+/index.html.*

--- a/local-watch.js
+++ b/local-watch.js
@@ -4,12 +4,16 @@ const childProcess = require('child_process');
 const promiseDebounce = require('promise-debounce');
 const emuAlgify = require('emu-algify');
 
+const INPUT = 'index.bs';
+
+let fsWatcher;
+
 const build = promiseDebounce(() => {
   log('Building...');
 
   try {
     childProcess.execSync(
-      'bikeshed spec index.bs index.html --md-Text-Macro="SNAPSHOT-LINK <local watch copy>"',
+      `bikeshed spec ${INPUT} index.html.postbs --md-Text-Macro="SNAPSHOT-LINK <local watch copy>"`,
       { encoding: 'utf-8', stdio: 'inherit' }
     );
     log('(bikeshed done)');
@@ -18,11 +22,13 @@ const build = promiseDebounce(() => {
     console.error(e.stdout);
   }
 
-  const input = fs.readFileSync('index.html', { encoding: 'utf-8' });
+  const input = fs.readFileSync('index.html.postbs', { encoding: 'utf-8' });
+  fs.unlinkSync('index.html.postbs');
 
   return emuAlgify(input, { throwingIndicators: true })
     .then(output => {
-      fs.writeFileSync('index.html', output);
+      fs.writeFileSync('index.html.new', output);
+      fs.renameSync('index.html.new', 'index.html');
       log('Build complete');
     })
     .catch(err => {
@@ -32,8 +38,41 @@ const build = promiseDebounce(() => {
   );
 });
 
-fs.watch('index.bs', build);
-build();
+function onChange(eventType, filename) {
+  log(`Saw ${eventType} event with filename '${filename}'`);
+  // Restart the watch in case the file has been renamed or deleted. This fixes an issue where the file stopped being
+  // watched when a different branch was checked out.
+  tryWatch();
+}
+
+// If index.bs exists, start watching it and run a build. Otherwise retry with a truncated exponential delay until it
+// starts to exist.
+function tryWatch(delay) {
+  if (fsWatcher !== undefined) {
+    fsWatcher.close();
+    fsWatcher = undefined;
+  }
+  try {
+    fsWatcher = fs.watch(INPUT, onChange);
+    build();
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      log(`${INPUT} not there right now. Waiting a bit.`);
+      if (delay === undefined) {
+        delay = 100;
+      }
+      delay *= 2;
+      if (delay > 20000) {
+        delay = 20000;
+      }
+      setTimeout(tryWatch, delay, delay);
+    } else {
+      throw e;
+    }
+  }
+}
+
+tryWatch();
 
 function log(s) {
   console.log(`[${(new Date()).toISOString()}] ${s}`);


### PR DESCRIPTION
- Restart the file watch on every change. This avoids a problem where
  updates stop happening after performing a git checkout.
- Use a temporary file for the output of bikeshed. This avoids a problem
  where reloading the page in the middle of an update gives a
  partially-rendered result.