### PR TITLE
Don't error canceled branches when erroring a teed stream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -901,8 +901,8 @@ noticable asymmetry between the two branches, and limits the possible <a>chunks<
   1. Set _pull_.[[branch2]] to _branch2Stream_.[[readableStreamController]].
   1. <a>Upon rejection</a> of _reader_.[[closedPromise]] with reason _r_,
     1. If _teeState_.[[closedOrErrored]] is *false*, then:
-      1. Perform ! ReadableStreamDefaultControllerError(_pull_.[[branch1]], _r_).
-      1. Perform ! ReadableStreamDefaultControllerError(_pull_.[[branch2]], _r_).
+      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_pull_.[[branch1]], _r_).
+      1. Perform ! ReadableStreamDefaultControllerErrorIfNeeded(_pull_.[[branch2]], _r_).
       1. Set _teeState_.[[closedOrErrored]] to *true*.
   1. Return « _branch1Stream_, _branch2Stream_ ».
 </emu-alg>

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -368,8 +368,8 @@ function ReadableStreamTee(stream, cloneForBranch2) {
       return;
     }
 
-    ReadableStreamDefaultControllerError(pull._branch1, r);
-    ReadableStreamDefaultControllerError(pull._branch2, r);
+    ReadableStreamDefaultControllerErrorIfNeeded(pull._branch1, r);
+    ReadableStreamDefaultControllerErrorIfNeeded(pull._branch2, r);
     teeState.closedOrErrored = true;
   });
 


### PR DESCRIPTION
The handler currently uses ReadableStreamDefaultControllerError, which runs ReadableStreamError on a closed stream, changing the state from "closed" to "errored" in the process.

Simply using ReadableStreamDefaultControllerErrorIfNeeded instead should be all that's needed.

Makes w3c/web-platform-tests#8299 pass.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tschneidereit/streams/teed-streams-error-cancel-interaction.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/streams/ce56450...tschneidereit:4dba88e.html)