### PR TITLE
WIP: allow creating streams from specs while using fewer JS objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -124,9 +124,9 @@ constantly being pushed from the OS level, at a rate that can be controlled by c
 synchronously, e.g. if it is held by the operating system's in-memory buffers, or asynchronously, e.g. if it has to be
 read from disk. An example pull source is a file handle, where you seek to specific locations and read specific amounts.
 
-Readable streams are designed to wrap both types of sources behind a single, unified interface. The implementation
-details of a source are provided by an object with certain methods and properties. It is passed to the
-{{ReadableStream()}} constructor.
+Readable streams are designed to wrap both types of sources behind a single, unified interface. For
+web developer–created streams, the implementation details of a source are provided by an object with certain methods and
+properties. It is passed to the {{ReadableStream()}} constructor.
 
 <a>Chunks</a> are enqueued into the stream by the stream's <a>underlying source</a>. They can then be read one at a
 time via the stream's public interface, in particular by using a <a>readable stream reader</a> acquired using the
@@ -245,10 +245,11 @@ For readable streams, an underlying source can use this desired size as a backpr
 generation so as to try to keep the desired size above or at zero. For writable streams, a producer can behave
 similarly, avoiding writes that would cause the desired size to go negative.
 
-Concretely, a queuing strategy is given by any JavaScript object with a <code>highWaterMark</code> property. For byte
-streams the <code>highWaterMark</code> always has units of bytes. For other streams the default unit is <a>chunks</a>,
-but a <code>size()</code> function can be included in the strategy object which returns the size for a given chunk. This
-permits the <code>highWaterMark</code> to be specified in arbitrary floating-point units.
+Concretely, a queuing strategy for web developer–created streams is given by any JavaScript object with a
+<code>highWaterMark</code> property. For byte streams the <code>highWaterMark</code> always has units of bytes. For
+other streams the default unit is <a>chunks</a>, but a <code>size()</code> function can be included in the strategy
+object which returns the size for a given chunk. This permits the <code>highWaterMark</code> to be specified in
+arbitrary floating-point units.
 <!-- TODO: https://github.com/whatwg/streams/issues/427 -->
 
 <div class="example" id="example-simple-queuing-strategy">

--- a/index.bs
+++ b/index.bs
@@ -1868,7 +1868,7 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorit
   1. Set _controller_.[[pullAlgorithm]] to _pullAlgorithm_.
   1. Set _controller_.[[cancelAlgorithm]] to _cancelAlgorithm_.
   1. Set _stream_.[[readableStreamController]] to _controller_.
-  1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw and exception.)
+  1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)
   1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
     1. <a>Upon fulfillment</a>  of _startPromise_,
       1. Set _controller_.[[started]] to *true*.

--- a/index.bs
+++ b/index.bs
@@ -4369,10 +4369,24 @@ nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>
 
 <emu-alg>
   1. Let _transformAlgorithm_ be the following steps, taking a _chunk_ argument:
-    1. Return ! TransformStreamDefaultSinkTransform(_stream_, _transformer_, _chunk_).
+    1. Return ! TransformStreamDefaultControllerPromiseCallTransform(_stream_, _transformer_, _chunk_).
   1. Let _flushAlgorithm_ be the following steps:
     1. Return ! PromiseInvokeOrNoop(_transformer_, `"flush"`, « _stream_.[[transformStreamController]] »).
   1. Perform ! SetUpTransformStreamDefaultController(_stream_, _transformAlgorithm_, _flushAlgorithm_).
+</emu-alg>
+
+<h4 id="transform-stream-default-controller-call-transform-or-fallback"
+aoid="TransformStreamDefaultControllerCallTransformOrFallback"
+throws>TransformStreamDefaultControllerCallTransformOrFallback ( <var>stream</var>, <var>transformer</var>,
+<var>chunk</var> )</h4>
+
+<emu-alg>
+  1. Let _controller_ be _stream_.[[transformStreamController]].
+  1. Let _method_ be ? GetV(_transformer_, `"transform"`).
+  1. If _method_ is *undefined*,
+    1. Perform ? TransformStreamDefaultControllerEnqueue(_controller_, _chunk_).
+    1. Return *undefined*.
+  1. Return ? Call(_method_, _transformer_, « _chunk_, _controller_ »).
 </emu-alg>
 
 <h4 id="transform-stream-default-controller-enqueue" aoid="TransformStreamDefaultControllerEnqueue"
@@ -4424,6 +4438,25 @@ this to streams they did not create.
   1. Perform ! TransformStreamErrorWritableAndUnblockWrite(_stream_, _error_).
 </emu-alg>
 
+<h4 id="transform-stream-default-controller-promise-call-transform"
+aoid="TransformStreamDefaultControllerPromiseCallTransform"
+nothrow>TransformStreamDefaultControllerPromiseCallTransform ( <var>stream</var>, <var>transformer</var>,
+<var>chunk</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[readable]].[[state]] is not `"errored"`.
+  1. Assert: _stream_.[[backpressure]] is *false*.
+  1. Let _transformPromise_ be *undefined*.
+  1. Let _transformResult_ be TransformStreamDefaultControllerCallTransformOrFallback(_stream_, _transformer_, _chunk_).
+  1. If _transformResult_ is an abrupt completion, set _transformPromise_ to <a>a promise rejected with</a>
+     _transformResult_.[[Value]].
+  1. Otherwise, set _transformPromise_ to <a>a promise resolved with</a> _transformResult_.[[Value]].
+  1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
+     argument _e_, performs the following steps:
+    1. Perform ! TransformStreamError(_stream_, _e_).
+    1. Throw _e_.
+</emu-alg>
+
 <h3 id="ts-default-sink-abstract-ops">Transform Stream Default Sink Abstract Operations</h3>
 
 <h4 id="transform-stream-default-sink-write-algorithm" aoid="TransformStreamDefaultSinkWriteAlgorithm"
@@ -4469,35 +4502,6 @@ nothrow>TransformStreamDefaultSinkCloseAlgorithm( <var>stream</var> )</h4>
     1. A rejection handler that, when called with argument _r_, performs the following steps:
       1. Perform ! TransformStreamError(_stream_, _r_).
       1. Throw _readable_.[[storedError]].
-</emu-alg>
-
-<h4 id="transform-stream-default-sink-invoke-transform" aoid="TransformStreamDefaultSinkInvokeTransform"
-throws>TransformStreamDefaultSinkInvokeTransform ( <var>stream</var>, <var>transformer</var>, <var>chunk</var> )</h4>
-
-<emu-alg>
-  1. Let _controller_ be _stream_.[[transformStreamController]].
-  1. Let _method_ be ? GetV(_transformer_, `"transform"`).
-  1. If _method_ is *undefined*,
-    1. Perform ? TransformStreamDefaultControllerEnqueue(_controller_, _chunk_).
-    1. Return *undefined*.
-  1. Return ? Call(_method_, _transformer_, « _chunk_, _controller_ »).
-</emu-alg>
-
-<h4 id="transform-stream-default-sink-transform" aoid="TransformStreamDefaultSinkTransform"
-nothrow>TransformStreamDefaultSinkTransform ( <var>stream</var>, <var>transformer</var>, <var>chunk</var> )</h4>
-
-<emu-alg>
-  1. Assert: _stream_.[[readable]].[[state]] is not `"errored"`.
-  1. Assert: _stream_.[[backpressure]] is *false*.
-  1. Let _transformPromise_ be *undefined*.
-  1. Let _transformResult_ be TransformStreamDefaultSinkInvokeTransform(_stream_, _transformer_, _chunk_).
-  1. If _transformResult_ is an abrupt completion, set _transformPromise_ to <a>a promise rejected with</a>
-     _transformResult_.[[Value]].
-  1. Otherwise, set _transformPromise_ to <a>a promise resolved with</a> _transformResult_.[[Value]].
-  1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
-     argument _e_, performs the following steps:
-    1. Perform ! TransformStreamError(_stream_, _e_).
-    1. Throw _e_.
 </emu-alg>
 
 <h3 id="ts-default-source-abstract-ops">Transform Stream Default Source Abstract Operations</h3>

--- a/index.bs
+++ b/index.bs
@@ -858,7 +858,6 @@ throws.</p>
   1. Assert: _highWaterMark_ is not negative.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
-  1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
   1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _sizeAlgorithm_, _highWaterMark_).
   1. Return _stream_.
@@ -2864,18 +2863,19 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
 </div>
 
 <emu-alg>
-  1. Set *this*.[[state]] to `"writable"`.
-  1. Set *this*.[[storedError]], *this*.[[writer]], *this*.[[writableStreamController]],
-     *this*.[[inFlightWriteRequest]], *this*.[[closeRequest]], *this*.[[inFlightCloseRequest]] and
-     *this*.[[pendingAbortRequest]] to *undefined*.
-  1. Set *this*.[[writeRequests]] to a new empty List.
-  1. Set *this*.[[backpressure]] to *false*.
+  1. Perform ! InitializeWritableStream(_this_);
   1. Let _type_ be ? GetV(_underlyingSink_, `"type"`).
   1. If _type_ is not *undefined*, throw a *RangeError* exception. <p class="note">This is to allow us to add new
      potential types in the future, without backward-compatibility concerns.</p>
-  1. Set *this*.[[writableStreamController]] to ? Construct(`<a idl>WritableStreamDefaultController</a>`, « *this*,
-     _underlyingSink_, _size_, _highWaterMark_ »).
-  1. Perform ? *this*.[[writableStreamController]].[[StartSteps]]().
+  1. Let _sizeAlgorithm_ be *undefined;
+  1. If _size_ is *undefined*, set _sizeAlgorithm_ to an algorithm that returns *1*.
+  1. Otherwise,
+    1. If ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
+    1. Set _sizeAlgorithm_ to the following steps, taking a _chunk_ argument:
+      1. Return ? Call(_size_, *undefined*, « _chunk_ »).
+  1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
+  1. Perform ! SetUpWritableStreamDefaultControllerFromUnderlyingSink(*this*, _underlyingSink_, _highWaterMark_,
+     _sizeAlgorithm_);
 </emu-alg>
 
 <h4 id="ws-prototype">Properties of the {{WritableStream}} Prototype</h4>
@@ -2932,6 +2932,33 @@ throws>AcquireWritableStreamDefaultWriter ( <var>stream</var> )</h4>
 
 <emu-alg>
   1. Return ? Construct(`<a idl>WritableStreamDefaultWriter</a>`, « _stream_ »).
+</emu-alg>
+
+<h4 id="create-writable-stream" aoid="CreateWritableStream" throws>CreateWritableStream ( <var>startAlgorithm</var>,
+<var>writeAlgorithm</var>, <var>closeAlgorithm</var>, <var>abortAlgorithm</var>, <var>highWaterMark</var>,
+<var>sizeAlgorithm</var> )</h4>
+
+<emu-alg>
+  1. Assert: Type(_highWaterMark_) is Number.
+  1. Assert: _highWaterMark_ is not NaN.
+  1. Assert: _highWaterMark_ is not +∞.
+  1. Assert: _highWaterMark_ is not negative.
+  1. Let _stream_ be ObjectCreate(the original value of <a idl>WritableStream</a>'s `prototype` property).
+  1. Perform ! InitializeWritableStream(_stream_).
+  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
+     _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
+</emu-alg>
+
+<h4 id="initialize-writable-stream" aoid="InitializeWritableStream" nothrow>InitializeWritableStream ( <var>stream</var>
+)</h4>
+
+<emu-alg>
+  1. Set _stream_.[[state]] to `"writable"`.
+  1. Set _stream_.[[storedError]], _stream_.[[writer]], _stream_.[[writableStreamController]],
+     _stream_.[[inFlightWriteRequest]], _stream_.[[closeRequest]], _stream_.[[inFlightCloseRequest]] and
+     _stream_.[[pendingAbortRequest]] to *undefined*.
+  1. Set _stream_.[[writeRequests]] to a new empty List.
+  1. Set _stream_.[[backpressure]] to *false*.
 </emu-alg>
 
 <h4 id="is-writable-stream" aoid="IsWritableStream" nothrow>IsWritableStream ( <var>x</var> )</h4>
@@ -3589,27 +3616,14 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
 </table>
 
 <h4 id="ws-default-controller-constructor" constructor for="WritableStreamDefaultController"
-lt="WritableStreamDefaultController(stream, underlyingSink, size, highWaterMark)">new
-WritableStreamDefaultController(<var>stream</var>, <var>underlyingSink</var>, <var>size</var>,
-<var>highWaterMark</var>)</h4>
+lt="WritableStreamDefaultController()">new WritableStreamDefaultController()</h4>
 
 <div class="note">
-  The <code>WritableStreamDefaultController</code> constructor cannot be used directly; it only works on a
-  {{WritableStream}} that is in the middle of being constructed.
+  The <code>WritableStreamDefaultController</code> constructor cannot be used directly.
 </div>
 
 <emu-alg>
-  1. If ! IsWritableStream(_stream_) is *false*, throw a *TypeError* exception.
-  1. If _stream_.[[writableStreamController]] is not *undefined*, throw a *TypeError* exception.
-  1. Set *this*.[[controlledWritableStream]] to _stream_.
-  1. Set *this*.[[underlyingSink]] to _underlyingSink_.
-  1. Perform ! ResetQueue(*this*).
-  1. Set *this*.[[started]] to *false*.
-  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
-  1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to
-     _normalizedStrategy_.[[highWaterMark]].
-  1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(*this*).
-  1. Perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
+  1. Throw a *TypeError* exception.
 </emu-alg>
 
 <h4 id="ws-default-controller-prototype">Properties of the {{WritableStreamDefaultController}} Prototype</h4>
@@ -3647,7 +3661,7 @@ used polymorphically.
 <var>reason</var> )</h5>
 
 <emu-alg>
-  1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingSink]], `"abort"`, « _reason_ »).
+  1. Return the result of performing *this*.[[abortAlgorithm]].
 </emu-alg>
 
 <h5 id="ws-default-controller-private-error">\[[ErrorSteps]]()</h5>
@@ -3656,30 +3670,64 @@ used polymorphically.
   1. Perform ! ResetQueue(*this*).
 </emu-alg>
 
-<h5 id="ws-default-controller-private-start" oldids="writable-stream-default-controller-start">\[[StartSteps]]()</h5>
+<h3 id="ws-default-controller-abstract-ops">Writable Stream Default Controller Abstract Operations</h3>
+
+<h4 id="set-up-writable-stream-default-controller" aoid="SetUpWritableStreamDefaultController"
+throws>SetUpWritableStreamDefaultController ( <var>stream</var>, <var>startAlgorithm</var>, <var>writeAlgorithm</var>,
+<var>closeAlgorithm</var>, <var>abortAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
-  1. Let _startResult_ be ? InvokeOrNoop(*this*.[[underlyingSink]], `"start"`, « *this* »).
-  1. Let _stream_ be *this*.[[controlledWritableStream]].
-  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
-  1. <a>Upon fulfillment</a>  of _startPromise_,
-    1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
-    1. Set *this*.[[started]] to *true*.
-    1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(*this*).
-  1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-    1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
-    1. Set *this*.[[started]] to *true*.
-    1. Perform ! WritableStreamDealWithRejection(_stream_, _r_).
+  1. Assert: ! IsWritableStream(_stream_) is *true*.
+  1. Assert: _stream_.[[writableStreamController]] is *undefined*.
+  1. Let _controller_ be ObjectCreate(the original value of <a idl>WritableStreamDefaultController</a>'s `prototype`
+     property).
+  1. Set _controller_.[[controlledWritableStream]] to _stream_.
+  1. Set _stream_.[[writableStreamController]] to _controller_.
+  1. Perform ! ResetQueue(_controller_).
+  1. Set _controller_.[[started]] to *false*.
+  1. Set _controller_.[[strategySizeAlgorithm]] to _sizeAlgorithm_.
+  1. Set _controller_.[[strategyHWM]] to _highWaterMark_.
+  1. Set _controller_.[[writeAlgorithm]] to _writeAlgorithm_.
+  1. Set _controller_.[[closeAlgorithm]] to _closeAlgorithm_.
+  1. Set _controller_.[[abortAlgorithm]] to _abortAlgorithm_.
+  1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
+  1. Perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
+  1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)
+  1. Let _startPromise_ be a promise resolve with _startResult_:
+    1. <a>Upon fulfillment</a> of _startPromise_,
+      1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+      1. Set _controller_.[[started]] to *true*.
+      1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
+    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+      1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+      1. Set _controller_.[[started]] to *true*.
+      1. Perform ! WritableStreamDealWithRejection(_stream_, _r_).
 </emu-alg>
 
-<h3 id="ws-default-controller-abstract-ops">Writable Stream Default Controller Abstract Operations</h3>
+<h4 id="set-up-writable-stream-default-controller-from-underlying-sink"
+aoid="SetUpWritableStreamDefaultControllerFromUnderlyingSink"
+throws>SetUpWritableStreamDefaultControllerFromUnderlyingSink ( <var>stream</var>, <var>underlyingSink</var>,
+<var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
+
+<emu-alg>
+  1. Let _startAlgorithm_ be the following steps:
+    1. Return ? InvokeOrNoop(_underlyingSink_, `"start"`, « _stream_.[[writableStreamController]] »).
+  1. Let _writeAlgorithm_ be the following steps, taking a _chunk_ argument:
+    1. Return ! PromiseInvokeOrNoop(_underlyingSink_, `"write"`, « _chunk_, _stream_.[[writableStreamController]] »).
+  1. Let _closeAlgorithm_ be the following steps:
+    1. Return ! PromiseInvokeOrNoop(_underlyingSink_, `"close"`, « »).
+  1. Let _abortAlgorithm_ be the following steps, taking a _reason_ argument:
+    1. Return ! PromiseInvokeOrNoop(_underlyingSink_, `"abort"`, « _reason_ »).
+  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
+     _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
+</emu-alg>
 
 <h4 id="is-writable-stream-default-controller" aoid="IsWritableStreamDefaultController"
 nothrow>IsWritableStreamDefaultController ( <var>x</var> )</h4>
 
 <emu-alg>
   1. If Type(_x_) is not Object, return *false*.
-  1. If _x_ does not have an [[underlyingSink]] internal slot, return *false*.
+  1. If _x_ does not have an [[controlledWritableStream]] internal slot, return *false*.
   1. Return *true*.
 </emu-alg>
 
@@ -3695,9 +3743,8 @@ nothrow>WritableStreamDefaultControllerClose ( <var>controller</var> )</h4>
 nothrow>WritableStreamDefaultControllerGetChunkSize ( <var>controller</var>, <var>chunk</var> )</h4>
 
 <emu-alg>
-  1. Let _strategySize_ be _controller_.[[strategySize]].
-  1. If _strategySize_ is *undefined*, return 1.
-  1. Let _returnValue_ be Call(_strategySize_, *undefined*, « _chunk_ »).
+  1. Let _returnValue_ be the result of performing _controller_.[[strategySizeAlgorithm]]_, passing in _chunk_, and
+     interpreting the result as an ECMAScript completion value.
   1. If _returnValue_ is an abrupt completion,
     1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _returnValue_.[[Value]]).
     1. Return 1.
@@ -3762,7 +3809,7 @@ nothrow>WritableStreamDefaultControllerProcessClose ( <var>controller</var> )</h
   1. Perform ! WritableStreamMarkCloseRequestInFlight(_stream_).
   1. Perform ! DequeueValue(_controller_).
   1. Assert: _controller_.[[queue]] is empty.
-  1. Let _sinkClosePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"close"`, « »).
+  1. Let _sinkClosePromise_ be the result of performing _controller_.[[closeAlgorithm]].
   1. <a>Upon fulfillment</a> of _sinkClosePromise_,
     1. Perform ! WritableStreamFinishInFlightClose(_stream_).
   1. <a>Upon rejection</a> of _sinkClosePromise_ with reason _reason_,
@@ -3775,8 +3822,7 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
 <emu-alg>
   1. Let _stream_ be _controller_.[[controllerWritableStream]].
   1. Perform ! WritableStreamMarkFirstWriteRequestInFlight(_stream_).
-  1. Let _sinkWritePromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSink]], `"write"`, « _chunk_,
-     _controller_ »).
+  1. Let _sinkWritePromise_ be the result of performing _controller_.[[writeAlgorithm]], passing in _chunk_.
   1. <a>Upon fulfillment</a> of _sinkWritePromise_,
     1. Perform ! WritableStreamFinishInFlightWrite(_stream_).
     1. Let _state_ be _stream_.[[state]].

--- a/index.bs
+++ b/index.bs
@@ -3760,7 +3760,7 @@ throws>SetUpWritableStreamDefaultController ( <var>stream</var>, <var>startAlgor
   1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
   1. Perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
   1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)
-  1. Let _startPromise_ be a promise resolve with _startResult_.
+  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_.
   1. <a>Upon fulfillment</a> of _startPromise_,
     1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
     1. Set _controller_.[[started]] to *true*.

--- a/index.bs
+++ b/index.bs
@@ -503,15 +503,15 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 </div>
 
 <emu-alg>
+  1. Set *this*.[[state]] to `"readable"`.
+  1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
+  1. Set *this*.[[disturbed]] to *false*.
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _typeString_ be ? ToString(_type_).
   1. If _typeString_ is `"bytes"`,
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. If _size_ is not *undefined*, throw a *RangeError* exception.
-    1. Set *this*.[[state]] to `"readable"`.
-    1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
-    1. Set *this*.[[disturbed]] to *false*.
     1. Set *this*.[[readableStreamController]] to *undefined*.
     1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableByteStreamController</a>`, « *this*,
        _underlyingSource_, _highWaterMark_ »).
@@ -531,7 +531,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
       1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
     1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
       1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
-    1. Perform ? InitializeReadableStream(*this*, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+    1. Perform ? SetUpReadableStreamDefaultController(*this*, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
        _highWaterMark_, _sizeAlgorithm_).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
@@ -862,23 +862,13 @@ instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithm
   1. Assert: _highWaterMark_ is not +∞.
   1. Assert: _highWaterMark_ is not negative.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
-  1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
-  1. Let _result_ be InitializeReadableStream(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
-     _sizeAlgorithm_, _highWaterMark_).
-  1. Assert: _result_ is not an <a>abrupt completion</a>.
-  1. Return _stream_.
-</emu-alg>
-
-<h4 id="initialize-readable-stream" aoid="InitializeReadableStream" throws>InitializeReadableStream (
-<var>stream</var>, <var>startAlgorithm</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var>,
-<var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
-
-<emu-alg>
   1. Set _stream_.[[state]] to `"readable"`.
   1. Set _stream_.[[reader]] and _stream_.[[storedError]] to *undefined*.
   1. Set _stream_.[[disturbed]] to *false*.
+  1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
   1. Perform ! SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _sizeAlgorithm_, _highWaterMark_).
+  1. Return _stream_.
 </emu-alg>
 
 <h4 id="is-readable-stream" aoid="IsReadableStream" nothrow>IsReadableStream ( <var>x</var> )</h4>

--- a/index.bs
+++ b/index.bs
@@ -160,8 +160,8 @@ Analogously to readable streams, most writable streams wrap a lower-level I/O si
 queuing subsequent writes and only delivering them to the underlying sink one by one.
 
 <a>Chunks</a> are written to the stream via its public interface, and are passed one at a time to the stream's
-<a>underlying sink</a>. The implementation details of the sink are provided by an object with certain methods that is
-passed to the {{WritableStream()}} constructor.
+<a>underlying sink</a>. For web developer-created streams, the implementation details of the sink are provided by an
+object with certain methods that is passed to the {{WritableStream()}} constructor.
 
 Code that writes into a writable stream using its public interface is known as a <dfn>producer</dfn>.
 
@@ -842,7 +842,7 @@ reader</a> for a given stream.
 <var>sizeAlgorithm</var> ] ] )</h4>
 
 This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
