### PR TITLE
Add SyncOneToOneTransformFunctionAdaptor example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5150,52 +5150,6 @@ for the [promise]." But we don't have to worry about that when writing the <code
 function, since the stream implementation guarantees that the <a>underlying sink</a>'s <code>write</code> method will
 not be called until any promises returned by previous calls have fulfilled!
 
-<h3 id="example-ts-sync-mapper">A transform stream created from a sync mapper function</h3>
-
-The following function allows creating new {{TransformStream}} instances from synchronous "mapper" functions, of the
-type you would normally pass to {{Array.prototype/map|Array.prototype.map}}. It demonstrates that the API is concise
-even for trivial transforms.
-
-<pre><code class="lang-javascript">
-  function mapperTransformStream(mapperFunction) {
-    return new TransformStream({
-      transform(chunk, controller) {
-        controller.enqueue(mapperFunction(chunk));
-      }
-    });
-  }
-</code></pre>
-
-This function can then be used to create a {{TransformStream}} that uppercases all its inputs:
-
-<pre><code class="lang-javascript">
-  const ts = mapperTransformStream(chunk => chunk.toUpperCase());
-  const writer = ts.writable.getWriter();
-  const reader = ts.readable.getReader();
-
-  writer.write("No need to shout");
-
-  // Logs "NO NEED TO SHOUT":
-  reader.read().then(({ value }) => console.log(value));
-</code></pre>
-
-Although a synchronous transform never causes backpressure itself, it will only transform chunks as long as there is no
-backpressure, so resources will not be wasted.
-
-Exceptions error the stream in a natural way:
-
-<pre><code class="lang-javascript">
-  const ts = mapperTransformStream(chunk => JSON.parse(chunk));
-  const writer = ts.writable.getWriter();
-  const reader = ts.readable.getReader();
-
-  writer.write("[1, ");
-
-  // Logs a SyntaxError, twice:
-  reader.read().catch(e => console.error(e));
-  writer.write("{}").catch(e => console.error(e));
-</code></pre>
-
 <h3 id="example-both">A { readable, writable } stream pair wrapping the same underlying resource</h3>
 
 The following function returns an object of the form <code>{ readable, writable }</code>, with the
@@ -5375,6 +5329,52 @@ The class would be used in code like:
 
 <div class="warning">For simplicity, <code>LipFuzzTransformer</code> performs unescaped text substitutions. In real
 applications, a template system that performs context-aware escaping is good practice for security and robustness.</div>
+
+<h3 id="example-ts-sync-mapper">A transform stream created from a sync mapper function</h3>
+
+The following function allows creating new {{TransformStream}} instances from synchronous "mapper" functions, of the
+type you would normally pass to {{Array.prototype/map|Array.prototype.map}}. It demonstrates that the API is concise
+even for trivial transforms.
+
+<pre><code class="lang-javascript">
+  function mapperTransformStream(mapperFunction) {
+    return new TransformStream({
+      transform(chunk, controller) {
+        controller.enqueue(mapperFunction(chunk));
+      }
+    });
+  }
+</code></pre>
+
+This function can then be used to create a {{TransformStream}} that uppercases all its inputs:
+
+<pre><code class="lang-javascript">
+  const ts = mapperTransformStream(chunk => chunk.toUpperCase());
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
+  writer.write("No need to shout");
+
+  // Logs "NO NEED TO SHOUT":
+  reader.read().then(({ value }) => console.log(value));
+</code></pre>
+
+Although a synchronous transform never causes backpressure itself, it will only transform chunks as long as there is no
+backpressure, so resources will not be wasted.
+
+Exceptions error the stream in a natural way:
+
+<pre><code class="lang-javascript">
+  const ts = mapperTransformStream(chunk => JSON.parse(chunk));
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
+  writer.write("[1, ");
+
+  // Logs a SyntaxError, twice:
+  reader.read().catch(e => console.error(e));
+  writer.write("{}").catch(e => console.error(e));
+</code></pre>
 
 <h2 id="conventions" class="no-num">Conventions</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -35,6 +35,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: TypeError; url: #sec-native-error-types-used-in-this-standard-typeerror; type: exception
     text: Invoke; url: #sec-invoke; type: abstract-op
     text: DestructuringAssignmentEvaluation; url: #sec-runtime-semantics-destructuringassignmentevaluation; type: abstract-op
+    text: map; url: #sec-array.prototype.map; type: method; for: Array.prototype
 </pre>
 
 <style>
@@ -5149,49 +5150,50 @@ for the [promise]." But we don't have to worry about that when writing the <code
 function, since the stream implementation guarantees that the <a>underlying sink</a>'s <code>write</code> method will
 not be called until any promises returned by previous calls have fulfilled!
 
-<h3 id="example-ts-sync-one-to-one-transform-function-adaptor">A transform stream adaptor for a simple function</h3>
+<h3 id="example-ts-sync-mapper">A transform stream created from a sync mapper function</h3>
 
