### PR TITLE
Add an example of a transform stream that replaces template tags

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5252,6 +5252,83 @@ and similarly, closing or aborting the <code>writable</code> side will implicitl
 
 </div>
 
+<h3 id="example-ts-lipfuzz">A transform stream that replaces template tags</h3>
+
+It's often useful to substitute tags with variables on a stream of data, where the parts that need to be replaced are
+small compared to the overall data size. This example presents a simple way to do that. It maps strings to strings,
+transforming a template like <code>"Time: \{{time}} Message: \{{message}}"</code> to <code>"Time: 15:36 Message:
+hello"</code> assuming that <code>{ time: "15:36", message: "hello" }</code> was passed in the
+<code>substitutions</code> parameter to <code>LipFuzzTransformer</code>.
+
+This example also demonstrates one way to deal with a situation where a chunk contains partial data that cannot be
+transformed until more data is received. In this case, a partial template tag will be accumulated in the
+<code>partialChunk</code> instance variable until either the end of the tag is found or the end of the stream is
+reached.
+
+<pre><code class="lang-javascript">
+  class LipFuzzTransformer {
+    constructor(substitutions) {
+      this.substitutions = substitutions;
+      this.partialChunk = '';
+      this.lastIndex = undefined;
+    }
+
+    transform(chunk, controller) {
+      chunk = this.partialChunk + chunk;
+      this.partialChunk = '';
+      // lastIndex is the index of the first character after the last substitution.
+      this.lastIndex = 0;
+      chunk = chunk.replace(/\{\{([a-zA-Z0-9_-]+)\}\}/g, this.replaceTag.bind(this));
+      // Regular expression for an incomplete template at the end of a string.
+      const partialAtEndRegexp = /\{(\{([a-zA-Z0-9_-]+(\})?)?)?$/g;
+      // Avoid looking at any characters that have already been substituted.
+      partialAtEndRegexp.lastIndex = this.lastIndex;
+      this.lastIndex = undefined;
+      const match = partialAtEndRegexp.exec(chunk);
+      if (match) {
+        this.partialChunk = chunk.substring(match.index);
+        chunk = chunk.substring(0, match.index);
+      }
+      controller.enqueue(chunk);
+    }
+
+    flush(controller) {
+      if (this.partialChunk.length > 0) {
+        controller.enqueue(this.partialChunk);
+      }
+    }
+
+    replaceTag(match, p1, offset) {
+      let replacement = this.substitutions[p1];
+      if (replacement === undefined) {
+        replacement = '';
+      }
+      this.lastIndex = offset + replacement.length;
+      return replacement;
+    }
+  }
+</code></pre>
+
+In this case we define the <a>transformer</a> to be passed to the {{TransformStream}} constructor as a class. This is
+useful when there is instance data to track.
+
+The class would be used in code like:
+
+<pre><code class="lang-javascript">
+  const data = { userName, displayName, icon, date };
+  const ts = new TransformStream(new LipFuzzTransformer(data));
+
+  fetchEvent.respondWith(
+    fetch(url).then(response => {
+      const transformedBody = response.body.pipeThrough(ts);
+      return new Response(transformedBody);
+    )
+  );
+</code></pre>
+
+<div class="warning">For simplicity, <code>LipFuzzTransformer</code> performs unescaped text substitutions. In real
+applications, a template system that performs context-aware escaping is good practice for security and robustness.</div>
+
 <h2 id="conventions" class="no-num">Conventions</h2>
 
 This specification uses algorithm conventions very similar to those of [[!ECMASCRIPT]], whose rules should be used to

--- a/reference-implementation/to-upstream-wpts/transform-streams/lipfuzz.html
+++ b/reference-implementation/to-upstream-wpts/transform-streams/lipfuzz.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>lipfuzz.js browser context wrapper file</title>
+
+<!-- This is a placeholder file until the tests are upstreamed. -->
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+
+<script src="lipfuzz.js"></script>

--- a/reference-implementation/to-upstream-wpts/transform-streams/lipfuzz.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/lipfuzz.js
@@ -1,0 +1,168 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+class LipFuzzTransformer {
+  constructor(substitutions) {
+    this.substitutions = substitutions;
+    this.partialChunk = '';
+    this.lastIndex = undefined;
+  }
+
+  transform(chunk, controller) {
+    chunk = this.partialChunk + chunk;
+    this.partialChunk = '';
+    // lastIndex is the index of the first character after the last substitution.
+    this.lastIndex = 0;
+    chunk = chunk.replace(/\{\{([a-zA-Z0-9_-]+)\}\}/g, this.replaceTag.bind(this));
+    // Regular expression for an incomplete template at the end of a string.
+    const partialAtEndRegexp = /\{(\{([a-zA-Z0-9_-]+(\})?)?)?$/g;
+    // Avoid looking at any characters that have already been substituted.
+    partialAtEndRegexp.lastIndex = this.lastIndex;
+    this.lastIndex = undefined;
+    const match = partialAtEndRegexp.exec(chunk);
+    if (match) {
+      this.partialChunk = chunk.substring(match.index);
+      chunk = chunk.substring(0, match.index);
+    }
+    controller.enqueue(chunk);
+  }
+
+  flush(controller) {
+    if (this.partialChunk.length > 0) {
+      controller.enqueue(this.partialChunk);
+    }
+  }
+
+  replaceTag(match, p1, offset) {
+    let replacement = this.substitutions[p1];
+    if (replacement === undefined) {
+      replacement = '';
+    }
+    this.lastIndex = offset + replacement.length;
+    return replacement;
+  }
+}
+
+const substitutions = {
+  in1: 'out1',
+  in2: 'out2',
+  quine: '{{quine}}',
+  bogusPartial: '{{incompleteResult}'
+};
+
+const cases = [
+  {
+    input: [''],
+    output: ['']
+  },
+  {
+    input: [],
+    output: []
+  },
+  {
+    input: ['{{in1}}'],
+    output: ['out1']
+  },
+  {
+    input: ['z{{in1}}'],
+    output: ['zout1']
+  },
+  {
+    input: ['{{in1}}q'],
+    output: ['out1q']
+  },
+  {
+    input: ['{{in1}}{{in1}'],
+    output: ['out1', '{{in1}']
+  },
+  {
+    input: ['{{in1}}{{in1}', '}'],
+    output: ['out1', 'out1']
+  },
+  {
+    input: ['{{in1', '}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{{', 'in1}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{', '{in1}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{{', 'in1}'],
+    output: ['', '', '{{in1}']
+  },
+  {
+    input: ['{'],
+    output: ['', '{']
+  },
+  {
+    input: ['{', ''],
+    output: ['', '', '{']
+  },
+  {
+    input: ['{', '{', 'i', 'n', '1', '}', '}'],
+    output: ['', '', '', '', '', '', 'out1']
+  },
+  {
+    input: ['{{in1}}{{in2}}{{in1}}'],
+    output: ['out1out2out1']
+  },
+  {
+    input: ['{{wrong}}'],
+    output: ['']
+  },
+  {
+    input: ['{{wron', 'g}}'],
+    output: ['', '']
+  },
+  {
+    input: ['{{quine}}'],
+    output: ['{{quine}}']
+  },
+  {
+    input: ['{{bogusPartial}}'],
+    output: ['{{incompleteResult}']
+  },
+  {
+    input: ['{{bogusPartial}}}'],
+    output: ['{{incompleteResult}}']
+  }
+];
+
+for (const testCase of cases) {
+  const inputChunks = testCase.input;
+  const outputChunks = testCase.output;
+  promise_test(() => {
+    const lft = new TransformStream(new LipFuzzTransformer(substitutions));
+    const writer = lft.writable.getWriter();
+    const promises = [];
+    for (const inputChunk of inputChunks) {
+      promises.push(writer.write(inputChunk));
+    }
+    promises.push(writer.close());
+    const reader = lft.readable.getReader();
+    let readerChain = Promise.resolve();
+    for (const outputChunk of outputChunks) {
+      readerChain = readerChain.then(() => {
+        return reader.read().then(({ value, done }) => {
+          assert_false(done, `done should be false when reading ${outputChunk}`);
+          assert_equals(value, outputChunk, `value should match outputChunk`);
+        });
+      });
+    }
+    readerChain = readerChain.then(() => {
+      return reader.read().then(({ done }) => assert_true(done, `done should be true`));
+    });
+    promises.push(readerChain);
+    return Promise.all(promises);
+  }, `testing "${inputChunks}"`);
+}
+
+done();


### PR DESCRIPTION
Add an example of a TransformStream which replaces tags in a streaming template
according to the values of variables passed to the constructor.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ricea/streams/transform-stream-example-lipfuzz.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/streams/7457dd9...ricea:c942426.html)