-instances. The <var>startAlgorithm</var>, <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return
+instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return
 promises; if supplied, <var>sizeAlgorithm</var> must be an algorithm accepting <a>chunk</a> objects and returning a
 number; and if supplied, <var>highWaterMark</var> must be a nonnegative, finite number.
 
@@ -2774,13 +2774,13 @@ Instances of {{WritableStream}} are created with the internal slots described in
   <tr>
     <td>\[[inFlightWriteRequest]]
     <td class="non-normative">A slot set to the promise for the current in-flight write operation while the
-      <a>underlying sink</a>'s <code>write</code> method is executing and has not yet fulfilled, used to prevent
+      <a>underlying sink</a>'s <code>write</code> algorithm is executing and has not yet fulfilled, used to prevent
       reentrant calls
   </tr>
   <tr>
     <td>\[[inFlightCloseRequest]]
     <td class="non-normative">A slot set to the promise for the current in-flight close operation while the
-      <a>underlying sink</a>'s <code>close</code> method is executing and has not yet fulfilled, used to prevent the
+      <a>underlying sink</a>'s <code>close</code> algorithm is executing and has not yet fulfilled, used to prevent the
       {{WritableStreamDefaultWriter/abort()}} method from interrupting close
   </tr>
   <tr>
@@ -2937,6 +2937,14 @@ throws>AcquireWritableStreamDefaultWriter ( <var>stream</var> )</h4>
 <h4 id="create-writable-stream" aoid="CreateWritableStream" throws>CreateWritableStream ( <var>startAlgorithm</var>,
 <var>writeAlgorithm</var>, <var>closeAlgorithm</var>, <var>abortAlgorithm</var>, <var>highWaterMark</var>,
 <var>sizeAlgorithm</var> )</h4>
+
+This abstract operation is meant to be called from other specifications that wish to create {{WritableStream}}
+instances. The <var>writeAlgorithm</var>, <var>closeAlgorithm</var> and <var>abortAlgorithm</var> algorithms must return
+promises; if supplied, <var>sizeAlgorithm</var> must be an algorithm accepting <a>chunk</a> objects and returning a
+number; and if supplied, <var>highWaterMark</var> must be a nonnegative, finite number.
+
+<p class="note">CreateWritableStream throws an exception if and only if the supplied <var>startAlgorithm</var>
+throws.</p>
 
 <emu-alg>
   1. Assert: Type(_highWaterMark_) is Number.
@@ -3562,7 +3570,7 @@ it would look like
 
 <pre><code class="lang-javascript">
   class WritableStreamDefaultController {
-    constructor(stream, underlyingSink, size, highWaterMark)
+    constructor() // always throws
 
     error(e)
   }

--- a/index.bs
+++ b/index.bs
@@ -845,9 +845,7 @@ throws.</p>
 <emu-alg>
   1. If _highWaterMark_ was not passed, set it to *1*.
   1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
-  1. Assert: Type(_highWaterMark_) is Number.
-  1. Assert: _highWaterMark_ is not NaN.
-  1. Assert: _highWaterMark_ is not negative.
+  1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
   1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
@@ -870,9 +868,7 @@ throws.</p>
 <emu-alg>
   1. If _highWaterMark_ was not passed, set it to *0*.
   1. If _autoAllocateChunkSize_ was not passed, set it to *undefined*.
-  1. Assert: Type(_highWaterMark_) is Number.
-  1. Assert: _highWaterMark_ is not NaN.
-  1. Assert: _highWaterMark_ is not negative.
+  1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
   1. If _autoAllocateChunkSize_ is not *undefined*,
     1. Assert: ! IsInteger(_autoAllocateChunkSize_) is *true*.
     1. Assert: _autoAllocateChunkSize_ is positive.
@@ -2990,9 +2986,7 @@ number; and if supplied, <var>highWaterMark</var> must be a nonnegative, non-NaN
 throws.</p>
 
 <emu-alg>
-  1. Assert: Type(_highWaterMark_) is Number.
-  1. Assert: _highWaterMark_ is not NaN.
-  1. Assert: _highWaterMark_ is not negative.
+  1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>WritableStream</a>'s `prototype` property).
   1. Perform ! InitializeWritableStream(_stream_).
   1. Perform ! SetUpWritableStreamDefaultController(_stream_, _startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
@@ -4139,12 +4133,8 @@ throws.</p>
   1. If _writableSizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. If _readableHighWaterMark_ was not passed, set it to *0*.
   1. If _readableSizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
-  1. Assert: Type(_writableHighWaterMark_) is Number.
-  1. Assert: _writableHighWaterMark_ is not NaN.
-  1. Assert: _writableHighWaterMark_ is not negative.
-  1. Assert: Type(_readableHighWaterMark_) is Number.
-  1. Assert: _readableHighWaterMark_ is not NaN.
-  1. Assert: _readableHighWaterMark_ is not negative.
+  1. Assert: ! IsNonNegativeNumber(_writableHighWaterMark_) is *true*.
+  1. Assert: ! IsNonNegativeNumber(_readableHighWaterMark_) is *true*.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>TransformStream</a>'s `prototype` property).
   1. Let _startPromise_ be <a>a new promise</a>.
   1. Perform ! InitializeTransformStream(_stream_, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
@@ -4762,8 +4752,16 @@ A few abstract operations are used in this specification for utility purposes. W
 )</h4>
 
 <emu-alg>
-  1. If _v_ is *NaN*, return *false*.
+  1. If ! IsNonNegativeNumber(_v_) is *false*, return *false*.
   1. If _v_ is *+∞*, return *false*.
+  1. Return *true*.
+</emu-alg>
+
+<h4 id="is-non-negative-number" aoid="IsNonNegativeNumber" nothrow>IsNonNegativeNumber ( <var>v</var> )</h4>
+
+<emu-alg>
+  1. If Type(_v_) is not Number, return *false*.
+  1. If _v_ is *NaN*, return *false*.
   1. If _v_ < *0*, return *false*.
   1. Return *true*.
 </emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -126,7 +126,7 @@ read from disk. An example pull source is a file handle, where you seek to speci
 
 Readable streams are designed to wrap both types of sources behind a single, unified interface. For
 web developer–created streams, the implementation details of a source are provided by an object with certain methods and
-properties. It is passed to the {{ReadableStream()}} constructor.
+properties that is passed to the {{ReadableStream()}} constructor.
 
 <a>Chunks</a> are enqueued into the stream by the stream's <a>underlying source</a>. They can then be read one at a
 time via the stream's public interface, in particular by using a <a>readable stream reader</a> acquired using the
@@ -846,7 +846,7 @@ throws.</p>
   1. If _highWaterMark_ was not passed, set it to *1*.
   1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
-  1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
+  1. Let _stream_ be ObjectCreate(the original value of `<a idl>ReadableStream</a>`'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
   1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _highWaterMark_, _sizeAlgorithm_).
@@ -872,7 +872,7 @@ throws.</p>
   1. If _autoAllocateChunkSize_ is not *undefined*,
     1. Assert: ! IsInteger(_autoAllocateChunkSize_) is *true*.
     1. Assert: _autoAllocateChunkSize_ is positive.
-  1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
+  1. Let _stream_ be ObjectCreate(the original value of `<a idl>ReadableStream</a>`'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
   1. Perform ? SetUpReadableByteStreamController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _highWaterMark_, _autoAllocateChunkSize_).
@@ -962,7 +962,7 @@ noticable asymmetry between the two branches, and limits the possible <a>chunks<
       1. If _closedOrErrored_ is *true*, return.
       1. Let _value1_ and _value2_ be _value_.
       1. If _canceled2_ is *false* and _cloneForBranch2_ is *true*, set _value2_ to ? <a
-         abstract-op>StructuredDeserialize</a>(<a abstract-op>StructuredSerialize</a>(_value2_), the current Realm
+         abstract-op>StructuredDeserialize</a>(? <a abstract-op>StructuredSerialize</a>(_value2_), the current Realm
          Record).
       1. If _canceled1_ is *false*, perform ?
          ReadableStreamDefaultControllerEnqueue(_branch1_.[[readableStreamController]], _value1_).
@@ -1878,7 +1878,7 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorit
 
 <emu-alg>
   1. Assert: _stream_.[[readableStreamController]] is *undefined*.
-  1. Let _controller_ be ObjectCreate(the original value of <a idl>ReadableStreamDefaultController</a>'s `prototype`
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableStreamDefaultController</a>`'s `prototype`
      property).
   1. Set _controller_.[[controlledReadableStream]] to _stream_.
   1. Set _controller_.[[queue]] and _controller_.[[queueSize]] to *undefined*, then perform ! ResetQueue(_controller_).
@@ -1889,14 +1889,14 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorit
   1. Set _controller_.[[cancelAlgorithm]] to _cancelAlgorithm_.
   1. Set _stream_.[[readableStreamController]] to _controller_.
   1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)
-  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
-    1. <a>Upon fulfillment</a>  of _startPromise_,
-      1. Set _controller_.[[started]] to *true*.
-      1. Assert: _controller_.[[pulling]] is *false*.
-      1. Assert: _controller_.[[pullAgain]] is *false*.
-      1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
-    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_.
+  1. <a>Upon fulfillment</a>  of _startPromise_,
+    1. Set _controller_.[[started]] to *true*.
+    1. Assert: _controller_.[[pulling]] is *false*.
+    1. Assert: _controller_.[[pullAgain]] is *false*.
+    1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
+  1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+    1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
 </emu-alg>
 
 <h4 id="set-up-readable-stream-default-controller-from-underlying-source"
@@ -1933,7 +1933,7 @@ would look like
 
 <pre><code class="lang-javascript">
   class ReadableByteStreamController {
-    constructor(stream, underlyingByteSource, highWaterMark)
+    constructor() // always throws
 
     get byobRequest()
     get desiredSize()
@@ -2023,11 +2023,12 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
 </div>
 
 <h4 id="rbs-controller-constructor" constructor for="ReadableByteStreamController"
-lt="ReadableByteStreamController(stream, underlyingByteSource, highWaterMark)">new
-ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>, <var>highWaterMark</var>)</h4>
+lt="ReadableByteStreamController()">new
+ReadableByteStreamController()</h4>
 
 <div class="note">
-  The <code>ReadableByteStreamController</code> constructor cannot be used directly.
+  The <code>ReadableByteStreamController</code> constructor cannot be used directly;
+  {{ReadableByteStreamController}} instances are created automatically during {{ReadableStream}} construction.
 </div>
 
 <emu-alg>
@@ -2646,7 +2647,7 @@ throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>startAlgorith
   1. If _autoAllocateChunkSize_ is not *undefined*,
     1. Assert: ! IsInteger(_autoAllocateChunkSize_) is *true*.
     1. Assert: _autoAllocateChunkSize_ is positive.
-  1. Let _controller_ be ObjectCreate(the original value of <a idl>ReadableByteStreamController</a>'s `prototype`
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableByteStreamController</a>`'s `prototype`
      property).
   1. Set _controller_.[[controlledReadableByteStream]] to _stream_.
   1. Set _controller_.[[pullAgain]] and _controller_.[[pulling]] to *false*.
@@ -2660,14 +2661,14 @@ throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>startAlgorith
   1. Set _controller_.[[pendingPullIntos]] to a new empty List.
   1. Set _stream_.[[readableStreamController]] to _controller_.
   1. Let _startResult_ be the result of performing _startAlgorithm_.
-  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
-    1. <a>Upon fulfillment</a>  of _startPromise_,
-      1. Set _controller_.[[started]] to *true*.
-      1. Assert: _controller_.[[pulling]] is *false*.
-      1. Assert: _controller_.[[pullAgain]] is *false*.
-      1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
-    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-      1. If _stream_.[[state]] is `"readable"`, perform ! ReadableByteStreamControllerError(_controller_, _r_).
+  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_.
+  1. <a>Upon fulfillment</a>  of _startPromise_,
+    1. Set _controller_.[[started]] to *true*.
+    1. Assert: _controller_.[[pulling]] is *false*.
+    1. Assert: _controller_.[[pullAgain]] is *false*.
+    1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
+  1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+    1. If _stream_.[[state]] is `"readable"`, perform ! ReadableByteStreamControllerError(_controller_, _r_).
 </emu-alg>
 
 <h4 id="set-up-readable-byte-stream-controller-from-underlying-source"
@@ -2818,13 +2819,12 @@ Instances of {{WritableStream}} are created with the internal slots described in
   <tr>
     <td>\[[inFlightWriteRequest]]
     <td class="non-normative">A slot set to the promise for the current in-flight write operation while the
-      <a>underlying sink</a>'s <code>write</code> algorithm is executing and has not yet fulfilled, used to prevent
-      reentrant calls
+      <a>underlying sink</a>'s write algorithm is executing and has not yet fulfilled, used to prevent reentrant calls
   </tr>
   <tr>
     <td>\[[inFlightCloseRequest]]
     <td class="non-normative">A slot set to the promise for the current in-flight close operation while the
-      <a>underlying sink</a>'s <code>close</code> algorithm is executing and has not yet fulfilled, used to prevent the
+      <a>underlying sink</a>'s close algorithm is executing and has not yet fulfilled, used to prevent the
       {{WritableStreamDefaultWriter/abort()}} method from interrupting close
   </tr>
   <tr>
@@ -2907,14 +2907,14 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
 </div>
 
 <emu-alg>
-  1. Perform ! InitializeWritableStream(_this_);
+  1. Perform ! InitializeWritableStream(_this_).
   1. Let _type_ be ? GetV(_underlyingSink_, `"type"`).
   1. If _type_ is not *undefined*, throw a *RangeError* exception. <p class="note">This is to allow us to add new
      potential types in the future, without backward-compatibility concerns.</p>
   1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
   1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
   1. Perform ! SetUpWritableStreamDefaultControllerFromUnderlyingSink(*this*, _underlyingSink_, _highWaterMark_,
-     _sizeAlgorithm_);
+     _sizeAlgorithm_).
 </emu-alg>
 
 <h4 id="ws-prototype">Properties of the {{WritableStream}} Prototype</h4>
@@ -2989,7 +2989,7 @@ throws.</p>
   1. If _highWaterMark_ was not passed, set it to *1*.
   1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
-  1. Let _stream_ be ObjectCreate(the original value of <a idl>WritableStream</a>'s `prototype` property).
+  1. Let _stream_ be ObjectCreate(the original value of `<a idl>WritableStream</a>`'s `prototype` property).
   1. Perform ! InitializeWritableStream(_stream_).
   1. Perform ! SetUpWritableStreamDefaultController(_stream_, _startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
      _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
@@ -3676,7 +3676,8 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
 lt="WritableStreamDefaultController()">new WritableStreamDefaultController()</h4>
 
 <div class="note">
-  The <code>WritableStreamDefaultController</code> constructor cannot be used directly.
+  The <code>WritableStreamDefaultController</code> constructor cannot be used directly;
+  {{WritableStreamDefaultController}} instances are created automatically during {{WritableStream}} construction.
 </div>
 
 <emu-alg>
@@ -3729,6 +3730,15 @@ used polymorphically.
 
 <h3 id="ws-default-controller-abstract-ops">Writable Stream Default Controller Abstract Operations</h3>
 
+<h4 id="is-writable-stream-default-controller" aoid="IsWritableStreamDefaultController"
+nothrow>IsWritableStreamDefaultController ( <var>x</var> )</h4>
+
+<emu-alg>
+  1. If Type(_x_) is not Object, return *false*.
+  1. If _x_ does not have an [[controlledWritableStream]] internal slot, return *false*.
+  1. Return *true*.
+</emu-alg>
+
 <h4 id="set-up-writable-stream-default-controller" aoid="SetUpWritableStreamDefaultController"
 throws>SetUpWritableStreamDefaultController ( <var>stream</var>, <var>startAlgorithm</var>, <var>writeAlgorithm</var>,
 <var>closeAlgorithm</var>, <var>abortAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
@@ -3736,7 +3746,7 @@ throws>SetUpWritableStreamDefaultController ( <var>stream</var>, <var>startAlgor
 <emu-alg>
   1. Assert: ! IsWritableStream(_stream_) is *true*.
   1. Assert: _stream_.[[writableStreamController]] is *undefined*.
-  1. Let _controller_ be ObjectCreate(the original value of <a idl>WritableStreamDefaultController</a>'s `prototype`
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
      property).
   1. Set _controller_.[[controlledWritableStream]] to _stream_.
   1. Set _stream_.[[writableStreamController]] to _controller_.
@@ -3750,15 +3760,15 @@ throws>SetUpWritableStreamDefaultController ( <var>stream</var>, <var>startAlgor
   1. Let _backpressure_ be ! WritableStreamDefaultControllerGetBackpressure(_controller_).
   1. Perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
   1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)
-  1. Let _startPromise_ be a promise resolve with _startResult_:
-    1. <a>Upon fulfillment</a> of _startPromise_,
-      1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
-      1. Set _controller_.[[started]] to *true*.
-      1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
-    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-      1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
-      1. Set _controller_.[[started]] to *true*.
-      1. Perform ! WritableStreamDealWithRejection(_stream_, _r_).
+  1. Let _startPromise_ be a promise resolve with _startResult_.
+  1. <a>Upon fulfillment</a> of _startPromise_,
+    1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+    1. Set _controller_.[[started]] to *true*.
+    1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
+  1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+    1. Assert: _stream_.[[state]] is `"writable"` or `"erroring"`.
+    1. Set _controller_.[[started]] to *true*.
+    1. Perform ! WritableStreamDealWithRejection(_stream_, _r_).
 </emu-alg>
 
 <h4 id="set-up-writable-stream-default-controller-from-underlying-sink"
@@ -3779,15 +3789,6 @@ throws>SetUpWritableStreamDefaultControllerFromUnderlyingSink ( <var>stream</var
      _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
 </emu-alg>
 
-<h4 id="is-writable-stream-default-controller" aoid="IsWritableStreamDefaultController"
-nothrow>IsWritableStreamDefaultController ( <var>x</var> )</h4>
-
-<emu-alg>
-  1. If Type(_x_) is not Object, return *false*.
-  1. If _x_ does not have an [[controlledWritableStream]] internal slot, return *false*.
-  1. Return *true*.
-</emu-alg>
-
 <h4 id="writable-stream-default-controller-close" aoid="WritableStreamDefaultControllerClose"
 nothrow>WritableStreamDefaultControllerClose ( <var>controller</var> )</h4>
 
@@ -3800,7 +3801,7 @@ nothrow>WritableStreamDefaultControllerClose ( <var>controller</var> )</h4>
 nothrow>WritableStreamDefaultControllerGetChunkSize ( <var>controller</var>, <var>chunk</var> )</h4>
 
 <emu-alg>
-  1. Let _returnValue_ be the result of performing _controller_.[[strategySizeAlgorithm]]_, passing in _chunk_, and
+  1. Let _returnValue_ be the result of performing _controller_.[[strategySizeAlgorithm]], passing in _chunk_, and
      interpreting the result as an ECMAScript completion value.
   1. If _returnValue_ is an abrupt completion,
     1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(_controller_, _returnValue_.[[Value]]).
@@ -4030,8 +4031,8 @@ Instances of {{TransformStream}} are created with the internal slots described i
 </table>
 
 <h4 id="ts-constructor" constructor for="TransformStream" lt="TransformStream(transformer, writableStrategy,
-readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writableStrategy</var> = {}, {
-<var>size</var>, <var>highWaterMark</var> = 0 } = {})</h4>
+readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writableStrategy</var> = {},
+<var>readableStrategy</var> = {})</h4>
 
 <div class="note">
   The <code>transformer</code> object passed to the constructor can implement any of the following methods to govern
@@ -4075,14 +4076,17 @@ readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writabl
   1. If _readableType_ is not *undefined*, throw a *RangeError* exception.
   1. Let _writableType_ be ? GetV(_transformer_, `"writableType"`).
   1. If _writableType_ is not *undefined*, throw a *RangeError* exception.
-  1. Let _startPromise_ be <a>a new promise</a>.
   1. Let _writableSizeFunction_ be ? GetV(_writableStrategy_, `"size"`).
   1. Let _writableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_writableSizeFunction_).
   1. Let _writableHighWaterMark_ be ? GetV(_writableStrategy_, `"highWaterMark"`).
   1. If _writableHighWaterMark_ is *undefined*, set _writableHighWaterMark_ to *1*.
   1. Set _writableHighWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_writableHighWaterMark_).
-  1. Let _readableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
-  1. Let _readableHighWaterMark_ be ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
+  1. Let _readableSizeFunction_ be ? GetV(_readableStrategy_, `"size"`).
+  1. Let _readableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_readableSizeFunction_).
+  1. Let _readableHighWaterMark_ be ? GetV(_readableStrategy_, `"highWaterMark"`).
+  1. If _readableHighWaterMark_ is *undefined*, set _readableHighWaterMark_ to *0*.
+  1. Set _readableHighWaterMark_ be ? ValidateAndNormalizeHighWaterMark(_readableHighWaterMark_).
+  1. Let _startPromise_ be <a>a new promise</a>.
   1. Perform ! InitializeTransformStream(*this*, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
   1. Perform ! SetUpTransformStreamDefaultControllerFromTransformer(*this*, _transformer_).
@@ -4137,7 +4141,7 @@ throws.</p>
   1. If _readableSizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. Assert: ! IsNonNegativeNumber(_writableHighWaterMark_) is *true*.
   1. Assert: ! IsNonNegativeNumber(_readableHighWaterMark_) is *true*.
-  1. Let _stream_ be ObjectCreate(the original value of <a idl>TransformStream</a>'s `prototype` property).
+  1. Let _stream_ be ObjectCreate(the original value of `<a idl>TransformStream</a>`'s `prototype` property).
   1. Let _startPromise_ be <a>a new promise</a>.
   1. Perform ! InitializeTransformStream(_stream_, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
@@ -4238,7 +4242,7 @@ it would look like
 
 <pre><code class="lang-javascript">
   class TransformStreamDefaultController {
-    constructor(stream)
+    constructor() // always throws
 
     get desiredSize()
 
@@ -4272,7 +4276,8 @@ Instances of {{TransformStreamDefaultController}} are created with the internal 
 lt="TransformStreamDefaultController()">new TransformStreamDefaultController()</h4>
 
 <div class="note">
-  The <code>TransformStreamDefaultController</code> constructor cannot be used directly.
+  The <code>TransformStreamDefaultController</code> constructor cannot be used directly;
+  {{TransformStreamDefaultController}} instances are created automatically during {{TransformStream}} construction.
 </div>
 
 <emu-alg>
@@ -4350,7 +4355,7 @@ nothrow>SetUpTransformStreamDefaultController ( <var>stream</var>, <var>transfor
 <emu-alg>
   1. Assert: ! IsTransformStream(_stream_) is *true*.
   1. Assert: _stream_.[[writableStreamController]] is *undefined*.
-  1. Let _controller_ be ObjectCreate(the original value of <a idl>TransformStreamDefaultController</a>'s `prototype`
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
      property).
   1. Set _controller_.[[controlledTransformStream]] to _stream_.
   1. Set _stream_.[[transformStreamController]] to _controller_.
@@ -4450,7 +4455,7 @@ nothrow>TransformStreamDefaultSinkAbortAlgorithm ( <var>stream</var> )</h4>
 </emu-alg>
 
 <h4 id="transform-stream-default-sink-close-algorithm" aoid="TransformStreamDefaultSinkCloseAlgorithm"
-nothrow>TransformStreamDefaultSinkCloseAlgorithm( _stream_ )</h4>
+nothrow>TransformStreamDefaultSinkCloseAlgorithm( <var>stream</var> )</h4>
 
 <emu-alg>
   1. Let _readable_ be _stream_.[[readable]].
@@ -4498,7 +4503,8 @@ nothrow>TransformStreamDefaultSinkTransform ( <var>stream</var>, <var>transforme
 <h3 id="ts-default-source-abstract-ops">Transform Stream Default Source Abstract Operations</h3>
 
 <h4 id="transform-stream-default-source-pull"
-aoid="TransformStreamDefaultSourcePullAlgorithm" nothrow>TransformStreamDefaultSourcePullAlgorithm( _stream_ )</h4>
+aoid="TransformStreamDefaultSourcePullAlgorithm" nothrow>TransformStreamDefaultSourcePullAlgorithm( <var>stream</var>
+)</h4>
 
 <emu-alg>
   1. Assert: _stream_.[[backpressure]] is *true*.

--- a/index.bs
+++ b/index.bs
@@ -503,13 +503,13 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 </div>
 
 <emu-alg>
-  1. Set *this*.[[state]] to `"readable"`.
-  1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
-  1. Set *this*.[[disturbed]] to *false*.
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _typeString_ be ? ToString(_type_).
   1. If _typeString_ is `"bytes"`,
     1. If _size_ is not *undefined*, throw a *RangeError* exception.
+    1. Set *this*.[[state]] to `"readable"`.
+    1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
+    1. Set *this*.[[disturbed]] to *false*.
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. Set *this*.[[readableStreamController]] to *undefined*.
@@ -519,7 +519,8 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. Let _sizeAlgorithm_ be *undefined*.
-    1. If _size_ is not *undefined*,
+    1. If _size_ is *undefined*, set _sizeAlgorithm_ to an algorithm that returns *1*.
+    1. Otherwise:
       1. If ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
       1. Set _sizeAlgorithm_ to the following steps, taking a _chunk_ argument:
         1. Return ? Call(_size_, *undefined*, « _chunk_ »).
@@ -530,8 +531,8 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
       1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
     1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
       1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
-    1. Perform ? SetUpReadableStreamDefaultController(*this*, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
-       _sizeAlgorithm_, _highWaterMark_).
+    1. Perform ? InitializeReadableStream(*this*, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+       _highWaterMark_, _sizeAlgorithm_).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
 
@@ -846,23 +847,38 @@ reader</a> for a given stream.
 </emu-alg>
 
 <h4 id="create-readable-stream" aoid="CreateReadableStream" nothrow export>CreateReadableStream (
-<var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>sizeAlgorithm</var> [ , <var>highWaterMark</var> ] ] )</h4>
+<var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>highWaterMark</var> [, <var>sizeAlgorithm</var> ] ] )</h4>
 
 This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
 instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return promises; if supplied,
-<var>sizeAlgorithm</var> must be either an algorithm accepting <a>chunk</a> objects and returning a number, or or
-*undefined*; and if supplied, <var>highWaterMark</var> must be a nonnegative, finite number.
+<var>sizeAlgorithm</var> must be an algorithm accepting <a>chunk</a> objects and returning a number; and if supplied,
+<var>highWaterMark</var> must be a nonnegative, finite number.
 
 <emu-alg>
-  1. If _size_ was not passed, set it to *undefined*.
+  1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. If _highWaterMark_ was not passed, set it to *1*.
+  1. Assert: Type(_highWaterMark_) is Number.
+  1. Assert: _highWaterMark_ is not NaN.
+  1. Assert: _highWaterMark_ is not +∞.
+  1. Assert: _highWaterMark_ is not negative.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
+  1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
+  1. Let _result_ be InitializeReadableStream(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+     _sizeAlgorithm_, _highWaterMark_).
+  1. Assert: _result_ is not an <a>abrupt completion</a>.
+  1. Return _stream_.
+</emu-alg>
+
+<h4 id="initialize-readable-stream" aoid="InitializeReadableStream" throws>InitializeReadableStream (
+<var>stream</var>, <var>startAlgorithm</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var>,
+<var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
+
+<emu-alg>
   1. Set _stream_.[[state]] to `"readable"`.
   1. Set _stream_.[[reader]] and _stream_.[[storedError]] to *undefined*.
   1. Set _stream_.[[disturbed]] to *false*.
-  1. Perform ! SetUpReadableStreamDefaultController(_stream_, *undefined*, _pullAlgorithm_, _cancelAlgorithm_,
+  1. Perform ! SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _sizeAlgorithm_, _highWaterMark_).
-  1. Return _stream_.
 </emu-alg>
 
 <h4 id="is-readable-stream" aoid="IsReadableStream" nothrow>IsReadableStream ( <var>x</var> )</h4>
@@ -1771,14 +1787,12 @@ asserts).
   1. If ! IsReadableStreamLocked(_stream_) is *true* and ! ReadableStreamGetNumReadRequests(_stream_) > *0*, perform
      ! ReadableStreamFulfillReadRequest(_stream_, _chunk_, *false*).
   1. Otherwise,
-    1. Let _chunkSize_ be *1*.
-    1. If _controller_.[[strategySizeAlgorithm]] is not *undefined*,
-      1. Set _chunkSize_ to the result of performing _controller_.[[strategySizeAlgorithm]], passing in _chunk_, and
-         interpreting the result as an ECMAScript completion value.
-      1. If _chunkSize_ is an abrupt completion,
-        1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _chunkSize_.[[Value]]).
-        1. Return _chunkSize_.
-      1. Let _chunkSize_ be _chunkSize_.[[Value]].
+    1. Let _result_ be the result of performing _controller_.[[strategySizeAlgorithm]], passing in _chunk_, and
+       interpreting the result as an ECMAScript completion value.
+    1. If _result_ is an abrupt completion,
+      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _result_.[[Value]]).
+      1. Return _result_.
+    1. Let _chunkSize_ be _result_.[[Value]].
     1. Let _enqueueResult_ be EnqueueValueWithSize(_controller_, _chunk_, _chunkSize_).
     1. If _enqueueResult_ is an abrupt completion,
       1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _enqueueResult_.[[Value]]).
@@ -1853,7 +1867,7 @@ nothrow>ReadableStreamDefaultControllerCanCloseOrEnqueue ( <var>controller</var>
 
 <h4 id="set-up-readable-stream-default-controller" aoid="SetUpReadableStreamDefaultController"
 throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorithm</var>, <var>pullAlgorithm</var>,
-<var>cancelAlgorithm</var>, <var>sizeAlgorithm</var>, <var>highWaterMark</var>)</h4>
+<var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
   1. Assert: ! IsReadableStream(_stream_) is *true*.

--- a/index.bs
+++ b/index.bs
@@ -1918,6 +1918,10 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
       this value specifies the size of buffer to allocate. It is <emu-val>undefined</emu-val> otherwise.
   </tr>
   <tr>
+    <td>\[[byobRequest]]
+    <td class="non-normative">A {{ReadableStreamBYOBRequest}} instance representing the current BYOB pull request
+  </tr>
+  <tr>
     <td>\[[closeRequested]]
     <td class="non-normative">A boolean flag indicating whether the stream has been closed by its <a>underlying byte
       source</a>, but still has <a>chunks</a> in its internal queue that have not yet been read
@@ -1936,10 +1940,6 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
     <td>\[[pulling]]
     <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> while the <a>underlying byte source</a>'s
       <code>pull</code> method is executing and has not yet fulfilled, used to prevent reentrant calls
-  </tr>
-  <tr>
-    <td>\[[byobRequest]]
-    <td class="non-normative">A {{ReadableStreamBYOBRequest}} instance representing the current BYOB pull request
   </tr>
   <tr>
     <td>\[[pendingPullIntos]]

--- a/index.bs
+++ b/index.bs
@@ -837,13 +837,17 @@ reader</a> for a given stream.
   1. Return ? Construct(`<a idl>ReadableStreamDefaultReader</a>`, « _stream_ »).
 </emu-alg>
 
-<h4 id="create-readable-stream" aoid="CreateReadableStream" nothrow export>CreateReadableStream (
-<var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>highWaterMark</var> [, <var>sizeAlgorithm</var> ] ] )</h4>
+<h4 id="create-readable-stream" aoid="CreateReadableStream" throws export>CreateReadableStream (
+<var>startAlgorithm</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>highWaterMark</var> [,
+<var>sizeAlgorithm</var> ] ] )</h4>
 
 This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
-instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return promises; if supplied,
-<var>sizeAlgorithm</var> must be an algorithm accepting <a>chunk</a> objects and returning a number; and if supplied,
-<var>highWaterMark</var> must be a nonnegative, finite number.
+instances. The <var>startAlgorithm</var>, <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return
+promises; if supplied, <var>sizeAlgorithm</var> must be an algorithm accepting <a>chunk</a> objects and returning a
+number; and if supplied, <var>highWaterMark</var> must be a nonnegative, finite number.
+
+<p class="note">CreateReadableStream throws an exception if and only if the supplied <var>startAlgorithm</var>
+throws.</p>
 
 <emu-alg>
   1. If _highWaterMark_ was not passed, set it to *1*.
@@ -855,7 +859,7 @@ instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithm
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
   1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
-  1. Perform ! SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _sizeAlgorithm_, _highWaterMark_).
   1. Return _stream_.
 </emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -510,11 +510,18 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
   1. If _typeString_ is `"bytes"`,
     1. If _size_ is not *undefined*, throw a *RangeError* exception.
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
+    1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. Set *this*.[[readableStreamController]] to *undefined*.
     1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableByteStreamController</a>`, « *this*,
        _underlyingSource_, _highWaterMark_ »).
   1. Otherwise, if _type_ is *undefined*,
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
+    1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
+    1. Let _sizeAlgorithm_ be *undefined*.
+    1. If _size_ is not *undefined*,
+      1. If ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
+      1. Set _sizeAlgorithm_ to the following steps, taking a _chunk_ argument:
+        1. Return ? Call(_size_, *undefined*, « _chunk_ »).
     1. Let _stream_ be *this*.
     1. Let _startAlgorithm_ be the following steps:
       1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _stream_.[[readableStreamController]] »).
@@ -522,8 +529,8 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
       1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
     1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
       1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
-    1. Perform ? SetUpReadableStreamDefaultController(*this*, _size_, _highWaterMark_, _startAlgorithm_,
-       _pullAlgorithm_, _cancelAlgorithm_ »).
+    1. Perform ? SetUpReadableStreamDefaultController(*this*, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+       _sizeAlgorithm_, _highWaterMark_).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
 
@@ -838,12 +845,12 @@ reader</a> for a given stream.
 </emu-alg>
 
 <h4 id="create-readable-stream" aoid="CreateReadableStream" nothrow export>CreateReadableStream (
-<var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>size</var> [ , <var>highWaterMark</var> ] ] )</h4>
+<var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>sizeAlgorithm</var> [ , <var>highWaterMark</var> ] ] )</h4>
 
 This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
 instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return promises; if supplied,
-<var>size</var> must be either a function of one argument that returns a number or *undefined*; and if supplied,
-<var>highWaterMark</var> must be a nonnegative, finite number.
+<var>sizeAlgorithm</var> must be either an algorithm accepting <a>chunk</a> objects and returning a number, or or
+*undefined*; and if supplied, <var>highWaterMark</var> must be a nonnegative, finite number.
 
 <emu-alg>
   1. If _size_ was not passed, set it to *undefined*.
@@ -852,8 +859,8 @@ instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithm
   1. Set _stream_.[[state]] to `"readable"`.
   1. Set _stream_.[[reader]] and _stream_.[[storedError]] to *undefined*.
   1. Set _stream_.[[disturbed]] to *false*.
-  1. Perform ! SetUpReadableStreamDefaultController(_stream_, _size_, _highWaterMark_, *undefined*, _pullAlgorithm_,
-     _cancelAlgorithm_).
+  1. Perform ! SetUpReadableStreamDefaultController(_stream_, *undefined*, _pullAlgorithm_, _cancelAlgorithm_,
+     _sizeAlgorithm_, _highWaterMark_).
   1. Return _stream_.
 </emu-alg>
 
@@ -1589,9 +1596,9 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
       indicating the point at which the stream will apply <a>backpressure</a> to its <a>underlying source</a>
   </tr>
   <tr>
-    <td>\[[strategySize]]
-    <td class="non-normative">A function supplied to the constructor as part of the stream's <a>queuing strategy</a>,
-      designed to calculate the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default behavior
+    <td>\[[strategySizeAlgorithm]]
+    <td class="non-normative">An algorithm to calculate the size of enqueued <a>chunks</a>, as part of the stream's
+      <a>queuing strategy</a>.
   </tr>
 </table>
 
@@ -1764,8 +1771,9 @@ asserts).
      ! ReadableStreamFulfillReadRequest(_stream_, _chunk_, *false*).
   1. Otherwise,
     1. Let _chunkSize_ be *1*.
-    1. If _controller_.[[strategySize]] is not *undefined*,
-      1. Set _chunkSize_ to Call(_controller_.[[strategySize]], *undefined*, « _chunk_ »).
+    1. If _controller_.[[strategySizeAlgorithm]] is not *undefined*,
+      1. Set _chunkSize_ to the result of performing _controller_.[[strategySizeAlgorithm]], passing in _chunk_, and
+         interpreting the result as an ECMAScript completion value.
       1. If _chunkSize_ is an abrupt completion,
         1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _chunkSize_.[[Value]]).
         1. Return _chunkSize_.
@@ -1843,8 +1851,8 @@ nothrow>ReadableStreamDefaultControllerCanCloseOrEnqueue ( <var>controller</var>
 </div>
 
 <h4 id="set-up-readable-stream-default-controller" aoid="SetUpReadableStreamDefaultController"
-throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>size</var>, <var>highWaterMark</var>,
-<var>startAlgorithm</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var>)</h4>
+throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorithm</var>, <var>pullAlgorithm</var>,
+<var>cancelAlgorithm</var>, <var>sizeAlgorithm</var>, <var>highWaterMark</var>)</h4>
 
 <emu-alg>
   1. Assert: ! IsReadableStream(_stream_) is *true*.
@@ -1855,9 +1863,7 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>size</var>, 
   1. Set _controller_.[[queue]] and _controller_.[[queueSize]] to *undefined*, then perform ! ResetQueue(_controller_).
   1. Set _controller_.[[started]], _controller_.[[closeRequested]], _controller_.[[pullAgain]], and
      _controller_.[[pulling]] to *false*.
-  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
-  1. Set _controller_.[[strategySize]] to _normalizedStrategy_.[[size]] and _controller_.[[strategyHWM]] to
-     _normalizedStrategy_.[[highWaterMark]].
+  1. Set _controller_.[[strategySizeAlgorithm]] to _sizeAlgorithm_ and _controller_.[[strategyHWM]] to _highWaterMark_.
   1. Set _controller_.[[pullAlgorithm]] to _pullAlgorithm_.
   1. Set _controller_.[[cancelAlgorithm]] to _cancelAlgorithm_.
   1. Set _stream_.[[readableStreamController]] to _controller_.

--- a/index.bs
+++ b/index.bs
@@ -179,7 +179,8 @@ side.
 
 Concretely, any object with a <code>writable</code> property and a <code>readable</code> property can serve as a
 transform stream. However, the standard {{TransformStream}} class makes it much easier to create such a pair that is
-properly entangled. It wraps a <dfn>transformer</dfn> object which defines the specific transformation to be performed.
+properly entangled. It wraps a <dfn>transformer</dfn>, which defines algorithms for the specific transformation to be
+performed.
 
 An <dfn>identity transform stream</dfn> is a type of transform stream which forwards all <a>chunks</a> written to its
 <a>writable side</a> to its <a>readable side</a>, without any changes. This can be useful in <a
@@ -4229,7 +4230,7 @@ the promise always resolves.</p>
 <code>TransformStreamDefaultController</code></h3>
 
 The {{TransformStreamDefaultController}} class has methods that allow manipulation of the associated {{ReadableStream}}
-and {{WritableStream}}. When constructing a {{TransformStream}}, the <a>transformer</a> is given a corresponding
+and {{WritableStream}}. When constructing a {{TransformStream}}, the <a>transformer</a> object is given a corresponding
 {{TransformStreamDefaultController}} instance to manipulate.
 
 <h4 id="ts-default-controller-class-definition">Class Definition</h4>

--- a/index.bs
+++ b/index.bs
@@ -506,12 +506,12 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _typeString_ be ? ToString(_type_).
   1. If _typeString_ is `"bytes"`,
+    1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
+    1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. If _size_ is not *undefined*, throw a *RangeError* exception.
     1. Set *this*.[[state]] to `"readable"`.
     1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
     1. Set *this*.[[disturbed]] to *false*.
-    1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
-    1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. Set *this*.[[readableStreamController]] to *undefined*.
     1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableByteStreamController</a>`, « *this*,
        _underlyingSource_, _highWaterMark_ »).
