### PR TITLE
Add examples of using identity transforms to manipulate streams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6863,6 +6863,67 @@ reader.read().catch(e => console.error(e));
 writer.write("{}").catch(e => console.error(e));
 </xmp>
 
+<h3 id="example-identity-transform-usages">Using an identity transform stream as a primitive to
+create new readable streams</h3>
+
+Combining an [=identity transform stream=] with {{pipeTo()}} is a powerful way to manipulate
+streams. This section contains a couple of examples of this general technique.
+
+It's sometimes natural to treat a promise for a [=readable stream=] as if it were a readable stream.
+A simple adapter function is all that's needed:
+
+<xmp highlight="js">
+function promiseToReadable(promiseForReadable) {
+  const ts = new TransformStream();
+
+  promiseForReadable
+      .then(readable => readable.pipeTo(ts.writable))
+      .catch(reason => ts.writable.abort(reason))
+      .catch(() => {});
+
+  return ts.readable;
+}
+</xmp>
+
+Here, we pipe the data to the [=writable side=] and return the [=readable side=]. If the pipe
+errors, we [=abort a writable stream|abort=] the writable side, which automatically propagates the
+error to the returned readable side. If the writable side had already been errored by
+{{ReadableStream/pipeTo()}}, then the {{WritableStream/abort()}} call will return a rejection, which
+we can safely ignore.
+
+A more complex extension of this is concatenating multiple readable streams into one:
+
+<xmp highlight="js">
+function concatenateReadables(readables) {
+  const ts = new TransformStream();
+  let promise = Promise.resolve();
+
+  for (const readable of readables) {
+    promise = promise.then(
+     () => readable.pipeTo(ts.writable, { preventClose: true }),
+     reason => {
+       return Promise.all([
+         ts.writable.abort(reason),
+         readable.cancel(reason)
+       ]);
+     }
+   );
+  }
+
+  promise.then(() => ts.writable.close(),
+               reason => ts.writable.abort(reason))
+         .catch(() => {});
+
+  return ts.readable;
+}
+</xmp>
+
+The error handling here is subtle because canceling the concatenated stream has to cancel all the
+input streams. However, the success case is simple enough. We just pipe each stream in the
+<code>readables</code> iterable one at a time to the [=identity transform stream=]'s [=writable
+side=], and then close it when we are done. The [=readable side=] is then a concatenation of all the
+chunks from all of of the streams. We return it from the function. Backpressure is applied as usual.
+
 <h2 id="acks" class="no-num">Acknowledgments</h2>
 
 The editors would like to thank


### PR DESCRIPTION
Add examples concatenateReadables and promiseToReadable, both of which combine
pipeTo and TransformStream to synthesize a readable stream from something else.

The examples are similar so they appear in a single section.

Tests are included to verify the correct behaviour of the examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/847.html" title="Last updated on Aug 26, 2020, 3:35 PM UTC (19604c5)">Preview</a> | <a href="https://whatpr.org/streams/847/f2be831...19604c5.html" title="Last updated on Aug 26, 2020, 3:35 PM UTC (19604c5)">Diff</a>