### PR TITLE
Test that TransformStream does not use global constructors

### DIFF
--- a/reference-implementation/to-upstream-wpts/transform-streams/patched-global.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/patched-global.js
@@ -20,7 +20,7 @@ test(() => {
   assert_not_equals(new TransformStream(), null, 'constructor should work');
 }, 'TransformStream constructor should not call setters for highWaterMark or size');
 
-test(() => {
+test(t => {
   /* eslint-disable no-native-reassign */
 
   const oldReadableStream = ReadableStream;
@@ -35,6 +35,10 @@ test(() => {
   WritableStream = function () {
     throw new Error('Called the global WritableStream constructor');
   };
+  t.add_cleanup(() => {
+    ReadableStream = oldReadableStream;
+    WritableStream = oldWritableStream;
+  });
 
   const ts = new TransformStream();
 
@@ -43,10 +47,6 @@ test(() => {
                     'getReader should work when called on ts.readable');
   assert_not_equals(getWriter.call(ts.writable), undefined,
                     'getWriter should work when called on ts.writable');
-
-  ReadableStream = oldReadableStream;
-  WritableStream = oldWritableStream;
-
   /* eslint-enable no-native-reassign */
 }, 'TransformStream should use the original value of ReadableStream and WritableStream');
 

--- a/reference-implementation/to-upstream-wpts/transform-streams/patched-global.js
+++ b/reference-implementation/to-upstream-wpts/transform-streams/patched-global.js
@@ -20,4 +20,34 @@ test(() => {
   assert_not_equals(new TransformStream(), null, 'constructor should work');
 }, 'TransformStream constructor should not call setters for highWaterMark or size');
 
+test(() => {
+  /* eslint-disable no-native-reassign */
+
+  const oldReadableStream = ReadableStream;
+  const oldWritableStream = WritableStream;
+  const getReader = ReadableStream.prototype.getReader;
+  const getWriter = WritableStream.prototype.getWriter;
+
+  // Replace ReadableStream and WritableStream with broken versions.
+  ReadableStream = function () {
+    throw new Error('Called the global ReadableStream constructor');
+  };
+  WritableStream = function () {
+    throw new Error('Called the global WritableStream constructor');
+  };
+
+  const ts = new TransformStream();
+
+  // Just to be sure, ensure the readable and writable pass brand checks.
+  assert_not_equals(getReader.call(ts.readable), undefined,
+                    'getReader should work when called on ts.readable');
+  assert_not_equals(getWriter.call(ts.writable), undefined,
+                    'getWriter should work when called on ts.writable');
+
+  ReadableStream = oldReadableStream;
+  WritableStream = oldWritableStream;
+
+  /* eslint-enable no-native-reassign */
+}, 'TransformStream should use the original value of ReadableStream and WritableStream');
+
 done();


### PR DESCRIPTION
The TransformStream constructor constructs a ReadableStream and
WritableStream. It should use the original constructors rather than what
currently exists on the global object.

Add tests to verify that it does.

Related to issue #850.