@@ -855,8 +855,8 @@ instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithm
 <var>highWaterMark</var> must be a nonnegative, finite number.
 
 <emu-alg>
-  1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. If _highWaterMark_ was not passed, set it to *1*.
+  1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. Assert: Type(_highWaterMark_) is Number.
   1. Assert: _highWaterMark_ is not NaN.
   1. Assert: _highWaterMark_ is not +∞.

--- a/index.bs
+++ b/index.bs
@@ -516,12 +516,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
   1. Otherwise, if _type_ is *undefined*,
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
-    1. Let _sizeAlgorithm_ be *undefined*.
-    1. If _size_ is *undefined*, set _sizeAlgorithm_ to an algorithm that returns *1*.
-    1. Otherwise:
-      1. If ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
-      1. Set _sizeAlgorithm_ to the following steps, taking a _chunk_ argument:
-        1. Return ? Call(_size_, *undefined*, « _chunk_ »).
+    1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
     1. Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource(*this*, _underlyingSource_,
        _highWaterMark_, _sizeAlgorithm_).
   1. Otherwise, throw a *RangeError* exception.
@@ -2867,12 +2862,7 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
   1. Let _type_ be ? GetV(_underlyingSink_, `"type"`).
   1. If _type_ is not *undefined*, throw a *RangeError* exception. <p class="note">This is to allow us to add new
      potential types in the future, without backward-compatibility concerns.</p>
-  1. Let _sizeAlgorithm_ be *undefined;
-  1. If _size_ is *undefined*, set _sizeAlgorithm_ to an algorithm that returns *1*.
-  1. Otherwise,
-    1. If ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
-    1. Set _sizeAlgorithm_ to the following steps, taking a _chunk_ argument:
-      1. Return ? Call(_size_, *undefined*, « _chunk_ »).
+  1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
   1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
   1. Perform ! SetUpWritableStreamDefaultControllerFromUnderlyingSink(*this*, _underlyingSink_, _highWaterMark_,
      _sizeAlgorithm_);
@@ -4840,13 +4830,14 @@ throws>ValidateAndNormalizeHighWaterMark ( <var>highWaterMark</var> )</h4>
   1. Return _highWaterMark_.
 </emu-alg>
 
-<h4 id="validate-and-normalize-queuing-strategy" aoid="ValidateAndNormalizeQueuingStrategy"
-throws>ValidateAndNormalizeQueuingStrategy ( <var>size</var>, <var>highWaterMark</var> )</h4>
+<h4 id="make-size-algorithm-from-size-function" aoid="MakeSizeAlgorithmFromSizeFunction"
+throws>MakeSizeAlgorithmFromSizeFunction ( <var>size</var> )</h4>
 
 <emu-alg>
-  1. If _size_ is not *undefined* and ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
-  1. Let _highWaterMark_ be ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
-  1. Return Record {[[size]]: _size_, [[highWaterMark]]: _highWaterMark_}.
+  1. If _size_ is *undefined*, return an algorithm that returns *1*.
+  1. If ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
+  1. Return an algorithm that performs the following steps, taking a _chunk_ argument:
+    1. Return ? Call(_size_, *undefined*, « _chunk_ »).
 </emu-alg>
 
 <h2 id="globals">Global Properties</h2>

--- a/index.bs
+++ b/index.bs
@@ -515,8 +515,15 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
        _underlyingSource_, _highWaterMark_ »).
   1. Otherwise, if _type_ is *undefined*,
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
-    1. Perform ? CreateReadableStreamDefaultControllerFromUnderlyingSourceObject(*this*, _size_, _highWaterMark_,
-       _underlyingSource_ »).
+    1. Let _stream_ be *this*.
+    1. Let _startAlgorithm_ be the following steps:
+      1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _stream_.[[readableStreamController]] »).
+    1. Let _pullAlgorithm_ be the following steps:
+      1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
+    1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
+      1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
+    1. Perform ? SetUpReadableStreamDefaultController(*this*, _size_, _highWaterMark_, _startAlgorithm_,
+       _pullAlgorithm_, _cancelAlgorithm_ »).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
 
@@ -835,8 +842,8 @@ reader</a> for a given stream.
 
 This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
 instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return promises; if supplied,
-<var>size</var> must be a function of one argument that returns a number; and if supplied, <var>highWaterMark</var> must
-be a nonnegative, finite number.
+<var>size</var> must be either a function of one argument that returns a number or *undefined*; and if supplied,
+<var>highWaterMark</var> must be a nonnegative, finite number.
 
 <emu-alg>
   1. If _size_ was not passed, set it to *undefined*.
@@ -845,8 +852,8 @@ be a nonnegative, finite number.
   1. Set _stream_.[[state]] to `"readable"`.
   1. Set _stream_.[[reader]] and _stream_.[[storedError]] to *undefined*.
   1. Set _stream_.[[disturbed]] to *false*.
-  1. Perform ! CreateReadableStreamDefaultControllerFromUnderlyingSourceAlgorithms(_stream_, _size_, _highWaterMark_,
-     _pullAlgorithm_, _cancelAlgorithm_).
+  1. Perform ! SetUpReadableStreamDefaultController(_stream_, _size_, _highWaterMark_, *undefined*, _pullAlgorithm_,
+     _cancelAlgorithm_).
   1. Return _stream_.
 </emu-alg>
 
@@ -1684,66 +1691,6 @@ readable stream implementation will polymorphically call to either these or thei
 
 <h3 id="rs-default-controller-abstract-ops">Readable Stream Default Controller Abstract Operations</h3>
 