-The following function converts a synchronous transform function that takes one chunk and returns the transformed chunk,
-and wraps it into a transformer object that can be passed to the TransformStream constructor. This demonstrates that the
-API is concise even for trivial transforms.
-
-Although a synchronous transform never causes backpressure itself, it will only transform chunks as long as there is no
-backpressure, so resources will not be wasted.
+The following function allows creating new {{TransformStream}} instances from synchronous "mapper" functions, of the
+type you would normally pass to {{Array.prototype/map|Array.prototype.map}}. It demonstrates that the API is concise
+even for trivial transforms.
 
 <pre><code class="lang-javascript">
-  function SyncOneToOneTransformFunctionAdaptor(transformFunction) {
-    return {
+  function mapperTransformStream(mapperFunction) {
+    return new TransformStream({
       transform(chunk, controller) {
-        controller.enqueue(transformFunction(chunk));
+        controller.enqueue(mapperFunction(chunk));
       }
-    };
+    });
   }
 </code></pre>
 
-This adaptor can then be used to create TransformStreams like this:
+This function can then be used to create a {{TransformStream}} that uppercases all its inputs:
 
 <pre><code class="lang-javascript">
-  const ts = new TransformStream(SyncOneToOneTransformFunctionAdaptor(chunk => chunk.toUpperCase()));
-
+  const ts = mapperTransformStream(chunk => chunk.toUpperCase());
   const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
   writer.write("No need to shout");
 
-  const reader = ts.readable.getReader();
   // Logs "NO NEED TO SHOUT":
   reader.read().then(({ value }) => console.log(value));
 </code></pre>
 
+Although a synchronous transform never causes backpressure itself, it will only transform chunks as long as there is no
+backpressure, so resources will not be wasted.
+
 Exceptions error the stream in a natural way:
 
 <pre><code class="lang-javascript">
-  const ts = new TransformStream(SyncOneToOneTransformFunctionAdaptor(chunk => JSON.parse(chunk)));
-
+  const ts = mapperTransformStream(chunk => JSON.parse(chunk));
   const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
   writer.write("[1, ");
 
-  const reader = ts.readable.getReader();
-  // Logs a SyntaxError:
+  // Logs a SyntaxError, twice:
   reader.read().catch(e => console.error(e));
+  writer.write("{}").catch(e => console.error(e));
 </code></pre>
 
 <h3 id="example-both">A { readable, writable } stream pair wrapping the same underlying resource</h3>

--- a/index.bs
+++ b/index.bs
@@ -5149,6 +5149,51 @@ for the [promise]." But we don't have to worry about that when writing the <code
 function, since the stream implementation guarantees that the <a>underlying sink</a>'s <code>write</code> method will
 not be called until any promises returned by previous calls have fulfilled!
 
+<h3 id="example-ts-sync-one-to-one-transform-function-adaptor">A transform stream adaptor for a simple function</h3>
+
+The following function converts a synchronous transform function that takes one chunk and returns the transformed chunk,
+and wraps it into a transformer object that can be passed to the TransformStream constructor. This demonstrates that the
+API is concise even for trivial transforms.
+
+Although a synchronous transform never causes backpressure itself, it will only transform chunks as long as there is no
+backpressure, so resources will not be wasted.
+
+<pre><code class="lang-javascript">
+  function SyncOneToOneTransformFunctionAdaptor(transformFunction) {
+    return {
+      transform(chunk, controller) {
+        controller.enqueue(transformFunction(chunk));
+      }
+    };
+  }
+</code></pre>
+
+This adaptor can then be used to create TransformStreams like this:
+
+<pre><code class="lang-javascript">
+  const ts = new TransformStream(SyncOneToOneTransformFunctionAdaptor(chunk => chunk.toUpperCase()));
+
+  const writer = ts.writable.getWriter();
+  writer.write("No need to shout");
+
+  const reader = ts.readable.getReader();
+  // Logs "NO NEED TO SHOUT":
+  reader.read().then(({ value }) => console.log(value));
+</code></pre>
+
+Exceptions error the stream in a natural way:
+
+<pre><code class="lang-javascript">
+  const ts = new TransformStream(SyncOneToOneTransformFunctionAdaptor(chunk => JSON.parse(chunk)));
+
+  const writer = ts.writable.getWriter();
+  writer.write("[1, ");
+
+  const reader = ts.readable.getReader();
+  // Logs a SyntaxError:
+  reader.read().catch(e => console.error(e));
+</code></pre>
+
 <h3 id="example-both">A { readable, writable } stream pair wrapping the same underlying resource</h3>
 
 The following function returns an object of the form <code>{ readable, writable }</code>, with the


### PR DESCRIPTION
An example of a simple adaptor which wrap a synchronous 1:1 transform function
into a transformer object ready to construct a TransformStream.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ricea/streams/transform-stream-trivial-adaptor-example.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/streams/3c0a2ab...ricea:8414c24.html)