-<h4 id="create-readable-stream-default-controller-from-underlying-source-object"
-aoid="CreateReadableStreamDefaultControllerFromUnderlyingSourceObject"
-throws>CreateReadableStreamDefaultControllerFromUnderlyingSourceObject(<var>stream</var>, <var>size</var>,
-<var>highWaterMark</var>, <var>underlyingSource</var>)</h4>
-
-<emu-alg>
-  1. Let _controller_ be CreateReadableStreamDefaultControllerSharedSetup(_stream_, _size_, _highWaterMark_).
-  1. Set _controller_.[[pullAlgorithm]] to an algorithm, taking no parameters, which runs the following steps:
-    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _controller_ »).
-  1. Set _controller_.[[cancelAlgorithm]] to an algorithm, taking one parameter _reason_, which runs the following
-     steps:
-    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
-  1. Let _startResult_ be ? InvokeOrNoop(_underlyingSource_, `"start"`, « _controller_ »).
-  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
-    1. <a>Upon fulfillment</a>  of _startPromise_,
-      1. Set _controller_.[[started]] to *true*.
-      1. Assert: _controller_.[[pulling]] is *false*.
-      1. Assert: _controller_.[[pullAgain]] is *false*.
-      1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
-    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
-  1. Return _controller_.
-</emu-alg>
-
-<h4 id="create-readable-stream-default-controller-from-underlying-source-algorithms"
-aoid="CreateReadableStreamDefaultControllerFromUnderlyingSourceAlgorithms"
-throws>CreateReadableStreamDefaultControllerFromUnderlyingSourceAlgorithms(<var>stream</var>, <var>size</var>,
-<var>highWaterMark</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var>)</h4>
-
-<emu-alg>
-  1. Let _controller_ be CreateReadableStreamDefaultControllerSharedSetup(_stream_, _size_, _highWaterMark_).
-  1. Set _controller_.[[pullAlgorithm]] to _pullAlgorithm_.
-  1. Set _controller_.[[cancelAlgorithm]] to _cancelAlgorithm_.
-  1. <a>Queue a microtask</a> to perform the following steps:
-    1. Set _controller_.[[started]] to *true*.
-    1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
-  1. Return _controller_.
-</emu-alg>
-
-<h4 id="create-readable-stream-default-controller-shared-setup"
-aoid="CreateReadableStreamDefaultControllerSharedSetup"
-throws>CreateReadableStreamDefaultControllerSharedSetup(<var>stream</var>, <var>size</var>,
-<var>highWaterMark</var>)</h4>
-
-<emu-alg>
-  1. Assert: ! IsReadableStream(_stream_) is *true*.
-  1. Assert: _stream_.[[readableStreamController]] is *undefined*.
-  1. Let _controller_ be ObjectCreate(the original value of <a idl>ReadableStreamDefaultController</a>'s `prototype`
-     property).
-  1. Set _controller_.[[controlledReadableStream]] to _stream_.
-  1. Set _controller_.[[queue]] and _controller_.[[queueSize]] to *undefined*, then perform ! ResetQueue(_controller_).
-  1. Set _controller_.[[started]], _controller_.[[closeRequested]], _controller_.[[pullAgain]], and
-     _controller_.[[pulling]] to *false*.
-  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
-  1. Set _controller_.[[strategySize]] to _normalizedStrategy_.[[size]] and _controller_.[[strategyHWM]] to
-     _normalizedStrategy_.[[highWaterMark]].
-  1. Set _stream_.[[readableStreamController]] to _controller_.
-  1. Return _controller_.
-</emu-alg>
-
 <h4 id="is-readable-stream-default-controller" aoid="IsReadableStreamDefaultController"
 nothrow>IsReadableStreamDefaultController ( <var>x</var> )</h4>
 
@@ -1894,6 +1841,36 @@ nothrow>ReadableStreamDefaultControllerCanCloseOrEnqueue ( <var>controller</var>
   when it is closed without its controller's <code>close</code> method ever being called: e.g., if the stream was closed
   by a call to {{ReadableStream/cancel(reason)}}.
 </div>
+
+<h4 id="set-up-readable-stream-default-controller" aoid="SetUpReadableStreamDefaultController"
+throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>size</var>, <var>highWaterMark</var>,
+<var>startAlgorithm</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var>)</h4>
+
+<emu-alg>
+  1. Assert: ! IsReadableStream(_stream_) is *true*.
+  1. Assert: _stream_.[[readableStreamController]] is *undefined*.
+  1. Let _controller_ be ObjectCreate(the original value of <a idl>ReadableStreamDefaultController</a>'s `prototype`
+     property).
+  1. Set _controller_.[[controlledReadableStream]] to _stream_.
+  1. Set _controller_.[[queue]] and _controller_.[[queueSize]] to *undefined*, then perform ! ResetQueue(_controller_).
+  1. Set _controller_.[[started]], _controller_.[[closeRequested]], _controller_.[[pullAgain]], and
+     _controller_.[[pulling]] to *false*.
+  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
+  1. Set _controller_.[[strategySize]] to _normalizedStrategy_.[[size]] and _controller_.[[strategyHWM]] to
+     _normalizedStrategy_.[[highWaterMark]].
+  1. Set _controller_.[[pullAlgorithm]] to _pullAlgorithm_.
+  1. Set _controller_.[[cancelAlgorithm]] to _cancelAlgorithm_.
+  1. Set _stream_.[[readableStreamController]] to _controller_.
+  1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw and exception.)
+  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
+    1. <a>Upon fulfillment</a>  of _startPromise_,
+      1. Set _controller_.[[started]] to *true*.
+      1. Assert: _controller_.[[pulling]] is *false*.
+      1. Assert: _controller_.[[pullAgain]] is *false*.
+      1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
+    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+</emu-alg>
 
 <h3 id="rbs-controller-class" interface lt="ReadableByteStreamController">Class
 <code>ReadableByteStreamController</code></h3>

--- a/index.bs
+++ b/index.bs
@@ -1724,7 +1724,7 @@ nothrow>IsReadableStreamDefaultController ( <var>x</var> )</h4>
 
 <emu-alg>
   1. If Type(_x_) is not Object, return *false*.
-  1. If _x_ does not have an [[underlyingSource]] internal slot, return *false*.
+  1. If _x_ does not have a [[controlledReadableStream]] internal slot, return *false*.
   1. Return *true*.
 </emu-alg>
 
@@ -1927,7 +1927,7 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
       source</a>, but still has <a>chunks</a> in its internal queue that have not yet been read
   </tr>
   <tr>
-    <td>\[[controlledReadableStream]]
+    <td>\[[controlledReadableByteStream]]
     <td class="non-normative">The {{ReadableStream}} instance controlled
   </tr>
   <tr>
@@ -1989,7 +1989,7 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
 <emu-alg>
   1. If ! IsReadableStream(_stream_) is *false*, throw a *TypeError* exception.
   1. If _stream_.[[readableStreamController]] is not *undefined*, throw a *TypeError* exception.
-  1. Set *this*.[[controlledReadableStream]] to _stream_.
+  1. Set *this*.[[controlledReadableByteStream]] to _stream_.
   1. Set *this*.[[underlyingByteSource]] to _underlyingByteSource_.
   1. Set *this*.[[pullAgain]], and *this*.[[pulling]] to *false*.
   1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(*this*).
@@ -2055,7 +2055,7 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
 <emu-alg>
   1. If ! IsReadableByteStreamController(*this*) is *false*, throw a *TypeError* exception.
   1. If *this*.[[closeRequested]] is *true*, throw a *TypeError* exception.
-  1. If *this*.[[controlledReadableStream]].[[state]] is not `"readable"`, throw a *TypeError* exception.
+  1. If *this*.[[controlledReadableByteStream]].[[state]] is not `"readable"`, throw a *TypeError* exception.
   1. Perform ? ReadableByteStreamControllerClose(*this*).
 </emu-alg>
 
@@ -2068,7 +2068,7 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
 <emu-alg>
   1. If ! IsReadableByteStreamController(*this*) is *false*, throw a *TypeError* exception.
   1. If *this*.[[closeRequested]] is *true*, throw a *TypeError* exception.
-  1. If *this*.[[controlledReadableStream]].[[state]] is not `"readable"`, throw a *TypeError* exception.
+  1. If *this*.[[controlledReadableByteStream]].[[state]] is not `"readable"`, throw a *TypeError* exception.
   1. If Type(_chunk_) is not Object, throw a *TypeError* exception.
   1. If _chunk_ does not have a [[ViewedArrayBuffer]] internal slot, throw a *TypeError* exception.
   1. If ! IsDetachedBuffer(_chunk_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
@@ -2084,7 +2084,7 @@ ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>,
 
 <emu-alg>
   1. If ! IsReadableByteStreamController(*this*) is *false*, throw a *TypeError* exception.
-  1. Let _stream_ be *this*.[[controlledReadableStream]].
+  1. Let _stream_ be *this*.[[controlledReadableByteStream]].
   1. If _stream_.[[state]] is not `"readable"`, throw a *TypeError* exception.
   1. Perform ! ReadableByteStreamControllerError(*this*, _e_).
 </emu-alg>
@@ -2107,7 +2107,7 @@ readable stream implementation will polymorphically call to either these or thei
 <h5 id="rbs-controller-private-pull"><a abstract-op>\[[PullSteps]]</a>()</h5>
 
 <emu-alg>
-  1. Let _stream_ be *this*.[[controlledReadableStream]].
+  1. Let _stream_ be *this*.[[controlledReadableByteStream]].
   1. Assert: ! ReadableStreamHasDefaultReader(_stream_) is *true*.
   1. If *this*.[[queueTotalSize]] > *0*,
     1. Assert: ! ReadableStreamGetNumReadRequests(_stream_) is *0*.
@@ -2238,7 +2238,7 @@ for="ReadableStreamBYOBRequest">respondWithNewView(<var>view</var>)</h5>
 
 <emu-alg>
   1. If Type(_x_) is not Object, return *false*.
-  1. If _x_ does not have an [[underlyingByteSource]] internal slot, return *false*.
+  1. If _x_ does not have an [[controlledReadableByteStream]] internal slot, return *false*.
   1. Return *true*.
 </emu-alg>
 
@@ -2260,7 +2260,7 @@ nothrow>ReadableByteStreamControllerCallPullIfNeeded ( <var>controller</var> )</
       1. Set _controller_.[[pullAgain]] to *false*.
       1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
   1. <a>Upon rejection</a> of _pullPromise_ with reason _e_,
-    1. If _controller_.[[controlledReadableStream]].[[state]] is `"readable"`, perform
+    1. If _controller_.[[controlledReadableByteStream]].[[state]] is `"readable"`, perform
        ! ReadableByteStreamControllerError(_controller_, _e_).
 </emu-alg>
 
@@ -2277,7 +2277,7 @@ aoid="ReadableByteStreamControllerClearPendingPullIntos" nothrow>ReadableByteStr
 throws>ReadableByteStreamControllerClose ( <var>controller</var> )</h4>
 
 <emu-alg>
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. Assert: _controller_.[[closeRequested]] is *false*.
   1. Assert: _stream_.[[state]] is `"readable"`.
   1. If _controller_.[[queueTotalSize]] > *0*,
@@ -2327,7 +2327,7 @@ nothrow>ReadableByteStreamControllerConvertPullIntoDescriptor ( <var>pullIntoDes
 nothrow>ReadableByteStreamControllerEnqueue ( <var>controller</var>, <var>chunk</var> )</h4>
 
 <emu-alg>
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. Assert: _controller_.[[closeRequested]] is *false*.
   1. Assert: _stream_.[[state]] is `"readable"`.
   1. Let _buffer_ be _chunk_.[[ViewedArrayBuffer]].
@@ -2367,7 +2367,7 @@ nothrow>ReadableByteStreamControllerEnqueueChunkToQueue ( <var>controller</var>,
 nothrow>ReadableByteStreamControllerError ( <var>controller</var>, <var>e</var> )</h4>
 
 <emu-alg>
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. Assert: _stream_.[[state]] is `"readable"`.
   1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(_controller_).
   1. Perform ! ResetQueue(_controller_).
@@ -2432,7 +2432,7 @@ nothrow>ReadableByteStreamControllerFillPullIntoDescriptorFromQueue ( <var>contr
 nothrow>ReadableByteStreamControllerGetDesiredSize ( <var>controller</var> )</h4>
 
 <emu-alg>
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"errored"`, return *null*.
   1. If _state_ is `"closed"`, return *0*.
@@ -2443,9 +2443,9 @@ nothrow>ReadableByteStreamControllerGetDesiredSize ( <var>controller</var> )</h4
 nothrow>ReadableByteStreamControllerHandleQueueDrain ( <var>controller</var> )</h4>
 
 <emu-alg>
-  1. Assert: _controller_.[[controlledReadableStream]].[[state]] is `"readable"`.
+  1. Assert: _controller_.[[controlledReadableByteStream]].[[state]] is `"readable"`.
   1. If _controller_.[[queueTotalSize]] is *0* and _controller_.[[closeRequested]] is *true*,
-    1. Perform ! ReadableStreamClose(_controller_.[[controlledReadableStream]]).
+    1. Perform ! ReadableStreamClose(_controller_.[[controlledReadableByteStream]]).
   1. Otherwise,
     1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
 </emu-alg>
@@ -2472,7 +2472,7 @@ nothrow>ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue ( <var>
     1. Let _pullIntoDescriptor_ be the first element of _controller_.[[pendingPullIntos]].
     1. If ! ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(_controller_, _pullIntoDescriptor_) is *true*,
       1. Perform ! ReadableByteStreamControllerShiftPendingPullInto(_controller_).
-      1. Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(_controller_.[[controlledReadableStream]],
+      1. Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(_controller_.[[controlledReadableByteStream]],
          _pullIntoDescriptor_).
 </emu-alg>
 
@@ -2480,7 +2480,7 @@ nothrow>ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue ( <var>
 nothrow>ReadableByteStreamControllerPullInto ( <var>controller</var>, <var>view</var> )</h4>
 
 <emu-alg>
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. Let _elementSize_ be 1.
   1. Let _ctor_ be %DataView%.
   1. If _view_ has a [[TypedArrayName]] internal slot (i.e., it is not a `<a idl>DataView</a>`),
@@ -2530,7 +2530,7 @@ nothrow>ReadableByteStreamControllerRespondInClosedState ( <var>controller</var>
 <emu-alg>
   1. Set _firstDescriptor_.[[buffer]] to ! TransferArrayBuffer(_firstDescriptor_.[[buffer]]).
   1. Assert: _firstDescriptor_.[[bytesFilled]] is *0*.
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. If ReadableStreamHasBYOBReader(_stream_) is *true*,
     1. Repeat the following steps while ! ReadableStreamGetNumReadIntoRequests(_stream_) > *0*,
       1. Let _pullIntoDescriptor_ be ! ReadableByteStreamControllerShiftPendingPullInto(_controller_).
@@ -2557,7 +2557,7 @@ aoid="ReadableByteStreamControllerRespondInReadableState" throws>ReadableByteStr
        _remainder_.[[ByteLength]]).
   1. Set _pullIntoDescriptor_.[[buffer]] to ! TransferArrayBuffer(_pullIntoDescriptor_.[[buffer]]).
   1. Set _pullIntoDescriptor_.[[bytesFilled]] to _pullIntoDescriptor_.[[bytesFilled]] − _remainderSize_.
-  1. Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(_controller_.[[controlledReadableStream]],
+  1. Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(_controller_.[[controlledReadableByteStream]],
      _pullIntoDescriptor_).
   1. Perform ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(_controller_).
 </emu-alg>
@@ -2567,7 +2567,7 @@ throws>ReadableByteStreamControllerRespondInternal ( <var>controller</var>, <var
 
 <emu-alg>
   1. Let _firstDescriptor_ be the first element of _controller_.[[pendingPullIntos]].
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. If _stream_.[[state]] is `"closed"`,
     1. If _bytesWritten_ is not *0*, throw a *TypeError* exception.
     1. Perform ! ReadableByteStreamControllerRespondInClosedState(_controller_, _firstDescriptor_).
@@ -2604,7 +2604,7 @@ nothrow>ReadableByteStreamControllerShiftPendingPullInto ( <var>controller</var>
 nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4>
 
 <emu-alg>
-  1. Let _stream_ be _controller_.[[controlledReadableStream]].
+  1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
   1. If _stream_.[[state]] is not `"readable"`, return *false*.
   1. If _controller_.[[closeRequested]] is *true*, return *false*.
   1. If _controller_.[[started]] is *false*, return *false*.

--- a/index.bs
+++ b/index.bs
@@ -2974,8 +2974,8 @@ throws>AcquireWritableStreamDefaultWriter ( <var>stream</var> )</h4>
 </emu-alg>
 
 <h4 id="create-writable-stream" aoid="CreateWritableStream" throws>CreateWritableStream ( <var>startAlgorithm</var>,
-<var>writeAlgorithm</var>, <var>closeAlgorithm</var>, <var>abortAlgorithm</var>, <var>highWaterMark</var>,
-<var>sizeAlgorithm</var> )</h4>
+<var>writeAlgorithm</var>, <var>closeAlgorithm</var>, <var>abortAlgorithm</var> [, <var>highWaterMark</var> [,
+<var>sizeAlgorithm</var> ] ] )</h4>
 
 This abstract operation is meant to be called from other specifications that wish to create {{WritableStream}}
 instances. The <var>writeAlgorithm</var>, <var>closeAlgorithm</var> and <var>abortAlgorithm</var> algorithms must return
@@ -2986,6 +2986,8 @@ number; and if supplied, <var>highWaterMark</var> must be a nonnegative, non-NaN
 throws.</p>
 
 <emu-alg>
+  1. If _highWaterMark_ was not passed, set it to *1*.
+  1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>WritableStream</a>'s `prototype` property).
   1. Perform ! InitializeWritableStream(_stream_).

--- a/index.bs
+++ b/index.bs
@@ -505,18 +505,18 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
   1. Set *this*.[[state]] to `"readable"`.
   1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
   1. Set *this*.[[disturbed]] to *false*.
-  1. Set *this*.[[readableStreamController]] to *undefined*.
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _typeString_ be ? ToString(_type_).
   1. If _typeString_ is `"bytes"`,
     1. If _size_ is not *undefined*, throw a *RangeError* exception.
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
+    1. Set *this*.[[readableStreamController]] to *undefined*.
     1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableByteStreamController</a>`, « *this*,
        _underlyingSource_, _highWaterMark_ »).
   1. Otherwise, if _type_ is *undefined*,
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
-    1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableStreamDefaultController</a>`, « *this*,
-       _underlyingSource_, _size_, _highWaterMark_ »).
+    1. Perform ? CreateReadableStreamDefaultControllerFromUnderlyingSourceObject(*this*, _size_, _highWaterMark_,
+       _underlyingSource_ »).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
 
@@ -1532,7 +1532,7 @@ it would look like
 
 <pre><code class="lang-javascript">
   class ReadableStreamDefaultController {
-    constructor(stream, underlyingSource, size, highWaterMark)
+    constructor() // always throws
 
     get desiredSize()
 
@@ -1556,6 +1556,10 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
     </tr>
   </thead>
   <tr>
+    <td>\[[cancelAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm, taking one argument (the cancel reason), which communicates
+      a requested cancelation to the <a>underlying source</a>
+  <tr>
     <td>\[[closeRequested]]
     <td class="non-normative">A boolean flag indicating whether the stream has been closed by its <a>underlying
       source</a>, but still has <a>chunks</a> in its internal queue that have not yet been read
@@ -1567,13 +1571,17 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
   <tr>
     <td>\[[pullAgain]]
     <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> if the stream's mechanisms requested a call
-      to the underlying source's <code>pull</code> method to pull more data, but the pull could not yet be done since a
+      to the <a>underlying source</a>'s pull algorithm to pull more data, but the pull could not yet be done since a
       previous call is still executing
+  </tr>
+  <tr>
+    <td>\[[pullAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm that pulls data from the <a>underlying source</a>
   </tr>
   <tr>
     <td>\[[pulling]]
     <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> while the <a>underlying source</a>'s
-      <code>pull</code> method is executing and has not yet fulfilled, used to prevent reentrant calls
+      pull algorithm is executing and the returned promise has not yet fulfilled, used to prevent reentrant calls
   </tr>
   <tr>
     <td>\[[queue]]
@@ -1597,43 +1605,19 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
     <td class="non-normative">A function supplied to the constructor as part of the stream's <a>queuing strategy</a>,
       designed to calculate the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default behavior
   </tr>
-  <tr>
-    <td>\[[underlyingSource]]
-    <td class="non-normative">An object representation of the stream's <a>underlying source</a>; also used for the <a
-    href="#is-readable-stream-default-controller">IsReadableStreamDefaultController</a> brand check
-  </tr>
 </table>
 
 <h4 id="rs-default-controller-constructor" constructor for="ReadableStreamDefaultController"
-lt="ReadableStreamDefaultController(stream, underlyingSource, size, highWaterMark)">new
-ReadableStreamDefaultController(<var>stream</var>, <var>underlyingSource</var>, <var>size</var>,
-<var>highWaterMark</var>)</h4>
+lt="ReadableStreamDefaultController()">new
+ReadableStreamDefaultController()</h4>
 
 <div class="note">
-  The <code>ReadableStreamDefaultController</code> constructor cannot be used directly; it only works on a
-  {{ReadableStream}} that is in the middle of being constructed.
+  The <code>ReadableStreamDefaultController</code> constructor cannot be used directly;
+  {{ReadableStreamDefaultController}} instances are created automatically during {{ReadableStream}} construction.
 </div>
 
 <emu-alg>
-  1. If ! IsReadableStream(_stream_) is *false*, throw a *TypeError* exception.
-  1. If _stream_.[[readableStreamController]] is not *undefined*, throw a *TypeError* exception.
-  1. Set *this*.[[controlledReadableStream]] to _stream_.
-  1. Set *this*.[[underlyingSource]] to _underlyingSource_.
-  1. Perform ! ResetQueue(*this*).
-  1. Set *this*.[[started]], *this*.[[closeRequested]], *this*.[[pullAgain]], and *this*.[[pulling]] to *false*.
-  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
-  1. Set *this*.[[strategySize]] to _normalizedStrategy_.[[size]] and *this*.[[strategyHWM]] to
-     _normalizedStrategy_.[[highWaterMark]].
-  1. Let _controller_ be *this*.
-  1. Let _startResult_ be ? InvokeOrNoop(_underlyingSource_, `"start"`, « *this* »).
-  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
-    1. <a>Upon fulfillment</a>  of _startPromise_,
-      1. Set _controller_.[[started]] to *true*.
-      1. Assert: _controller_.[[pulling]] is *false*.
-      1. Assert: _controller_.[[pullAgain]] is *false*.
-      1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
-    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+  1. Throw a *TypeError*.
 </emu-alg>
 
 <h4 id="rs-default-controller-prototype">Properties of the {{ReadableStreamDefaultController}} Prototype</h4>
@@ -1700,7 +1684,7 @@ readable stream implementation will polymorphically call to either these or thei
 
 <emu-alg>
   1. Perform ! ResetQueue(*this*).
-  1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingSource]], `"cancel"`, « _reason_ »)
+  1. Return the result of performing *this*.[[cancelAlgorithm]], passing _reason_.
 </emu-alg>
 
 <h5 id="rs-default-controller-private-pull"><a abstract-op>\[[PullSteps]]</a>()</h5>
@@ -1718,6 +1702,66 @@ readable stream implementation will polymorphically call to either these or thei
 </emu-alg>
 
 <h3 id="rs-default-controller-abstract-ops">Readable Stream Default Controller Abstract Operations</h3>
+
+<h4 id="create-readable-stream-default-controller-from-underlying-source-object"
+aoid="CreateReadableStreamDefaultControllerFromUnderlyingSourceObject"
+throws>CreateReadableStreamDefaultControllerFromUnderlyingSourceObject(<var>stream</var>, <var>size</var>,
+<var>highWaterMark</var>, <var>underlyingSource</var>)</h4>
+
+<emu-alg>
+  1. Let _controller_ be CreateReadableStreamDefaultControllerSharedSetup(_stream_, _size_, _highWaterMark_).
+  1. Set _controller_.[[pullAlgorithm]] to an algorithm, taking no parameters, which runs the following steps:
+    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _controller_ »).
+  1. Set _controller_.[[cancelAlgorithm]] to an algorithm, taking one parameter _reason_, which runs the following
+     steps:
+    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
+  1. Let _startResult_ be ? InvokeOrNoop(_underlyingSource_, `"start"`, « _controller_ »).
+  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
+    1. <a>Upon fulfillment</a>  of _startPromise_,
+      1. Set _controller_.[[started]] to *true*.
+      1. Assert: _controller_.[[pulling]] is *false*.
+      1. Assert: _controller_.[[pullAgain]] is *false*.
+      1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
+    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+  1. Return _controller_.
+</emu-alg>
+
+<h4 id="create-readable-stream-default-controller-from-underlying-source-algorithms"
+aoid="CreateReadableStreamDefaultControllerFromUnderlyingSourceAlgorithms"
+throws>CreateReadableStreamDefaultControllerFromUnderlyingSourceAlgorithms(<var>stream</var>, <var>size</var>,
+<var>highWaterMark</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var>)</h4>
+
+<emu-alg>
+  1. Let _controller_ be CreateReadableStreamDefaultControllerSharedSetup(_stream_, _size_, _highWaterMark_).
+  1. Set _controller_.[[pullAlgorithm]] to _pullAlgorithm_.
+  1. Set _controller_.[[cancelAlgorithm]] to _cancelAlgorithm_.
+  1. <a>Queue a microtask</a> to perform the following steps:
+    1. Set _controller_.[[started]] to *true*.
+    1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
+  1. Return _controller_.
+</emu-alg>
+
+<h4 id="create-readable-stream-default-controller-shared-setup"
+aoid="CreateReadableStreamDefaultControllerSharedSetup"
+throws>CreateReadableStreamDefaultControllerSharedSetup(<var>stream</var>, <var>size</var>,
+<var>highWaterMark</var>)</h4>
+
+<emu-alg>
+  1. Assert: ! IsReadableStream(_stream_) is *true*.
+  1. Assert: _stream_.[[readableStreamController]] is *undefined*.
+  1. Let _controller_ be ObjectCreate(the original value of <a idl>ReadableStreamDefaultController</a>'s `prototype`
+     property).
+  1. Set _controller_.[[controlledReadableStream]] to _stream_.
+  1. Set _controller_.[[queue]] and _controller_.[[queueSize]] to *undefined*, then perform ! ResetQueue(_controller_).
+  1. Set _controller_.[[started]], _controller_.[[closeRequested]], _controller_.[[pullAgain]], and
+     _controller_.[[pulling]] to *false*.
+  1. Let _normalizedStrategy_ be ? ValidateAndNormalizeQueuingStrategy(_size_, _highWaterMark_).
+  1. Set _controller_.[[strategySize]] to _normalizedStrategy_.[[size]] and _controller_.[[strategyHWM]] to
+     _normalizedStrategy_.[[highWaterMark]].
+  1. Set _stream_.[[readableStreamController]] to _controller_.
+  1. Return _controller_.
+</emu-alg>
 
 <h4 id="is-readable-stream-default-controller" aoid="IsReadableStreamDefaultController"
 nothrow>IsReadableStreamDefaultController ( <var>x</var> )</h4>
@@ -1739,7 +1783,7 @@ nothrow>ReadableStreamDefaultControllerCallPullIfNeeded ( <var>controller</var> 
     1. Return.
   1. Assert: _controller_.[[pullAgain]] is *false*.
   1. Set _controller_.[[pulling]] to *true*.
-  1. Let _pullPromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingSource]], `"pull"`, « _controller_ »).
+  1. Let _pullPromise_ be the result of performing _controller_.[[pullAlgorithm]].
   1. <a>Upon fulfillment</a> of _pullPromise_,
     1. Set _controller_.[[pulling]] to *false*.
     1. If _controller_.[[pullAgain]] is *true*,

--- a/index.bs
+++ b/index.bs
@@ -503,9 +503,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
 </div>
 
 <emu-alg>
-  1. Set *this*.[[state]] to `"readable"`.
-  1. Set *this*.[[reader]] and *this*.[[storedError]] to *undefined*.
-  1. Set *this*.[[disturbed]] to *false*.
+  1. Perform ! InitializeReadableStream(*this*).
   1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _typeString_ be ? ToString(_type_).
   1. If _typeString_ is `"bytes"`,
@@ -524,14 +522,7 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
       1. If ! IsCallable(_size_) is *false*, throw a *TypeError* exception.
       1. Set _sizeAlgorithm_ to the following steps, taking a _chunk_ argument:
         1. Return ? Call(_size_, *undefined*, « _chunk_ »).
-    1. Let _stream_ be *this*.
-    1. Let _startAlgorithm_ be the following steps:
-      1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _stream_.[[readableStreamController]] »).
-    1. Let _pullAlgorithm_ be the following steps:
-      1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
-    1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
-      1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
-    1. Perform ? SetUpReadableStreamDefaultController(*this*, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+    1. Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource(*this*, _underlyingSource_,
        _highWaterMark_, _sizeAlgorithm_).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
@@ -862,13 +853,20 @@ instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithm
   1. Assert: _highWaterMark_ is not +∞.
   1. Assert: _highWaterMark_ is not negative.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
-  1. Set _stream_.[[state]] to `"readable"`.
-  1. Set _stream_.[[reader]] and _stream_.[[storedError]] to *undefined*.
-  1. Set _stream_.[[disturbed]] to *false*.
+  1. Perform ! InitializeReadableStream(_stream_).
   1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
   1. Perform ! SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _sizeAlgorithm_, _highWaterMark_).
   1. Return _stream_.
+</emu-alg>
+
+<h4 id="initialize-readable-stream" aoid="InitializeReadableStream" throws>InitializeReadableStream (
+<var>stream</var> )</h4>
+
+<emu-alg>
+  1. Set _stream_.[[state]] to `"readable"`.
+  1. Set _stream_.[[reader]] and _stream_.[[storedError]] to *undefined*.
+  1. Set _stream_.[[disturbed]] to *false*.
 </emu-alg>
 
 <h4 id="is-readable-stream" aoid="IsReadableStream" nothrow>IsReadableStream ( <var>x</var> )</h4>
@@ -1881,6 +1879,22 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorit
       1. Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(_controller_).
     1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
       1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
+</emu-alg>
+
+<h4 id="initialize-readable-stream-default-controller-from-underlying-source"
+aoid="InitializeReadableStreamDefaultControllerFromUnderlyingSource"
+throws>InitializeReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var>, <var>underlyingSource</var>,
+<var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
+
+<emu-alg>
+  1. Let _startAlgorithm_ be the following steps:
+    1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _stream_.[[readableStreamController]] »).
+  1. Let _pullAlgorithm_ be the following steps:
+    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
+  1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
+    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
+  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _underlyingSource_,
+     _highWaterMark_, _sizeAlgorithm_)
 </emu-alg>
 
 <h3 id="rbs-controller-class" interface lt="ReadableByteStreamController">Class

--- a/index.bs
+++ b/index.bs
@@ -1606,7 +1606,7 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
   <tr>
     <td>\[[strategySizeAlgorithm]]
     <td class="non-normative">An algorithm to calculate the size of enqueued <a>chunks</a>, as part of the stream's
-      <a>queuing strategy</a>.
+      <a>queuing strategy</a>
   </tr>
 </table>
 
@@ -3582,6 +3582,16 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
     </tr>
   </thead>
   <tr>
+    <td>\[[abortAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm, taking one argument (the abort reason), which communicates
+      a requested abort to the <a>underlying sink</a>
+  </tr>
+  <tr>
+    <td>\[[closeAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm which communicates a requested close to the <a>underlying
+      sink</a>
+  </tr>
+  <tr>
     <td>\[[controlledWritableStream]]
     <td class="non-normative">The {{WritableStream}} instance controlled
   </tr>
@@ -3599,19 +3609,19 @@ Instances of {{WritableStreamDefaultController}} are created with the internal s
   </tr>
   <tr>
     <td>\[[strategyHWM]]
-    <td class="non-normative">A number supplied to the constructor as part of the stream's <a>queuing strategy</a>,
-      indicating the point at which the stream will apply <a>backpressure</a> to its <a>underlying sink</a>
+    <td class="non-normative">A number supplied by the creator of the stream as part of the stream's <a>queuing
+      strategy</a>, indicating the point at which the stream will apply <a>backpressure</a> to its <a>underlying
+      sink</a>
   </tr>
   <tr>
-    <td>\[[strategySize]]
-    <td class="non-normative">A function supplied to the constructor as part of the stream's <a>queuing strategy</a>,
-      designed to calculate the size of enqueued <a>chunks</a>; can be <emu-val>undefined</emu-val> for the default
-      behavior
+    <td>\[[strategySizeAlgorithm]]
+    <td class="non-normative">An algorithm to calculate the size of enqueued <a>chunks</a>, as part of the stream’s
+      <a>queuing strategy</a>
   </tr>
   <tr>
-    <td>\[[underlyingSink]]
-    <td class="non-normative">An object representation of the stream's <a>underlying sink</a>; also used for the <a
-    href="#is-writable-stream-default-controller">IsWritableStreamDefaultController</a> brand check
+    <td>\[[writeAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm, taking one argument (the <a>chunk</a> to write), which
+      writes data to the <a>underlying sink</a>
   </tr>
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -839,7 +839,7 @@ reader</a> for a given stream.
 This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
 instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return
 promises; if supplied, <var>sizeAlgorithm</var> must be an algorithm accepting <a>chunk</a> objects and returning a
-number; and if supplied, <var>highWaterMark</var> must be a nonnegative, finite number.
+number; and if supplied, <var>highWaterMark</var> must be a nonnegative, non-NaN number.
 
 <p class="note">CreateReadableStream throws an exception if and only if the supplied <var>startAlgorithm</var>
 throws.</p>
@@ -2930,7 +2930,7 @@ throws>AcquireWritableStreamDefaultWriter ( <var>stream</var> )</h4>
 This abstract operation is meant to be called from other specifications that wish to create {{WritableStream}}
 instances. The <var>writeAlgorithm</var>, <var>closeAlgorithm</var> and <var>abortAlgorithm</var> algorithms must return
 promises; if supplied, <var>sizeAlgorithm</var> must be an algorithm accepting <a>chunk</a> objects and returning a
-number; and if supplied, <var>highWaterMark</var> must be a nonnegative, finite number.
+number; and if supplied, <var>highWaterMark</var> must be a nonnegative, non-NaN number.
 
 <p class="note">CreateWritableStream throws an exception if and only if the supplied <var>startAlgorithm</var>
 throws.</p>
@@ -4021,47 +4021,23 @@ readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writabl
 </div>
 
 <emu-alg>
-  1. Set *this*.[[transformer]] to _transformer_.
   1. Let _readableType_ be ? GetV(_transformer_, `"readableType"`).
   1. If _readableType_ is not *undefined*, throw a *RangeError* exception.
   1. Let _writableType_ be ? GetV(_transformer_, `"writableType"`).
   1. If _writableType_ is not *undefined*, throw a *RangeError* exception.
-  1. Set *this*.[[transformStreamController]] to *undefined*.
-  1. Let _controller_ be ? Construct(`<a idl>TransformStreamDefaultController</a>`, « *this* »).
-  1. Set *this*.[[transformStreamController]] to _controller_.
   1. Let _startPromise_ be <a>a new promise</a>.
-  1. Let _startAlgorithm_ be an algorithm that returns _startPromise_.
-  1. Let _stream_ be *this*.
-  1. Let _writeAlgorithm_ be the following steps, taking a _chunk_ argument:
-    1. Return ! TransformStreamDefaultSinkWriteAlgorithm(_stream_, _chunk_).
-  1. Let _abortAlgorithm_ be the following steps:
-    1. Return ! TransformStreamDefaultSinkAbortAlgorithm(_stream_).
-  1. Let _closeAlgorithm_ be the following steps:
-    1. Return ! TransformStreamDefaultSinkCloseAlgorithm(_stream_).
   1. Let _writableSizeFunction_ be ? GetV(_writableStrategy_, `"size"`).
   1. Let _writableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_writableSizeFunction_).
   1. Let _writableHighWaterMark_ be ? GetV(_writableStrategy_, `"highWaterMark"`).
   1. If _writableHighWaterMark_ is *undefined*, set _writableHighWaterMark_ to *1*.
   1. Set _writableHighWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_writableHighWaterMark_).
-  1. Set *this*.[[writable]] to ! CreateWritableStream(_startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
-     _abortAlgorithm_, _writableHighWaterMark_, _writableSizeAlgorithm_).
-  1. Let _pullAlgorithm_ be the following steps:
-    1. Return ! TransformStreamDefaultSourcePullAlgorithm(_stream_).
-  1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
-    1. Perform ! TransformStreamErrorWritableAndUnblockWrite(_stream_, _reason_).
-    1. Return <a>a promise resolved with</a> *undefined*.
   1. Let _readableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
   1. Let _readableHighWaterMark_ be ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
-  1. Set *this*.[[readable]] to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+  1. Perform ! InitializeTransformStream(*this*, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
-  1. Set *this*.[[backpressure]] and *this*.[[backpressureChangePromise]] to *undefined*.
-     <p class="note">The [[backpressure]] slot is set to *undefined* so that it can be initialized by
-     TransformStreamSetBackpressure. Alternatively, implementations can use a strictly boolean value for
-     [[backpressure]] and change the way it is initialized. This will not be visible to user code so long as the
-     initialization is correctly completed before _transformer_'s <code>start()</code> method is is called.</p>
-  1. Perform ! TransformStreamSetBackpressure(*this*, *true*).
-  1. Let _startResult_ be ? InvokeOrNoop(_transformer_, `"start"`, « _controller_ »).
-  1. Resolve _startPromise_ with _startResult_.
+  1. Perform ! SetUpTransformStreamDefaultControllerFromTransformer(*this*, _transform_).
+  1. Let _startResult_ be ? InvokeOrNoop(_transformer_, `"start"`, « *this*.[[transformStreamController]] »).
+  1. <a>Resolve</a> _startPromise_ with _startResult_.
 </emu-alg>
 
 <h4 id="ts-prototype">Properties of the {{TransformStream}} Prototype</h4>
@@ -4089,6 +4065,71 @@ readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writabl
 </emu-alg>
 
 <h3 id="ts-abstract-ops">General Transform Stream Abstract Operations</h3>
+
+<h4 id="create-transform-stream" aoid="CreateTransformStream" throws export>CreateTransformStream (
+<var>startAlgorithm</var>, <var>transformAlgorithm</var>, <var>flushAlgorithm</var>
+[, <var>writableHighWaterMark</var> [, <var>writableSizeAlgorithm</var> [, <var>readableHighWaterMark</var> [,
+<var>readableSizeAlgorithm</var> ] ] ] ] )</h4>
+
+This abstract operation is meant to be called from other specifications that wish to create {{TransformStream}}
+instances. The <var>transformAlgorithm</var> and <var>flushAlgorithm</var> algorithms must return promises; if supplied,
+<var>writableHighWaterMark</var> and <var>readableHighWaterMark</var> must be nonnegative, non-NaN numbers; and if
+supplied, <var>writableSizeAlgorithm</var> and <var>readableSizeAlgorithm</var> must be algorithms accepting
+<a>chunk</a> objects and returning numbers.
+
+<p class="note">CreateTransformStream throws an exception if and only if the supplied <var>startAlgorithm</var>
+throws.</p>
+
+<emu-alg>
+  1. If _writableHighWaterMark_ was not passed, set it to *1*.
+  1. If _writableSizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
+  1. If _readableHighWaterMark_ was not passed, set it to *0*.
+  1. If _readableSizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
+  1. Assert: Type(_writableHighWaterMark_) is Number.
+  1. Assert: _writableHighWaterMark_ is not NaN.
+  1. Assert: _writableHighWaterMark_ is not negative.
+  1. Assert: Type(_readableHighWaterMark_) is Number.
+  1. Assert: _readableHighWaterMark_ is not NaN.
+  1. Assert: _readableHighWaterMark_ is not negative.
+  1. Let _stream_ be ObjectCreate(the original value of <a idl>TransformStream</a>'s `prototype` property).
+  1. Let _startPromise_ be <a>a new promise</a>.
+  1. Perform ! InitializeTransformStream(_stream_, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
+     _readableHighWaterMark_, _readableSizeAlgorithm_).
+  1. Perform ! SetUpTransformStreamDefaultController(_stream_, _transformAlgorithm_, _flushAlgorithm_).
+  1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)
+  1. <a>Resolve</a> _startPromise_ with _startResult_.
+  1. Return _stream_.
+</emu-alg>
+
+<h4 id="initialize-transform-stream" aoid="InitializeTransformStream" nothrow>InitializeTransformStream (
+<var>stream</var>, <var>startPromise</var>, <var>writableHighWaterMark</var>, <var>writableSizeAlgorithm</var>,
+<var>readableHighWaterMark</var>, <var>readableSizeAlgorithm</var> )</h4>
+
+<emu-alg>
+  1. Let _startAlgorithm_ be an algorithm that returns _startPromise_.
+  1. Let _writeAlgorithm_ be the following steps, taking a _chunk_ argument:
+    1. Return ! TransformStreamDefaultSinkWriteAlgorithm(_stream_, _chunk_).
+  1. Let _abortAlgorithm_ be the following steps:
+    1. Return ! TransformStreamDefaultSinkAbortAlgorithm(_stream_).
+  1. Let _closeAlgorithm_ be the following steps:
+    1. Return ! TransformStreamDefaultSinkCloseAlgorithm(_stream_).
+  1. Set *this*.[[writable]] to ! CreateWritableStream(_startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
+     _abortAlgorithm_, _writableHighWaterMark_, _writableSizeAlgorithm_).
+  1. Let _pullAlgorithm_ be the following steps:
+    1. Return ! TransformStreamDefaultSourcePullAlgorithm(_stream_).
+  1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
+    1. Perform ! TransformStreamErrorWritableAndUnblockWrite(_stream_, _reason_).
+    1. Return <a>a promise resolved with</a> *undefined*.
+  1. Set *this*.[[readable]] to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+     _readableHighWaterMark_, _readableSizeAlgorithm_).
+  1. Set *this*.[[backpressure]] and *this*.[[backpressureChangePromise]] to *undefined*.
+     <p class="note">The [[backpressure]] slot is set to *undefined* so that it can be initialized by
+     TransformStreamSetBackpressure. Alternatively, implementations can use a strictly boolean value for
+     [[backpressure]] and change the way it is initialized. This will not be visible to user code so long as the
+     initialization is correctly completed before _transformer_'s <code>start()</code> method is is called.</p>
+  1. Perform ! TransformStreamSetBackpressure(*this*, *true*).
+  1. Set _stream_.[[transformStreamController]] to *undefined*.
+</emu-alg>
 
 <h4 id="is-transform-stream" aoid="IsTransformStream" nothrow>IsTransformStream ( <var>x</var> )</h4>
 
@@ -4182,17 +4223,14 @@ Instances of {{TransformStreamDefaultController}} are created with the internal 
 </table>
 
 <h4 id="ts-default-controller-constructor" constructor for="TransformStreamDefaultController"
-lt="TransformStreamDefaultController(stream)">new TransformStreamDefaultController(<var>stream</var>)</h4>
+lt="TransformStreamDefaultController()">new TransformStreamDefaultController()</h4>
 
 <div class="note">
-  The <code>TransformStreamDefaultController</code> constructor cannot be used directly; it only works on a
-  {{TransformStream}} that is in the middle of being constructed.
+  The <code>TransformStreamDefaultController</code> constructor cannot be used directly.
 </div>
 
 <emu-alg>
-  1. If ! IsTransformStream(_stream_) is *false*, throw a *TypeError* exception.
-  1. If _stream_.[[transformStreamController]] is not *undefined*, throw a *TypeError* exception.
-  1. Set *this*.[[controlledTransformStream]] to _stream_.
+  1. Throw a *TypeError* exception.
 </emu-alg>
 
 <h4 id="ts-default-controller-prototype">Properties of the {{TransformStreamDefaultController}} Prototype</h4>
@@ -4259,8 +4297,35 @@ nothrow>IsTransformStreamDefaultController ( <var>x</var> )</h4>
   1. Return *true*.
 </emu-alg>
 
+<h4 id="set-up-transform-stream-default-controller" aoid="SetUpTransformStreamDefaultController"
+nothrow>SetUpTransformStreamDefaultController ( <var>stream</var>, <var>transformAlgorithm</var>,
+<var>flushAlgorithm</var> )</h4>
+
+<emu-alg>
+  1. Assert: ! IsTransformStream(_stream_) is *true*.
+  1. Assert: _stream_.[[writableStreamController]] is *undefined*.
+  1. Let _controller_ be ObjectCreate(the original value of <a idl>TransformStreamDefaultController</a>'s `prototype`
+     property).
+  1. Set _controller_.[[controlledTransformStream]] to _stream_.
+  1. Set _stream_.[[transformStreamController]] to _controller_.
+  1. Set _controller_.[[transformAlgorithm]] to _transformAlgorithm_.
+  1. Set _controller_.[[flushAlgorithm]] to _flushAlgorithm_.
+</emu-alg>
+
+<h4 id="set-up-transform-stream-default-controller-from-transformer"
+aoid="SetUpTransformStreamDefaultControllerFromTransformer"
+nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>, <var>transformer</var> )</h4>
+
+<emu-alg>
+  1. Let _transformAlgorithm_ be the following steps, taking a _chunk_ argument:
+    1. Return ! TransformStreamDefaultSinkTransform(_stream_, _transformer_, _chunk_).
+  1. Let _flushAlgorithm_ be the following steps:
+    1. Return ! PromiseInvokeOrNoop(_transformer_, `"flush"`, « _stream_.[[transformStreamController]] »).
+  1. Perform ! SetUpTransformStreamDefaultController(_stream_, _transformAlgorithm_, _flushAlgorithm_).
+</emu-alg>
+
 <h4 id="transform-stream-default-controller-enqueue" aoid="TransformStreamDefaultControllerEnqueue"
-throws>TransformStreamDefaultControllerEnqueue ( <var>controller</var>, <var>chunk</var> )</h4>
+throws export>TransformStreamDefaultControllerEnqueue ( <var>controller</var>, <var>chunk</var> )</h4>
 
 This abstract operation can be called by other specifications that wish to enqueue <a>chunks</a> in the <a>readable
 side</a>, in the same way a developer would enqueue chunks using the stream's associated controller object.
@@ -4282,7 +4347,7 @@ Specifications should <em>not</em> do this to streams they did not create.
 </emu-alg>
 
 <h4 id="transform-stream-default-controller-error" aoid="TransformStreamDefaultControllerError"
-nothrow>TransformStreamDefaultControllerError ( <var>controller</var>, <var>e</var> )</h4>
+nothrow export>TransformStreamDefaultControllerError ( <var>controller</var>, <var>e</var> )</h4>
 
 This abstract operation can be called by other specifications that wish to move a transform stream to an errored state,
 in the same way a developer would error a stream using its associated controller object. Specifications should
@@ -4293,7 +4358,7 @@ in the same way a developer would error a stream using its associated controller
 </emu-alg>
 
 <h4 id="transform-stream-default-controller-terminate" aoid="TransformStreamDefaultControllerTerminate"
-nothrow>TransformStreamDefaultControllerTerminate ( <var>controller</var> )</h4>
+nothrow export>TransformStreamDefaultControllerTerminate ( <var>controller</var> )</h4>
 
 This abstract operation can be called by other specifications that wish to terminate a transform stream, in the same way
 a developer-created stream would be closed by its associated controller object. Specifications should <em>not</em> do
@@ -4315,6 +4380,7 @@ nothrow>TransformStreamDefaultSinkWriteAlgorithm ( <var>stream</var>, <var>chunk
 
 <emu-alg>
   1. Assert: _stream_.[[writable]].[[state]] is `"writable"`.
+  1. Let _controller_ be _stream_.[[transformStreamController]].
   1. If _stream_.[[backpressure]] is *true*,
     1. Let _backpressureChangePromise_ be _stream_.[[backpressureChangePromise]].
     1. Assert: _backpressureChangePromise_ is not *undefined*.
@@ -4324,8 +4390,8 @@ nothrow>TransformStreamDefaultSinkWriteAlgorithm ( <var>stream</var>, <var>chunk
       1. Let _state_ be _writable_.[[state]].
       1. If _state_ is `"erroring"`, throw _writable_.[[storedError]].
       1. Assert: _state_ is `"writable"`.
-      1. Return ! TransformStreamDefaultSinkTransform(_stream_, _chunk_).
-  1. Return ! TransformStreamDefaultSinkTransform(_stream_, _chunk_).
+      1. Return the result of performing _controller_.[[transformAlgorithm]], passing _chunk_.
+  1. Return the result of performing _controller_.[[transformAlgorithm]], passing _chunk_.
 </emu-alg>
 
 <h4 id="transform-stream-default-sink-abort-algorithm" aoid="TransformStreamDefaultSinkAbortAlgorithm"
@@ -4342,8 +4408,7 @@ nothrow>TransformStreamDefaultSinkCloseAlgorithm( _stream_ )</h4>
 
 <emu-alg>
   1. Let _readable_ be _stream_.[[readable]].
-  1. Let _flushPromise_ be ! PromiseInvokeOrNoop(_stream_.[[transformer]], `"flush"`, «
-     _stream_.[[transformStreamController]] »).
+  1. Let _flushPromise_ be the result of performing _stream_.[[transformStreamController]].[[flushAlgorithm]].
   1. Return the result of <a>transforming</a> _flushPromise_ with:
     1. A fulfullment handler that performs the following steps:
       1. If _readable_.[[state]] is `"errored"`, throw _readable_.[[storedError]].
@@ -4356,11 +4421,10 @@ nothrow>TransformStreamDefaultSinkCloseAlgorithm( _stream_ )</h4>
 </emu-alg>
 
 <h4 id="transform-stream-default-sink-invoke-transform" aoid="TransformStreamDefaultSinkInvokeTransform"
-throws>TransformStreamDefaultSinkInvokeTransform ( <var>stream</var>, <var>chunk</var> )</h4>
+throws>TransformStreamDefaultSinkInvokeTransform ( <var>stream</var>, <var>transformer</var>, <var>chunk</var> )</h4>
 
 <emu-alg>
   1. Let _controller_ be _stream_.[[transformStreamController]].
-  1. Let _transformer_ be _stream_.[[transformer]].
   1. Let _method_ be ? GetV(_transformer_, `"transform"`).
   1. If _method_ is *undefined*,
     1. Perform ? TransformStreamDefaultControllerEnqueue(_controller_, _chunk_).
@@ -4369,13 +4433,13 @@ throws>TransformStreamDefaultSinkInvokeTransform ( <var>stream</var>, <var>chunk
 </emu-alg>
 
 <h4 id="transform-stream-default-sink-transform" aoid="TransformStreamDefaultSinkTransform"
-nothrow>TransformStreamDefaultSinkTransform ( <var>stream</var>, <var>chunk</var> )</h4>
+nothrow>TransformStreamDefaultSinkTransform ( <var>stream</var>, <var>transformer</var>, <var>chunk</var> )</h4>
 
 <emu-alg>
   1. Assert: _stream_.[[readable]].[[state]] is not `"errored"`.
   1. Assert: _stream_.[[backpressure]] is *false*.
   1. Let _transformPromise_ be *undefined*.
-  1. Let _transformResult_ be TransformStreamDefaultSinkInvokeTransform(_stream_, _chunk_).
+  1. Let _transformResult_ be TransformStreamDefaultSinkInvokeTransform(_stream_, _transformer_, _chunk_).
   1. If _transformResult_ is an abrupt completion, set _transformPromise_ to <a>a promise rejected with</a>
      _transformResult_.[[Value]].
   1. Otherwise, set _transformPromise_ to <a>a promise resolved with</a> _transformResult_.[[Value]].
@@ -4385,7 +4449,7 @@ nothrow>TransformStreamDefaultSinkTransform ( <var>stream</var>, <var>chunk</var
     1. Throw _e_.
 </emu-alg>
 
-<h3 id="ts-default-sink-abstract-ops">Transform Stream Default Source Abstract Operations</h3>
+<h3 id="ts-default-source-abstract-ops">Transform Stream Default Source Abstract Operations</h3>
 
 <h4 id="transform-stream-default-source-pull"
 aoid="TransformStreamDefaultSourcePullAlgorithm" nothrow>TransformStreamDefaultSourcePullAlgorithm( _stream_ )</h4>

--- a/index.bs
+++ b/index.bs
@@ -1884,9 +1884,9 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorit
       1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_controller_, _r_).
 </emu-alg>
 
-<h4 id="initialize-readable-stream-default-controller-from-underlying-source"
-aoid="InitializeReadableStreamDefaultControllerFromUnderlyingSource"
-throws>InitializeReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var>, <var>underlyingSource</var>,
+<h4 id="set-up-readable-stream-default-controller-from-underlying-source"
+aoid="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
+throws>SetUpReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var>, <var>underlyingSource</var>,
 <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -830,6 +830,26 @@ reader</a> for a given stream.
   1. Return ? Construct(`<a idl>ReadableStreamDefaultReader</a>`, « _stream_ »).
 </emu-alg>
 
+<h4 id="create-readable-stream" aoid="CreateReadableStream" nothrow export>CreateReadableStream (
+<var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>size</var> [ , <var>highWaterMark</var> ] ] )</h4>
+
+This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
+instances. The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return promises; if supplied,
+<var>size</var> must be a function of one argument that returns a number; and if supplied, <var>highWaterMark</var> must
+be a nonnegative, finite number.
+
+<emu-alg>
+  1. If _size_ was not passed, set it to *undefined*.
+  1. If _highWaterMark_ was not passed, set it to *1*.
+  1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
+  1. Set _stream_.[[state]] to `"readable"`.
+  1. Set _stream_.[[reader]] and _stream_.[[storedError]] to *undefined*.
+  1. Set _stream_.[[disturbed]] to *false*.
+  1. Perform ! CreateReadableStreamDefaultControllerFromUnderlyingSourceAlgorithms(_stream_, _size_, _highWaterMark_,
+     _pullAlgorithm_, _cancelAlgorithm_).
+  1. Return _stream_.
+</emu-alg>
+
 <h4 id="is-readable-stream" aoid="IsReadableStream" nothrow>IsReadableStream ( <var>x</var> )</h4>
 
 <emu-alg>
@@ -880,100 +900,61 @@ noticable asymmetry between the two branches, and limits the possible <a>chunks<
   1. Assert: ! IsReadableStream(_stream_) is *true*.
   1. Assert: Type(_cloneForBranch2_) is Boolean.
   1. Let _reader_ be ? AcquireReadableStreamDefaultReader(_stream_).
-  1. Let _teeState_ be Record {[[closedOrErrored]]: *false*, [[canceled1]]: *false*, [[canceled2]]: *false*,
-     [[reason1]]: *undefined*, [[reason2]]: *undefined*, [[promise]]: <a>a new promise</a>}.
-  1. Let _pull_ be a new <a>ReadableStreamTee pull function</a>.
-  1. Set _pull_.[[reader]] to _reader_, _pull_.[[teeState]] to _teeState_, and _pull_.[[cloneForBranch2]] to
-     _cloneForBranch2_.
-  1. Let _cancel1_ be a new <a>ReadableStreamTee branch 1 cancel function</a>.
-  1. Set _cancel1_.[[stream]] to _stream_ and _cancel1_.[[teeState]] to _teeState_.
-  1. Let _cancel2_ be a new <a>ReadableStreamTee branch 2 cancel function</a>.
-  1. Set _cancel2_.[[stream]] to _stream_ and _cancel2_.[[teeState]] to _teeState_.
-  1. Let _underlyingSource1_ be ! ObjectCreate(%ObjectPrototype%).
-  1. Perform ! CreateDataProperty(_underlyingSource1_, `"pull"`, _pull_).
-  1. Perform ! CreateDataProperty(_underlyingSource1_, `"cancel"`, _cancel1_).
-  1. Let _branch1Stream_ be ! Construct(`<a idl>ReadableStream</a>`, _underlyingSource1_).
-  1. Let _underlyingSource2_ be ! ObjectCreate(%ObjectPrototype%).
-  1. Perform ! CreateDataProperty(_underlyingSource2_, `"pull"`, _pull_).
-  1. Perform ! CreateDataProperty(_underlyingSource2_, `"cancel"`, _cancel2_).
-  1. Let _branch2Stream_ be ! Construct(`<a idl>ReadableStream</a>`, _underlyingSource2_).
-  1. Set _pull_.[[branch1]] to _branch1Stream_.[[readableStreamController]].
-  1. Set _pull_.[[branch2]] to _branch2Stream_.[[readableStreamController]].
+  1. Let _closedOrErrored_ be *false*.
+  1. Let _canceled1_ be *false*.
+  1. Let _canceled2_ be *false*.
+  1. Let _reason1_ be *undefined*.
+  1. Let _reason2_ be *undefined*.
+  1. Let _branch1_ be *undefined*.
+  1. Let _branch2_ be *undefined*.
+  1. Let _cancelPromise_ be <a>a new promise</a>.
+  1. Let _pullAlgorithm_ be the following steps:
+    1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
+       which takes the argument _result_ and performs the following steps:
+      1. Assert: Type(_result_) is Object.
+      1. Let _value_ be ? Get(_result_, `"value"`).
+      1. Let _done_ be ? Get(_result_, `"done"`).
+      1. Assert: Type(_done_) is Boolean.
+      1. If _done_ is *true* and _closedOrErrored_ is *false*,
+        1. If _canceled1_ is *false*,
+          1. Perform ! ReadableStreamDefaultControllerClose(_branch1_.[[readableStreamController]]).
+        1. If _canceled2_ is *false*,
+          1. Perform ! ReadableStreamDefaultControllerClose(_branch2_.[[readableStreamController]]).
+        1. Set _closedOrErrored_ to *true*.
+      1. If _closedOrErrored_ is *true*, return.
+      1. Let _value1_ and _value2_ be _value_.
+      1. If _canceled2_ is *false* and _cloneForBranch2_ is *true*, set _value2_ to ? <a
+         abstract-op>StructuredDeserialize</a>(<a abstract-op>StructuredSerialize</a>(_value2_), the current Realm
+         Record).
+      1. If _canceled1_ is *false*, perform ?
+         ReadableStreamDefaultControllerEnqueue(_branch1_.[[readableStreamController]], _value1_).
+      1. If _canceled2_ is *false*, perform ?
+         ReadableStreamDefaultControllerEnqueue(_branch2_.[[readableStreamController]], _value2_).
+  1. Let _cancel1Algorithm_ be the following steps, taking a _reason_ argument:
+    1. Set _canceled1_ to *true*.
+    1. Set _reason1_ to _reason_.
+    1. If _canceled2_ is *true*,
+      1. Let _compositeReason_ be ! CreateArrayFromList(« _reason1_, _reason2_ »).
+      1. Let _cancelResult_ be ! ReadableStreamCancel(_stream_, _compositeReason_).
+      1. <a>Resolve</a> _cancelPromise_ with _cancelResult_.
+    1. Return _cancelPromise_.
+  1. Let _cancel2Algorithm_ be the following steps, taking a _reason_ argument:
+    1. Set _canceled2_ to *true*.
+    1. Set _reason2_ to _reason_.
+    1. If _canceled1_ is *true*,
+      1. Let _compositeReason_ be ! CreateArrayFromList(« _reason1_, _reason2_ »).
+      1. Let _cancelResult_ be ! ReadableStreamCancel(_stream_, _compositeReason_).
+      1. <a>Resolve</a> _cancelPromise_ with _cancelResult_.
+    1. Return _cancelPromise_.
+  1. Set _branch1_ to CreateReadableStream(_pullAlgorithm_, _cancel1Algorithm_).
+  1. Set _branch2_ to CreateReadableStream(_pullAlgorithm_, _cancel2Algorithm_).
   1. <a>Upon rejection</a> of _reader_.[[closedPromise]] with reason _r_,
-    1. If _teeState_.[[closedOrErrored]] is *false*, then:
-      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_pull_.[[branch1]], _r_).
-      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_pull_.[[branch2]], _r_).
-      1. Set _teeState_.[[closedOrErrored]] to *true*.
-  1. Return « _branch1Stream_, _branch2Stream_ ».
+    1. If _closedOrErrored_ is *false*, then:
+      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_branch1_.[[readableStreamController]], _r_).
+      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_branch2_.[[readableStreamController]], _r_).
+      1. Set _closedOrErrored_ to *true*.
+  1. Return « _branch1_, _branch2_ ».
 </emu-alg>
-
-A <dfn>ReadableStreamTee pull function</dfn> is an anonymous built-in function that pulls data from a given <a>readable
-stream reader</a> and enqueues it into two other streams ("branches" of the associated tee). Each ReadableStreamTee
-pull function has \[[reader]], \[[branch1]], \[[branch2]], \[[teeState]], and \[[cloneForBranch2]] internal slots. When
-a ReadableStreamTee pull function <var>F</var> is called, it performs the following steps:
-
-<emu-alg>
-  1. Let _reader_ be _F_.[[reader]], _branch1_ be _F_.[[branch1]], _branch2_ be _F_.[[branch2]], _teeState_ be
-     _F_.[[teeState]], and _cloneForBranch2_ be _F_.[[cloneForBranch2]].
-  1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
-     which takes the argument _result_ and performs the following steps:
-    1. Assert: Type(_result_) is Object.
-    1. Let _value_ be ? Get(_result_, `"value"`).
-    1. Let _done_ be ? Get(_result_, `"done"`).
-    1. Assert: Type(_done_) is Boolean.
-    1. If _done_ is *true* and _teeState_.[[closedOrErrored]] is *false*,
-      1. If _teeState_.[[canceled1]] is *false*,
-        1. Perform ! ReadableStreamDefaultControllerClose(_branch1_).
-      1. If _teeState_.[[canceled2]] is *false*,
-        1. Perform ! ReadableStreamDefaultControllerClose(_branch2_).
-      1. Set _teeState_.[[closedOrErrored]] to *true*.
-    1. If _teeState_.[[closedOrErrored]] is *true*, return.
-    1. Let _value1_ and _value2_ be _value_.
-    1. If _teeState_.[[canceled2]] is *false* and _cloneForBranch2_ is *true*, set _value2_ to ? <a
-       abstract-op>StructuredDeserialize</a>(<a abstract-op>StructuredSerialize</a>(_value2_), the current Realm
-       Record).
-    1. If _teeState_.[[canceled1]] is *false*, perform ? ReadableStreamDefaultControllerEnqueue(_branch1_, _value1_).
-    1. If _teeState_.[[canceled2]] is *false*, perform ? ReadableStreamDefaultControllerEnqueue(_branch2_, _value2_).
-</emu-alg>
-
-A <dfn>ReadableStreamTee branch 1 cancel function</dfn> is an anonymous built-in function that reacts to the
-cancellation of the first of the two branches of the associated tee. Each ReadableStreamTee branch 1 cancel function
-has \[[stream]] and \[[teeState]] internal slots. When a ReadableStreamTee branch 1 cancel function <var>F</var> is
-called with argument <var>reason</var>, it performs the following steps:
-
-<emu-alg>
-  1. Let _stream_ be _F_.[[stream]] and _teeState_ be _F_.[[teeState]].
-  1. Set _teeState_.[[canceled1]] to *true*.
-  1. Set _teeState_.[[reason1]] to _reason_.
-  1. If _teeState_.[[canceled2]] is *true*,
-    1. Let _compositeReason_ be ! CreateArrayFromList(« _teeState_.[[reason1]], _teeState_.[[reason2]] »).
-    1. Let _cancelResult_ be ! ReadableStreamCancel(_stream_, _compositeReason_).
-    1. <a>Resolve</a> _teeState_.[[promise]] with _cancelResult_.
-  1. Return _teeState_.[[promise]].
-</emu-alg>
-
-A <dfn>ReadableStreamTee branch 2 cancel function</dfn> is an anonymous built-in function that reacts to the
-cancellation of the second of the two branches of the associated tee. Each ReadableStreamTee branch 2 cancel function
-has \[[stream]] and \[[teeState]] internal slots. When a ReadableStreamTee branch 2 cancel function <var>F</var> is
-called with argument <var>reason</var>, it performs the following steps:
-
-<emu-alg>
-  1. Let _stream_ be _F_.[[stream]] and _teeState_ be _F_.[[teeState]].
-  1. Set _teeState_.[[canceled2]] to *true*.
-  1. Set _teeState_.[[reason2]] to _reason_.
-  1. If _teeState_.[[canceled1]] is *true*,
-    1. Let _compositeReason_ be ! CreateArrayFromList(« _teeState_.[[reason1]], _teeState_.[[reason2]] »).
-    1. Let _cancelResult_ be ! ReadableStreamCancel(_stream_, _compositeReason_).
-    1. <a>Resolve</a> _teeState_.[[promise]] with _cancelResult_.
-  1. Return _teeState_.[[promise]].
-</emu-alg>
-
-<div class="note">
-  The algorithm given here is written such that three new function objects are created for each call to to
-  ReadableStreamTee. This is just a simplification, and is not actually necessary, since it is unobservable to
-  developer code. For example, a self-hosted implementation could optimize by creating a class whose prototype contains
-  methods for these functions, with the state stored as instance variables.
-</div>
 
 <h3 id="rs-abstract-ops-used-by-controllers">The Interface Between Readable Streams and Controllers</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -510,15 +510,13 @@ ReadableStream(<var>underlyingSource</var> = {}, { <var>size</var>, <var>highWat
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. If _size_ is not *undefined*, throw a *RangeError* exception.
-    1. Set *this*.[[readableStreamController]] to *undefined*.
-    1. Set *this*.[[readableStreamController]] to ? Construct(`<a idl>ReadableByteStreamController</a>`, « *this*,
-       _underlyingSource_, _highWaterMark_ »).
+    1. Perform ? SetUpReadableByteStreamControllerFromUnderlyingSource(*this*, _underlyingSource_, _highWaterMark_).
   1. Otherwise, if _type_ is *undefined*,
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
     1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
-    1. Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource(*this*, _underlyingSource_,
-       _highWaterMark_, _sizeAlgorithm_).
+    1. Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource(*this*, _underlyingSource_, _highWaterMark_,
+       _sizeAlgorithm_).
   1. Otherwise, throw a *RangeError* exception.
 </emu-alg>
 
@@ -853,7 +851,35 @@ throws.</p>
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
   1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
-     _sizeAlgorithm_, _highWaterMark_).
+     _highWaterMark_, _sizeAlgorithm_).
+  1. Return _stream_.
+</emu-alg>
+
+<h4 id="create-readable-byte-stream" aoid="CreateReadableByteStream" throws export>CreateReadableByteStream (
+<var>startAlgorithm</var>, <var>pullAlgorithm</var>, <var>cancelAlgorithm</var> [, <var>highWaterMark</var> [,
+<var>autoAllocateChunkSize</var> ] ] )</h4>
+
+This abstract operation is meant to be called from other specifications that wish to create {{ReadableStream}}
+instances of type "bytes". The <var>pullAlgorithm</var> and <var>cancelAlgorithm</var> algorithms must return
+promises; if supplied, <var>highWaterMark</var> must be a nonnegative, non-NaN number, and if supplied,
+<var>autoAllocateChunkSize</var> must be a positive integer.
+
+<p class="note">CreateReadableByteStream throws an exception if and only if the supplied <var>startAlgorithm</var>
+throws.</p>
+
+<emu-alg>
+  1. If _highWaterMark_ was not passed, set it to *0*.
+  1. If _autoAllocateChunkSize_ was not passed, set it to *undefined*.
+  1. Assert: Type(_highWaterMark_) is Number.
+  1. Assert: _highWaterMark_ is not NaN.
+  1. Assert: _highWaterMark_ is not negative.
+  1. If _autoAllocateChunkSize_ is not *undefined*,
+    1. Assert: ! IsInteger(_autoAllocateChunkSize_) is *true*.
+    1. Assert: _autoAllocateChunkSize_ is positive.
+  1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
+  1. Perform ! InitializeReadableStream(_stream_).
+  1. Perform ? SetUpReadableByteStreamController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+     _highWaterMark_, _autoAllocateChunkSize_).
   1. Return _stream_.
 </emu-alg>
 
@@ -1855,7 +1881,6 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorit
 <var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
-  1. Assert: ! IsReadableStream(_stream_) is *true*.
   1. Assert: _stream_.[[readableStreamController]] is *undefined*.
   1. Let _controller_ be ObjectCreate(the original value of <a idl>ReadableStreamDefaultController</a>'s `prototype`
      property).
@@ -2006,35 +2031,11 @@ lt="ReadableByteStreamController(stream, underlyingByteSource, highWaterMark)">n
 ReadableByteStreamController(<var>stream</var>, <var>underlyingByteSource</var>, <var>highWaterMark</var>)</h4>
 
 <div class="note">
-  The <code>ReadableByteStreamController</code> constructor cannot be used directly; it only works on a
-  {{ReadableStream}} that is in the middle of being constructed.
+  The <code>ReadableByteStreamController</code> constructor cannot be used directly.
 </div>
 
 <emu-alg>
-  1. If ! IsReadableStream(_stream_) is *false*, throw a *TypeError* exception.
-  1. If _stream_.[[readableStreamController]] is not *undefined*, throw a *TypeError* exception.
-  1. Set *this*.[[controlledReadableByteStream]] to _stream_.
-  1. Set *this*.[[underlyingByteSource]] to _underlyingByteSource_.
-  1. Set *this*.[[pullAgain]], and *this*.[[pulling]] to *false*.
-  1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(*this*).
-  1. Perform ! ResetQueue(*this*).
-  1. Set *this*.[[started]] and *this*.[[closeRequested]] to *false*.
-  1. Set *this*.[[strategyHWM]] to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
-  1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
-  1. If _autoAllocateChunkSize_ is not *undefined*,
-    1. If ! IsInteger(_autoAllocateChunkSize_) is *false*, or if _autoAllocateChunkSize_ ≤ *0*, throw a *RangeError* exception.
-  1. Set *this*.[[autoAllocateChunkSize]] to _autoAllocateChunkSize_.
-  1. Set *this*.[[pendingPullIntos]] to a new empty List.
-  1. Let _controller_ be *this*.
-  1. Let _startResult_ be ? InvokeOrNoop(_underlyingByteSource_, `"start"`, « *this* »).
-  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
-    1. <a>Upon fulfillment</a>  of _startPromise_,
-      1. Set _controller_.[[started]] to *true*.
-      1. Assert: _controller_.[[pulling]] is *false*.
-      1. Assert: _controller_.[[pullAgain]] is *false*.
-      1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
-    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
-      1. If _stream_.[[state]] is `"readable"`, perform ! ReadableByteStreamControllerError(_controller_, _r_).
+  1. Throw a *TypeError* exception.
 </emu-alg>
 
 <h4 id="rbs-controller-prototype">Properties of the {{ReadableByteStreamController}} Prototype</h4>
@@ -2125,7 +2126,7 @@ readable stream implementation will polymorphically call to either these or thei
     1. Let _firstDescriptor_ be the first element of *this*.[[pendingPullIntos]].
     1. Set _firstDescriptor_.[[bytesFilled]] to *0*.
   1. Perform ! ResetQueue(*this*).
-  1. Return ! PromiseInvokeOrNoop(*this*.[[underlyingByteSource]], `"cancel"`, « _reason_ »)
+  1. Return the result of performing *this*.[[cancelAlgorithm]], passing in _reason_.
 </emu-alg>
 
 <h5 id="rbs-controller-private-pull"><a abstract-op>\[[PullSteps]]</a>()</h5>
@@ -2277,7 +2278,7 @@ nothrow>ReadableByteStreamControllerCallPullIfNeeded ( <var>controller</var> )</
     1. Return.
   1. Assert: _controller_.[[pullAgain]] is *false*.
   1. Set _controller_.[[pulling]] to *true*.
-  1. Let _pullPromise_ be ! PromiseInvokeOrNoop(_controller_.[[underlyingByteSource]], `"pull"`, « _controller_ »).
+  1. Let _pullPromise_ be the result of performing _controller_.[[pullAlgorithm]].
   1. <a>Upon fulfillment</a> of _pullPromise_,
     1. Set _controller_.[[pulling]] to *false*.
     1. If _controller_.[[pullAgain]] is *true*,
@@ -2638,6 +2639,59 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
      return *true*.
   1. If ! ReadableByteStreamControllerGetDesiredSize(_controller_) > *0*, return *true*.
   1. Return *false*.
+</emu-alg>
+
+<h4 id="set-up-readable-byte-stream-controller" aoid="SetUpReadableByteStreamController"
+throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>startAlgorithm</var>, <var>pullAlgorithm</var>,
+<var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>autoAllocateChunkSize</var> )</h4>
+
+<emu-alg>
+  1. Assert: _stream_.[[readableStreamController]] is *undefined*.
+  1. If _autoAllocateChunkSize_ is not *undefined*,
+    1. Assert: ! IsInteger(_autoAllocateChunkSize_) is *true*.
+    1. Assert: _autoAllocateChunkSize_ is positive.
+  1. Let _controller_ be ObjectCreate(the original value of <a idl>ReadableByteStreamController</a>'s `prototype`
+     property).
+  1. Set _controller_.[[controlledReadableByteStream]] to _stream_.
+  1. Set _controller_.[[pullAgain]] and _controller_.[[pulling]] to *false*.
+  1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(_controller_).
+  1. Perform ! ResetQueue(_controller_).
+  1. Set _controller_.[[closeRequested]] and _controller_.[[started]] to *false*.
+  1. Set _controller_.[[strategyHWM]] to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
+  1. Set _controller_.[[pullAlgorithm]] to _pullAlgorithm_.
+  1. Set _controller_.[[cancelAlgorithm]] to _cancelAlgorithm_.
+  1. Set _controller_.[[autoAllocateChunkSize]] to _autoAllocateChunkSize_.
+  1. Set _controller_.[[pendingPullIntos]] to a new empty List.
+  1. Set _stream_.[[readableStreamController]] to _controller_.
+  1. Let _startResult_ be the result of performing _startAlgorithm_.
+  1. Let _startPromise_ be <a>a promise resolved with</a> _startResult_:
+    1. <a>Upon fulfillment</a>  of _startPromise_,
+      1. Set _controller_.[[started]] to *true*.
+      1. Assert: _controller_.[[pulling]] is *false*.
+      1. Assert: _controller_.[[pullAgain]] is *false*.
+      1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
+    1. <a>Upon rejection</a> of _startPromise_ with reason _r_,
+      1. If _stream_.[[state]] is `"readable"`, perform ! ReadableByteStreamControllerError(_controller_, _r_).
+</emu-alg>
+
+<h4 id="set-up-readable-byte-stream-controller-from-underlying-source"
+aoid="SetUpReadableByteStreamControllerFromUnderlyingSource"
+throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>, <var>underylingByteSource</var>,
+<var>highWaterMark</var> )</h4>
+
+<emu-alg>
+  1. Let _startAlgorithm_ be the following steps:
+    1. Return ? InvokeOrNoop(_underlyingByteSource_, `"start"`, « _stream_.[[readableStreamController]] »).
+  1. Let _pullAlgorithm_ be the following steps:
+    1. Return ! PromiseInvokeOrNoop(_underlyingByteSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
+  1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
+    1. Return ! PromiseInvokeOrNoop(_underlyingByteSource_, `"cancel"`, « _reason_ »).
+  1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
+  1. If _autoAllocateChunkSize_ is not *undefined*,
+    1. If ! IsInteger(_autoAllocateChunkSize_) is *false*, or if _autoAllocateChunkSize_ ≤ *0*, throw a *RangeError*
+       exception.
+  1. Perform ! SetUpReadableByteStreamController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+     _highWaterMark_, _autoAllocateChunkSize_).
 </emu-alg>
 
 <h2 id="ws">Writable Streams</h2>

--- a/index.bs
+++ b/index.bs
@@ -984,8 +984,9 @@ noticable asymmetry between the two branches, and limits the possible <a>chunks<
       1. Let _cancelResult_ be ! ReadableStreamCancel(_stream_, _compositeReason_).
       1. <a>Resolve</a> _cancelPromise_ with _cancelResult_.
     1. Return _cancelPromise_.
-  1. Set _branch1_ to CreateReadableStream(_pullAlgorithm_, _cancel1Algorithm_).
-  1. Set _branch2_ to CreateReadableStream(_pullAlgorithm_, _cancel2Algorithm_).
+  1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
+  1. Set _branch1_ to CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel1Algorithm_).
+  1. Set _branch2_ to CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel2Algorithm_).
   1. <a>Upon rejection</a> of _reader_.[[closedPromise]] with reason _r_,
     1. If _closedOrErrored_ is *false*, then:
       1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_branch1_.[[readableStreamController]], _r_).
@@ -1627,8 +1628,7 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
 </table>
 
 <h4 id="rs-default-controller-constructor" constructor for="ReadableStreamDefaultController"
-lt="ReadableStreamDefaultController()">new
-ReadableStreamDefaultController()</h4>
+lt="ReadableStreamDefaultController()">new ReadableStreamDefaultController()</h4>
 
 <div class="note">
   The <code>ReadableStreamDefaultController</code> constructor cannot be used directly;
@@ -1911,7 +1911,7 @@ throws>SetUpReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var
     1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
   1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
     1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
-  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _underlyingSource_,
+  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _highWaterMark_, _sizeAlgorithm_)
 </emu-alg>
 
@@ -3718,7 +3718,7 @@ used polymorphically.
 <var>reason</var> )</h5>
 
 <emu-alg>
-  1. Return the result of performing *this*.[[abortAlgorithm]].
+  1. Return the result of performing *this*.[[abortAlgorithm]], passing _reason_.
 </emu-alg>
 
 <h5 id="ws-default-controller-private-error">\[[ErrorSteps]]()</h5>
@@ -4085,7 +4085,7 @@ readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writabl
   1. Let _readableHighWaterMark_ be ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
   1. Perform ! InitializeTransformStream(*this*, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
-  1. Perform ! SetUpTransformStreamDefaultControllerFromTransformer(*this*, _transform_).
+  1. Perform ! SetUpTransformStreamDefaultControllerFromTransformer(*this*, _transformer_).
   1. Let _startResult_ be ? InvokeOrNoop(_transformer_, `"start"`, « *this*.[[transformStreamController]] »).
   1. <a>Resolve</a> _startPromise_ with _startResult_.
 </emu-alg>
@@ -4159,21 +4159,21 @@ throws.</p>
     1. Return ! TransformStreamDefaultSinkAbortAlgorithm(_stream_).
   1. Let _closeAlgorithm_ be the following steps:
     1. Return ! TransformStreamDefaultSinkCloseAlgorithm(_stream_).
-  1. Set *this*.[[writable]] to ! CreateWritableStream(_startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
+  1. Set _stream_.[[writable]] to ! CreateWritableStream(_startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
      _abortAlgorithm_, _writableHighWaterMark_, _writableSizeAlgorithm_).
   1. Let _pullAlgorithm_ be the following steps:
     1. Return ! TransformStreamDefaultSourcePullAlgorithm(_stream_).
   1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
     1. Perform ! TransformStreamErrorWritableAndUnblockWrite(_stream_, _reason_).
     1. Return <a>a promise resolved with</a> *undefined*.
-  1. Set *this*.[[readable]] to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+  1. Set _stream_.[[readable]] to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
-  1. Set *this*.[[backpressure]] and *this*.[[backpressureChangePromise]] to *undefined*.
+  1. Set _stream_.[[backpressure]] and _stream_.[[backpressureChangePromise]] to *undefined*.
      <p class="note">The [[backpressure]] slot is set to *undefined* so that it can be initialized by
      TransformStreamSetBackpressure. Alternatively, implementations can use a strictly boolean value for
      [[backpressure]] and change the way it is initialized. This will not be visible to user code so long as the
      initialization is correctly completed before _transformer_'s <code>start()</code> method is is called.</p>
-  1. Perform ! TransformStreamSetBackpressure(*this*, *true*).
+  1. Perform ! TransformStreamSetBackpressure(_stream_, *true*).
   1. Set _stream_.[[transformStreamController]] to *undefined*.
 </emu-alg>
 

--- a/index.bs
+++ b/index.bs
@@ -849,7 +849,6 @@ throws.</p>
   1. If _sizeAlgorithm_ was not passed, set it to an algorithm that returns *1*.
   1. Assert: Type(_highWaterMark_) is Number.
   1. Assert: _highWaterMark_ is not NaN.
-  1. Assert: _highWaterMark_ is not +∞.
   1. Assert: _highWaterMark_ is not negative.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>ReadableStream</a>'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
@@ -2939,12 +2938,12 @@ throws.</p>
 <emu-alg>
   1. Assert: Type(_highWaterMark_) is Number.
   1. Assert: _highWaterMark_ is not NaN.
-  1. Assert: _highWaterMark_ is not +∞.
   1. Assert: _highWaterMark_ is not negative.
   1. Let _stream_ be ObjectCreate(the original value of <a idl>WritableStream</a>'s `prototype` property).
   1. Perform ! InitializeWritableStream(_stream_).
   1. Perform ! SetUpWritableStreamDefaultController(_stream_, _startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
      _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
+  1. Return _stream_.
 </emu-alg>
 
 <h4 id="initialize-writable-stream" aoid="InitializeWritableStream" nothrow>InitializeWritableStream ( <var>stream</var>
@@ -3981,7 +3980,7 @@ Instances of {{TransformStream}} are created with the internal slots described i
 </table>
 
 <h4 id="ts-constructor" constructor for="TransformStream" lt="TransformStream(transformer, writableStrategy,
-readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writableStrategy</var> = undefined, {
+readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writableStrategy</var> = {}, {
 <var>size</var>, <var>highWaterMark</var> = 0 } = {})</h4>
 
 <div class="note">
@@ -4031,16 +4030,30 @@ readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writabl
   1. Let _controller_ be ? Construct(`<a idl>TransformStreamDefaultController</a>`, « *this* »).
   1. Set *this*.[[transformStreamController]] to _controller_.
   1. Let _startPromise_ be <a>a new promise</a>.
-  1. Let _source_ be ! Construct(`<a idl>TransformStreamDefaultSource</a>`, « *this*, _startPromise_ »).
-  1. Let _readableStrategy_ be ! ObjectCreate(%ObjectPrototype%).
-     <p class="note"><var>readableStrategy</var> is created from scratch so that the default <a>high water mark</a> can
-     be overridden. This does not apply to <var>writableStrategy</var>, so it is passed through unchanged from the
-     second constructor argument.</p>
-  1. Perform ! CreateDataProperty(_readableStrategy_, `"size"`, _size_).
-  1. Perform ! CreateDataProperty(_readableStrategy_, `"highWaterMark"`, _highWaterMark_).
-  1. Set *this*.[[readable]] to ? Construct(`<a idl>ReadableStream</a>`, « _source_, _readableStrategy_ »).
-  1. Let _sink_ be ! Construct(`<a idl>TransformStreamDefaultSink</a>`, « *this*, _startPromise_ »).
-  1. Set *this*.[[writable]] to ? Construct(`<a idl>WritableStream</a>`, « _sink_, _writableStrategy_ »).
+  1. Let _startAlgorithm_ be an algorithm that returns _startPromise_.
+  1. Let _stream_ be *this*.
+  1. Let _writeAlgorithm_ be the following steps, taking a _chunk_ argument:
+    1. Return ! TransformStreamDefaultSinkWriteAlgorithm(_stream_, _chunk_).
+  1. Let _abortAlgorithm_ be the following steps:
+    1. Return ! TransformStreamDefaultSinkAbortAlgorithm(_stream_).
+  1. Let _closeAlgorithm_ be the following steps:
+    1. Return ! TransformStreamDefaultSinkCloseAlgorithm(_stream_).
+  1. Let _writableSizeFunction_ be ? GetV(_writableStrategy_, `"size"`).
+  1. Let _writableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_writableSizeFunction_).
+  1. Let _writableHighWaterMark_ be ? GetV(_writableStrategy_, `"highWaterMark"`).
+  1. If _writableHighWaterMark_ is *undefined*, set _writableHighWaterMark_ to *1*.
+  1. Set _writableHighWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_writableHighWaterMark_).
+  1. Set *this*.[[writable]] to ! CreateWritableStream(_startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
+     _abortAlgorithm_, _writableHighWaterMark_, _writableSizeAlgorithm_).
+  1. Let _pullAlgorithm_ be the following steps:
+    1. Return ! TransformStreamDefaultSourcePullAlgorithm(_stream_).
+  1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
+    1. Perform ! TransformStreamErrorWritableAndUnblockWrite(_stream_, _reason_).
+    1. Return <a>a promise resolved with</a> *undefined*.
+  1. Let _readableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
+  1. Let _readableHighWaterMark_ be ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
+  1. Set *this*.[[readable]] to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
+     _readableHighWaterMark_, _readableSizeAlgorithm_).
   1. Set *this*.[[backpressure]] and *this*.[[backpressureChangePromise]] to *undefined*.
      <p class="note">The [[backpressure]] slot is set to *undefined* so that it can be initialized by
      TransformStreamSetBackpressure. Alternatively, implementations can use a strictly boolean value for
@@ -4105,9 +4118,9 @@ nothrow>TransformStreamErrorWritableAndUnblockWrite ( <var>stream</var>, <var>e<
   1. If _stream_.[[backpressure]] is *true*, perform ! TransformStreamSetBackpressure(_stream_, *false*).
 </emu-alg>
 
-<p class="note">The {{TransformStreamDefaultSink/write()}} method of {{TransformStreamDefaultSink}} could be waiting for
-the promise stored in the \[[backpressureChangePromise]] slot to resolve. This call to TransformStreamSetBackpressure
-ensures that the promise always resolves.</p>
+<p class="note">The TransformStreamDefaultSinkWriteAlgorithm abstract operation could be waiting for the promise
+stored in the \[[backpressureChangePromise]] slot to resolve. This call to TransformStreamSetBackpressure ensures that
+the promise always resolves.</p>
 
 <h4 id="transform-stream-set-backpressure" aoid="TransformStreamSetBackpressure" nothrow>TransformStreamSetBackpressure
 ( <var>stream</var>, <var>backpressure</var> )</h4>
@@ -4295,83 +4308,12 @@ this to streams they did not create.
   1. Perform ! TransformStreamErrorWritableAndUnblockWrite(_stream_, _error_).
 </emu-alg>
 
-<h3 id="ts-default-sink-class" interface lt="TransformStreamDefaultSink">Class
-<code>TransformStreamDefaultSink</code></h3>
+<h3 id="ts-default-sink-abstract-ops">Transform Stream Default Sink Abstract Operations</h3>
 
-The {{TransformStreamDefaultSink}} class is used internally as the <a>underlying sink</a> that is passed to the
-{{WritableStream}} constructor when constructing the \[[writable]] slot of a {{TransformStream}}.
-
-<div class="note">
-  This specification uses the public API for transmitting events from the {{WritableStream}} back to the
-  {{TransformStream}} implementation for simplicity. Since the {{TransformStreamDefaultSink}} class is not observable,
-  implementations do not need to implement it, but could instead do something else observably equivalent. See <a
-  href="https://github.com/whatwg/streams/issues/813">#813</a> for an alternate specification approach that will make
-  this clearer in the future.
-</div>
-
-<h4 id="ts-default-sink-class-definition">Class Definition</h4>
-
-<div class="non-normative">
-
-<em>This section is non-normative.</em>
-
-If one were to write the {{TransformStreamDefaultSink}} class in something close to the syntax of [[!ECMASCRIPT]],
-it would look like
-
-<pre><code class="lang-javascript">
-  class TransformStreamDefaultSink {
-    constructor(stream, startPromise)
-
-    start()
-    write(chunk)
-    abort()
-    close()
-  }
-</code></pre>
-
-</div>
-
-<h4 id="ts-default-sink-internal-slots">Internal Slots</h4>
-
-Instances of {{TransformStreamDefaultSink}} are created with the internal slots described in the following table:
-
-<table>
-  <thead>
-    <tr>
-      <th>Internal Slot</th>
-      <th>Description (<em>non-normative</em>)</th>
-    </tr>
-  </thead>
-  <tr>
-    <td>\[[ownerTransformStream]]
-    <td class="non-normative">The {{TransformStream}} instance
-  </tr>
-  <tr>
-    <td>\[[startPromise]]
-    <td class="non-normative">The <var>startPromise</var> parameter that was passed to the constructor
-  </tr>
-</table>
-
-<h4 id="ts-default-sink-constructor" constructor for="TransformStreamDefaultSink" lt="TransformStreamDefaultSink(stream,
-startPromise)">new TransformStreamDefaultSink(<var>stream</var>, <var>startPromise</var>)</h4>
+<h4 id="transform-stream-default-sink-write-algorithm" aoid="TransformStreamDefaultSinkWriteAlgorithm"
+nothrow>TransformStreamDefaultSinkWriteAlgorithm ( <var>stream</var>, <var>chunk</var> )</h4>
 
 <emu-alg>
-  1. Set *this*.[[ownerTransformStream]] to _stream_.
-  1. Set *this*.[[startPromise]] to _startPromise_.
-</emu-alg>
-
-<h4 id="ts-default-sink-prototype">Properties of the {{TransformStreamDefaultSink}} Prototype</h4>
-
-<h5 id="ts-default-sink-start" method for="TransformStreamDefaultSink">start()</h5>
-
-<emu-alg>
-  1. Return *this*.[[startPromise]].
-</emu-alg>
-
-<h5 id="ts-default-sink-write" method for="TransformStreamDefaultSink">write(<var>chunk</var>)</h5>
-
-<emu-alg>
-  1. Let _stream_ be *this*.[[ownerTransformStream]].
   1. Assert: _stream_.[[writable]].[[state]] is `"writable"`.
   1. If _stream_.[[backpressure]] is *true*,
     1. Let _backpressureChangePromise_ be _stream_.[[backpressureChangePromise]].
@@ -4382,21 +4324,23 @@ startPromise)">new TransformStreamDefaultSink(<var>stream</var>, <var>startPromi
       1. Let _state_ be _writable_.[[state]].
       1. If _state_ is `"erroring"`, throw _writable_.[[storedError]].
       1. Assert: _state_ is `"writable"`.
-      1. Return ! TransformStreamDefaultSinkTransform(*this*, _chunk_).
-  1. Return ! TransformStreamDefaultSinkTransform(*this*, _chunk_).
+      1. Return ! TransformStreamDefaultSinkTransform(_stream_, _chunk_).
+  1. Return ! TransformStreamDefaultSinkTransform(_stream_, _chunk_).
 </emu-alg>
 
-<h5 id="ts-default-sink-abort" method for="TransformStreamDefaultSink">abort()</h5>
+<h4 id="transform-stream-default-sink-abort-algorithm" aoid="TransformStreamDefaultSinkAbortAlgorithm"
+nothrow>TransformStreamDefaultSinkAbortAlgorithm ( <var>stream</var> )</h4>
 
 <emu-alg>
   1. Let _e_ be a *TypeError* exception indicating that the writable stream was aborted.
-  1. Perform ! TransformStreamError(*this*.[[ownerTransformStream]], _e_).
+  1. Perform ! TransformStreamError(_stream_, _e_).
+  1. Return <a>a promise resolved with</a> *undefined*.
 </emu-alg>
 
-<h5 id="ts-default-sink-close" method for="TransformStreamDefaultSink">close()</h5>
+<h4 id="transform-stream-default-sink-close-algorithm" aoid="TransformStreamDefaultSinkCloseAlgorithm"
+nothrow>TransformStreamDefaultSinkCloseAlgorithm( _stream_ )</h4>
 
 <emu-alg>
-  1. Let _stream_ be *this*.[[ownerTransformStream]].
   1. Let _readable_ be _stream_.[[readable]].
   1. Let _flushPromise_ be ! PromiseInvokeOrNoop(_stream_.[[transformer]], `"flush"`, «
      _stream_.[[transformStreamController]] »).
@@ -4410,8 +4354,6 @@ startPromise)">new TransformStreamDefaultSink(<var>stream</var>, <var>startPromi
       1. Perform ! TransformStreamError(_stream_, _r_).
       1. Throw _readable_.[[storedError]].
 </emu-alg>
-
-<h3 id="ts-default-sink-abstract-ops">Transform Stream Default Sink Abstract Operations</h3>
 
 <h4 id="transform-stream-default-sink-invoke-transform" aoid="TransformStreamDefaultSinkInvokeTransform"
 throws>TransformStreamDefaultSinkInvokeTransform ( <var>stream</var>, <var>chunk</var> )</h4>
@@ -4427,10 +4369,9 @@ throws>TransformStreamDefaultSinkInvokeTransform ( <var>stream</var>, <var>chunk
 </emu-alg>
 
 <h4 id="transform-stream-default-sink-transform" aoid="TransformStreamDefaultSinkTransform"
-nothrow>TransformStreamDefaultSinkTransform ( <var>sink</var>, <var>chunk</var> )</h4>
+nothrow>TransformStreamDefaultSinkTransform ( <var>stream</var>, <var>chunk</var> )</h4>
 
 <emu-alg>
-  1. Let _stream_ be _sink_.[[ownerTransformStream]].
   1. Assert: _stream_.[[readable]].[[state]] is not `"errored"`.
   1. Assert: _stream_.[[backpressure]] is *false*.
   1. Let _transformPromise_ be *undefined*.
@@ -4444,97 +4385,17 @@ nothrow>TransformStreamDefaultSinkTransform ( <var>sink</var>, <var>chunk</var> 
     1. Throw _e_.
 </emu-alg>
 
-<h3 id="ts-default-source-class" interface lt="TransformStreamDefaultSource">Class
-<code>TransformStreamDefaultSource</code></h3>
+<h3 id="ts-default-sink-abstract-ops">Transform Stream Default Source Abstract Operations</h3>
 
-The {{TransformStreamDefaultSource}} class is used internally as the <a>underlying source</a> that is passed to the
-{{ReadableStream}} constructor when constructing the \[[readable]] slot.
-
-<div class="note">
-  This specification uses the public API for transmitting events from the {{ReadableStream}} back to the
-  {{TransformStream}} implementation for simplicity. Since the {{TransformStreamDefaultSource}} class is not observable,
-  implementations do not need to implement it, but could instead do something else observably equivalent. See <a
-  href="https://github.com/whatwg/streams/issues/813">#813</a> for an alternate specification approach that will make
-  this clearer in the future.
-</div>
-
-<h4 id="ts-default-source-class-definition">Class Definition</h4>
-
-<div class="non-normative">
-
-<em>This section is non-normative.</em>
-
-If one were to write the {{TransformStreamDefaultSource}} class in something close to the syntax of [[!ECMASCRIPT]],
-it would look like
-
-<pre><code class="lang-javascript">
-  class TransformStreamDefaultSource {
-    constructor(stream, startPromise)
-
-    start()
-    pull()
-    cancel(reason)
-  }
-</code></pre>
-
-</div>
-
-<h4 id="ts-default-source-internal-slots">Internal Slots</h4>
-
-Instances of {{TransformStreamDefaultSource}} are created with the internal slots described in the following table:
-
-<table>
-  <thead>
-    <tr>
-      <th>Internal Slot</th>
-      <th>Description (<em>non-normative</em>)</th>
-    </tr>
-  </thead>
-  <tr>
-    <td>\[[ownerTransformStream]]
-    <td class="non-normative">The {{TransformStream}} instance
-  </tr>
-  <tr>
-    <td>\[[startPromise]]
-    <td class="non-normative">The <var>startPromise</var> parameter that was passed to the constructor
-  </tr>
-</table>
-
-<h4 id="ts-default-source-constructor" constructor for="TransformStreamDefaultSource"
-lt="TransformStreamDefaultSource(stream, startPromise)">new TransformStreamDefaultSource(<var>stream</var>,
-<var>startPromise</var>)</h4>
+<h4 id="transform-stream-default-source-pull"
+aoid="TransformStreamDefaultSourcePullAlgorithm" nothrow>TransformStreamDefaultSourcePullAlgorithm( _stream_ )</h4>
 
 <emu-alg>
-  1. Set *this*.[[ownerTransformStream]] to _stream_.
-  1. Set *this*.[[startPromise]] to _startPromise_.
-</emu-alg>
-
-<h4 id="ts-default-source-prototype">Properties of the {{TransformStreamDefaultSource}} Prototype</h4>
-
-<h5 id="ts-default-source-start" method for="TransformStreamDefaultSource">start()</h5>
-
-<emu-alg>
-  1. Return *this*.[[startPromise]].
-</emu-alg>
-
-<h5 id="ts-default-source-pull" method for="TransformStreamDefaultSource">pull()</h5>
-
-<emu-alg>
-  1. Let _stream_ be *this*.[[ownerTransformStream]].
   1. Assert: _stream_.[[backpressure]] is *true*.
   1. Assert: _stream_.[[backpressureChangePromise]] is not *undefined*.
   1. Perform ! TransformStreamSetBackpressure(_stream_, *false*).
   1. Return _stream_.[[backpressureChangePromise]].
 </emu-alg>
-
-<h5 id="ts-default-source-cancel" method for="TransformStreamDefaultSource">cancel(<var>reason</var>)</h5>
-
-<emu-alg>
-  1. Perform ! TransformStreamErrorWritableAndUnblockWrite(*this*.[[ownerTransformStream]], _reason_).
-</emu-alg>
-
-<p class="note">The <a>readable side</a> is closed before <code>cancel()</code> is called. Only the <a>writable side</a>
-becomes errored.</p>
 
 <h2 id="other-stuff">Other Stream APIs and Operations</h2>
 
@@ -4859,9 +4720,6 @@ The attributes of these properties must be { \[[Writable]]: <emu-val>true</emu-v
   The {{ReadableStreamDefaultReader}}, {{ReadableStreamBYOBReader}}, {{ReadableStreamDefaultController}},
   {{ReadableByteStreamController}}, {{WritableStreamDefaultWriter}}, {{WritableStreamDefaultController}}, and
   {{TransformStreamDefaultController}} classes are specifically not exposed, as they are not independently useful.
-
-  Similarly, the {{TransformStreamDefaultSource}} and {{TransformStreamDefaultSink}} classes are not exposed, as they
-  are unobservable specification details and never visible to web developers.
 </div>
 
 <h2 id="creating-examples">Examples of Creating Streams</h2>

--- a/index.bs
+++ b/index.bs
@@ -1579,6 +1579,7 @@ Instances of {{ReadableStreamDefaultController}} are created with the internal s
     <td>\[[cancelAlgorithm]]
     <td class="non-normative">A promise-returning algorithm, taking one argument (the cancel reason), which communicates
       a requested cancelation to the <a>underlying source</a>
+  </tr>
   <tr>
     <td>\[[closeRequested]]
     <td class="non-normative">A boolean flag indicating whether the stream has been closed by its <a>underlying
@@ -1967,6 +1968,11 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
     <td class="non-normative">A {{ReadableStreamBYOBRequest}} instance representing the current BYOB pull request
   </tr>
   <tr>
+    <td>\[[cancelAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm, taking one argument (the cancel reason), which communicates
+      a requested cancelation to the <a>underlying source</a>
+  </tr>
+  <tr>
     <td>\[[closeRequested]]
     <td class="non-normative">A boolean flag indicating whether the stream has been closed by its <a>underlying byte
       source</a>, but still has <a>chunks</a> in its internal queue that have not yet been read
@@ -1980,6 +1986,10 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
     <td class="non-normative">A boolean flag set to <emu-val>true</emu-val> if the stream's mechanisms requested a call
       to the <a>underlying byte source</a>'s <code>pull</code> method to pull more data, but the pull could not yet be
       done since a previous call is still executing
+  </tr>
+  <tr>
+    <td>\[[pullAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm that pulls data from the <a>underlying source</a>
   </tr>
   <tr>
     <td>\[[pulling]]
@@ -2006,11 +2016,6 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
     <td>\[[strategyHWM]]
     <td class="non-normative">A number supplied to the constructor as part of the stream's <a>queuing strategy</a>,
       indicating the point at which the stream will apply <a>backpressure</a> to its <a>underlying byte source</a>
-  </tr>
-  <tr>
-    <td>\[[underlyingByteSource]]
-    <td class="non-normative">An object representation of the stream's <a>underlying byte source</a>;
-      also used for the <a href="#is-readable-byte-stream-controller">IsReadableByteStreamController</a> brand check
   </tr>
 </table>
 
@@ -4016,10 +4021,6 @@ Instances of {{TransformStream}} are created with the internal slots described i
     <td class="non-normative">The {{ReadableStream}} instance controlled by this object
   </tr>
   <tr>
-    <td>\[[transformer]]
-    <td class="non-normative">The <var>transformer</var> object that was passed to the constructor
-  </tr>
-  <tr>
     <td>\[[transformStreamController]]
     <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to control \[[readable]]
     and \[[writable]]; also used for the <a href="#is-transform-stream">IsTransformStream</a> brand check
@@ -4270,6 +4271,15 @@ Instances of {{TransformStreamDefaultController}} are created with the internal 
     <td class="non-normative">The {{TransformStream}} instance controlled; also used for the
       IsTransformStreamDefaultController brand check
   </tr>
+  <tr>
+    <td>\[[flushAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm which communicates a requested close to the
+      <a>transformer</a>
+  </tr>
+  <tr>
+    <td>\[[transformAlgorithm]]
+    <td class="non-normative">A promise-returning algorithm, taking one argument (the <a>chunk</a> to transform), which
+      requests the <a>transformer</a> perform its transformation
 </table>
 
 <h4 id="ts-default-controller-constructor" constructor for="TransformStreamDefaultController"

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -33,12 +33,26 @@ exports.CreateIterResultObject = (value, done) => {
 };
 
 exports.IsFiniteNonNegativeNumber = v => {
-  if (Number.isNaN(v)) {
+  if (exports.IsNonNegativeNumber(v) === false) {
     return false;
   }
+
   if (v === Infinity) {
     return false;
   }
+
+  return true;
+};
+
+exports.IsNonNegativeNumber = v => {
+  if (typeof v !== 'number') {
+    return false;
+  }
+
+  if (Number.isNaN(v)) {
+    return false;
+  }
+
   if (v < 0) {
     return false;
   }

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -111,12 +111,12 @@ exports.ValidateAndNormalizeHighWaterMark = highWaterMark => {
   return highWaterMark;
 };
 
-exports.ValidateAndNormalizeQueuingStrategy = (size, highWaterMark) => {
-  if (size !== undefined && typeof size !== 'function') {
+exports.MakeSizeAlgorithmFromSizeFunction = size => {
+  if (size === undefined) {
+    return () => 1;
+  }
+  if (typeof size !== 'function') {
     throw new TypeError('size property of a queuing strategy must be a function');
   }
-
-  highWaterMark = exports.ValidateAndNormalizeHighWaterMark(highWaterMark);
-
-  return { size, highWaterMark };
+  return chunk => size(chunk);
 };

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('better-assert');
 const { ArrayBufferCopy, CreateIterResultObject, IsFiniteNonNegativeNumber, InvokeOrNoop, IsDetachedBuffer,
-        PromiseInvokeOrNoop, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark,
+        PromiseInvokeOrNoop, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
@@ -293,9 +293,7 @@ function AcquireReadableStreamDefaultReader(stream) {
 // Throws if and only if startAlgorithm throws.
 function CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark = 1,
                               sizeAlgorithm = () => 1) {
-  assert(typeof highWaterMark === 'number');
-  assert(!Number.isNaN(highWaterMark));
-  assert(highWaterMark >= 0);
+  assert(IsNonNegativeNumber(highWaterMark) === true);
 
   const stream = Object.create(ReadableStream.prototype);
   InitializeReadableStream(stream);
@@ -310,9 +308,7 @@ function CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, hi
 // Throws if and only if startAlgorithm throws.
 function CreateReadableByteStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark = 0,
                                   autoAllocateChunkSize = undefined) {
-  assert(typeof highWaterMark === 'number');
-  assert(!Number.isNaN(highWaterMark));
-  assert(highWaterMark >= 0);
+  assert(IsNonNegativeNumber(highWaterMark) === true);
   if (autoAllocateChunkSize !== undefined) {
     assert(Number.isInteger(autoAllocateChunkSize) === true);
     assert(autoAllocateChunkSize > 0);

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -299,7 +299,9 @@ function AcquireReadableStreamDefaultReader(stream) {
   return new ReadableStreamDefaultReader(stream);
 }
 
-function CreateReadableStream(pullAlgorithm, cancelAlgorithm, highWaterMark = 1, sizeAlgorithm = () => 1) {
+// Throws if and only if startAlgorithm throws.
+function CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark = 1,
+                              sizeAlgorithm = () => 1) {
   assert(typeof highWaterMark === 'number');
   assert(!Number.isNaN(highWaterMark));
   assert(highWaterMark !== Infinity);
@@ -308,15 +310,10 @@ function CreateReadableStream(pullAlgorithm, cancelAlgorithm, highWaterMark = 1,
   const stream = Object.create(ReadableStream.prototype);
   InitializeReadableStream(stream);
 
-  function startAlgorithm() { }
-
-  try {
-    SetUpReadableStreamDefaultController(
+  SetUpReadableStreamDefaultController(
       stream, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, sizeAlgorithm
-    );
-  } catch (e) {
-    assert(`Should not throw with an empty startAlgorithm: ${e}`);
-  }
+  );
+
   return stream;
 }
 
@@ -436,8 +433,10 @@ function ReadableStreamTee(stream, cloneForBranch2) {
     return cancelPromise;
   }
 
-  branch1 = CreateReadableStream(pullAlgorithm, cancel1Algorithm);
-  branch2 = CreateReadableStream(pullAlgorithm, cancel2Algorithm);
+  function startAlgorithm() {}
+
+  branch1 = CreateReadableStream(startAlgorithm, pullAlgorithm, cancel1Algorithm);
+  branch2 = CreateReadableStream(startAlgorithm, pullAlgorithm, cancel2Algorithm);
 
   reader._closedPromise.catch(r => {
     if (closedOrErrored === true) {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -21,6 +21,15 @@ class ReadableStream {
     const type = underlyingSource.type;
     const typeString = String(type);
     if (typeString === 'bytes') {
+      if (highWaterMark === undefined) {
+        highWaterMark = 0;
+      }
+      highWaterMark = ValidateAndNormalizeHighWaterMark(highWaterMark);
+
+      if (size !== undefined) {
+        throw new RangeError('The strategy for a byte stream cannot have a size function');
+      }
+
       // TODO(ricea): Share this initialisation.
       // Exposed to controllers.
       this._state = 'readable';
@@ -29,12 +38,6 @@ class ReadableStream {
       this._storedError = undefined;
 
       this._disturbed = false;
-      if (size !== undefined) {
-        throw new RangeError('The strategy for a byte stream cannot have a size function');
-      }
-      if (highWaterMark === undefined) {
-        highWaterMark = 0;
-      }
       // Initialize to undefined first because the constructor of the controller checks this
       // variable to validate the caller.
       this._readableStreamController = undefined;

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -271,6 +271,7 @@ class ReadableStream {
 }
 
 module.exports = {
+  CreateReadableStream,
   ReadableStream,
   IsReadableStreamDisturbed,
   ReadableStreamDefaultControllerClose,
@@ -296,7 +297,6 @@ function CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, hi
                               sizeAlgorithm = () => 1) {
   assert(typeof highWaterMark === 'number');
   assert(!Number.isNaN(highWaterMark));
-  assert(highWaterMark !== Infinity);
   assert(highWaterMark >= 0);
 
   const stream = Object.create(ReadableStream.prototype);

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,8 +1,8 @@
 'use strict';
 const assert = require('better-assert');
 const { ArrayBufferCopy, CreateIterResultObject, IsFiniteNonNegativeNumber, InvokeOrNoop, IsDetachedBuffer,
-        PromiseInvokeOrNoop, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark } = require('./helpers.js');
-const { createArrayFromList, typeIsObject } = require('./helpers.js');
+        PromiseInvokeOrNoop, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark,
+        MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStream, IsWritableStreamLocked,
@@ -38,15 +38,7 @@ class ReadableStream {
       }
       highWaterMark = ValidateAndNormalizeHighWaterMark(highWaterMark);
 
-      let sizeAlgorithm;
-      if (size === undefined) {
-        sizeAlgorithm = () => 1;
-      } else {
-        if (typeof size !== 'function') {
-          throw new TypeError('size property of a queuing strategy must be a function');
-        }
-        sizeAlgorithm = chunk => size(chunk);
-      }
+      const sizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(size);
 
       SetUpReadableStreamDefaultControllerFromUnderlyingSource(this, underlyingSource, highWaterMark, sizeAlgorithm);
     } else {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -33,7 +33,8 @@ class TransformStream {
       startPromise_resolve = resolve;
     });
 
-    const writableSizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(writableStrategy.size);
+    const writableSizeFunction = writableStrategy.size;
+    const writableSizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(writableSizeFunction);
     let writableHighWaterMark = writableStrategy.highWaterMark;
     if (writableHighWaterMark === undefined) {
       writableHighWaterMark = 1;

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -4,7 +4,7 @@ const assert = require('better-assert');
 // Calls to verbose() are purely for debugging the reference implementation and tests. They are not part of the standard
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:transform-stream:verbose');
-const { Call, InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject, ValidateAndNormalizeHighWaterMark,
+const { Call, InvokeOrNoop, PromiseInvokeOrNoop, typeIsObject, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
@@ -74,12 +74,8 @@ class TransformStream {
 function CreateTransformStream(startAlgorithm, transformAlgorithm, flushAlgorithm, writableHighWaterMark = 1,
                                writableSizeAlgorithm = () => 1, readableHighWaterMark = 0,
                                readableSizeAlgorithm = () => 1) {
-  assert(typeof writableHighWaterMark === 'number');
-  assert(!Number.isNaN(writableHighWaterMark));
-  assert(writableHighWaterMark >= 0);
-  assert(typeof readableHighWaterMark === 'number');
-  assert(!Number.isNaN(readableHighWaterMark));
-  assert(readableHighWaterMark >= 0);
+  assert(IsNonNegativeNumber(writableHighWaterMark));
+  assert(IsNonNegativeNumber(readableHighWaterMark));
 
   const stream = Object.create(TransformStream.prototype);
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -15,7 +15,7 @@ const { CreateWritableStream, WritableStreamDefaultControllerErrorIfNeeded } = r
 // Class TransformStream
 
 class TransformStream {
-  constructor(transformer = {}, writableStrategy = {}, { size, highWaterMark = 0 } = {}) {
+  constructor(transformer = {}, writableStrategy = {}, readableStrategy = {}) {
     const readableType = transformer.readableType;
 
     if (readableType !== undefined) {
@@ -28,11 +28,6 @@ class TransformStream {
       throw new RangeError('Invalid writable type specified');
     }
 
-    let startPromise_resolve;
-    const startPromise = new Promise(resolve => {
-      startPromise_resolve = resolve;
-    });
-
     const writableSizeFunction = writableStrategy.size;
     const writableSizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(writableSizeFunction);
     let writableHighWaterMark = writableStrategy.highWaterMark;
@@ -41,8 +36,18 @@ class TransformStream {
     }
     writableHighWaterMark = ValidateAndNormalizeHighWaterMark(writableHighWaterMark);
 
-    const readableSizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(size);
-    const readableHighWaterMark = ValidateAndNormalizeHighWaterMark(highWaterMark);
+    const readableSizeFunction = readableStrategy.size;
+    const readableSizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(readableSizeFunction);
+    let readableHighWaterMark = readableStrategy.highWaterMark;
+    if (readableHighWaterMark === undefined) {
+      readableHighWaterMark = 0;
+    }
+    readableHighWaterMark = ValidateAndNormalizeHighWaterMark(readableHighWaterMark);
+
+    let startPromise_resolve;
+    const startPromise = new Promise(resolve => {
+      startPromise_resolve = resolve;
+    });
 
     InitializeTransformStream(this, startPromise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark,
                               readableSizeAlgorithm);

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -311,7 +311,7 @@ function TransformStreamDefaultControllerTerminate(controller) {
   TransformStreamErrorWritableAndUnblockWrite(stream, error);
 }
 
-// Class TransformStreamDefaultSink
+// TransformStreamDefaultSink Algorithms
 
 function TransformStreamDefaultSinkWriteAlgorithm(stream, chunk) {
   verbose('TransformStreamDefaultSinkWriteAlgorithm()');
@@ -403,7 +403,7 @@ function TransformStreamDefaultSinkTransform(stream, transformer, chunk) {
   });
 }
 
-// Class TransformStreamDefaultSource
+// TransformStreamDefaultSource Algorithms
 
 function TransformStreamDefaultSourcePullAlgorithm(stream) {
   verbose('TransformStreamDefaultSourcePullAlgorithm()');

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -759,7 +759,9 @@ function SetUpWritableStreamDefaultController(stream, startAlgorithm, writeAlgor
   const backpressure = WritableStreamDefaultControllerGetBackpressure(controller);
   WritableStreamUpdateBackpressure(stream, backpressure);
 
-  startAlgorithm().then(
+  const startResult = startAlgorithm();
+  const startPromise = Promise.resolve(startResult);
+  startPromise.then(
       () => {
         assert(stream._state === 'writable' || stream._state === 'erroring');
         controller._started = true;
@@ -776,7 +778,7 @@ function SetUpWritableStreamDefaultController(stream, startAlgorithm, writeAlgor
 
 function SetUpWritableStreamDefaultControllerFromUnderlyingSink(stream, underlyingSink, highWaterMark, sizeAlgorithm) {
   function startAlgorithm() {
-    return Promise.resolve(InvokeOrNoop(underlyingSink, 'start', [stream._writableStreamController]));
+    return InvokeOrNoop(underlyingSink, 'start', [stream._writableStreamController]);
   }
 
   function writeAlgorithm(chunk) {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -5,8 +5,8 @@ const assert = require('better-assert');
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:writable-stream:verbose');
 
-const { InvokeOrNoop, PromiseInvokeOrNoop, ValidateAndNormalizeHighWaterMark, MakeSizeAlgorithmFromSizeFunction,
-        typeIsObject } = require('./helpers.js');
+const { InvokeOrNoop, PromiseInvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
+        MakeSizeAlgorithmFromSizeFunction, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
@@ -81,9 +81,7 @@ function AcquireWritableStreamDefaultWriter(stream) {
 // Throws if and only if startAlgorithm throws.
 function CreateWritableStream(startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm, highWaterMark,
                               sizeAlgorithm) {
-  assert(typeof highWaterMark === 'number');
-  assert(!Number.isNaN(highWaterMark));
-  assert(highWaterMark >= 0);
+  assert(IsNonNegativeNumber(highWaterMark) === true);
 
   const stream = Object.create(WritableStream.prototype);
   InitializeWritableStream(stream);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -79,8 +79,8 @@ function AcquireWritableStreamDefaultWriter(stream) {
 }
 
 // Throws if and only if startAlgorithm throws.
-function CreateWritableStream(startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm, highWaterMark,
-                              sizeAlgorithm) {
+function CreateWritableStream(startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm, highWaterMark = 1,
+                              sizeAlgorithm = () => 1) {
   assert(IsNonNegativeNumber(highWaterMark) === true);
 
   const stream = Object.create(WritableStream.prototype);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -83,7 +83,6 @@ function CreateWritableStream(startAlgorithm, writeAlgorithm, closeAlgorithm, ab
                               sizeAlgorithm) {
   assert(typeof highWaterMark === 'number');
   assert(!Number.isNaN(highWaterMark));
-  assert(highWaterMark !== Infinity);
   assert(highWaterMark >= 0);
 
   const stream = Object.create(WritableStream.prototype);
@@ -91,6 +90,7 @@ function CreateWritableStream(startAlgorithm, writeAlgorithm, closeAlgorithm, ab
 
   SetUpWritableStreamDefaultController(stream, startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm,
                                        highWaterMark, sizeAlgorithm);
+  return stream;
 }
 
 function InitializeWritableStream(stream) {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -722,6 +722,18 @@ class WritableStreamDefaultController {
 
 // Abstract operations implementing interface required by the WritableStream.
 
+function IsWritableStreamDefaultController(x) {
+  if (!typeIsObject(x)) {
+    return false;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(x, '_controlledWritableStream')) {
+    return false;
+  }
+
+  return true;
+}
+
 function SetUpWritableStreamDefaultController(stream, startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm,
                                               highWaterMark, sizeAlgorithm) {
   assert(IsWritableStream(stream) === true);
@@ -824,18 +836,6 @@ function WritableStreamDefaultControllerWrite(controller, chunk, chunkSize) {
 }
 
 // Abstract operations for the WritableStreamDefaultController.
-
-function IsWritableStreamDefaultController(x) {
-  if (!typeIsObject(x)) {
-    return false;
-  }
-
-  if (!Object.prototype.hasOwnProperty.call(x, '_controlledWritableStream')) {
-    return false;
-  }
-
-  return true;
-}
 
 function WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller) {
   verbose('WritableStreamDefaultControllerAdvanceQueueIfNeeded()');

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -5,8 +5,8 @@ const assert = require('better-assert');
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:writable-stream:verbose');
 
-const { InvokeOrNoop, PromiseInvokeOrNoop, ValidateAndNormalizeHighWaterMark, typeIsObject } =
-  require('./helpers.js');
+const { InvokeOrNoop, PromiseInvokeOrNoop, ValidateAndNormalizeHighWaterMark, MakeSizeAlgorithmFromSizeFunction,
+        typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
@@ -23,16 +23,7 @@ class WritableStream {
       throw new RangeError('Invalid type is specified');
     }
 
-    let sizeAlgorithm;
-    if (size === undefined) {
-      sizeAlgorithm = () => 1;
-    } else {
-      if (typeof size !== 'function') {
-        throw new TypeError('size property of a queuing strategy must be a function');
-      }
-      sizeAlgorithm = chunk => size(chunk);
-    }
-
+    const sizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(size);
     highWaterMark = ValidateAndNormalizeHighWaterMark(highWaterMark);
 
     SetUpWritableStreamDefaultControllerFromUnderlyingSink(this, underlyingSink, highWaterMark, sizeAlgorithm);


### PR DESCRIPTION
This is a start at addressing #813. Task list:

- [x] Add CreateReadableStream(pullAlgorithm, cancelAlgorithm, sizeAlgorithm, highWaterMark)
- [x] Update TeeReadableStream to use it
- [ ] Consider making pullAlgorithm and cancelAlgorithm optional so as to better match [fetch](https://fetch.spec.whatwg.org/#concept-construct-readablestream)
- [x] Update writable streams analogously
- [x] Update transform streams to use the two above
- [x] Update readable byte streams analogously
- [x] Update web platform tests for the change in the .length of the controller constructors

One thing that slightly regressed is that a lot of the controller-specific logic has moved back into the ReadableStream constructor. The thinking I currently have is that the ReadableStream constructor is responsible for turning incoming JS objects into their most abstract forms: algorithms + numbers, all validated and normalized. Unfortunately this validation/normalization branches depending on whether it's a byte stream or not. This may be fixable by just creating extra abstract ops and shuffling them off into the right section, I guess, but for now I've just created a bigger ReadableStream constructor.

I'd appreciate help on the above task list while I'm asleep, if people have free time :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whatwg/streams/pull/857.html" title="Last updated on Nov 29, 2017, 11:37 PM GMT">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/whatwg/streams/65752c9...5e5252b.html" title="Last updated on Nov 29, 2017, 11:37 PM GMT">Diff</a>