### PR TITLE
Lookup methods in constructors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1913,8 +1913,8 @@ throws>SetUpReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var
      property).
   1. Let _startAlgorithm_ be the following steps:
     1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _controller_ »).
-  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"pull"`, 0, « _controller_ »).
-  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"cancel"`, 1, « » ).
+  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"pull"`, *0*, « _controller_ »).
+  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"cancel"`, *1*, « » ).
   1. Perform ? SetUpReadableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
      _cancelAlgorithm_, _highWaterMark_, _sizeAlgorithm_)
 </emu-alg>
@@ -2687,8 +2687,9 @@ throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>
      property).
   1. Let _startAlgorithm_ be the following steps:
     1. Return ? InvokeOrNoop(_underlyingByteSource_, `"start"`, « _controller_ »).
-  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"pull"`, 0, « _controller_ »).
-  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"cancel"`, 1, « »).
+  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"pull"`, *0*, « _controller_
+     »).
+  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"cancel"`, *1*, « »).
   1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
   1. If _autoAllocateChunkSize_ is not *undefined*,
     1. If ! IsInteger(_autoAllocateChunkSize_) is *false*, or if _autoAllocateChunkSize_ ≤ *0*, throw a *RangeError*
@@ -2997,8 +2998,10 @@ throws.</p>
   1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
   1. Let _stream_ be ObjectCreate(the original value of `<a idl>WritableStream</a>`'s `prototype` property).
   1. Perform ! InitializeWritableStream(_stream_).
-  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
-     _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
+  1. Let _stream_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
+     property).
+  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _writeAlgorithm_,
+     _closeAlgorithm_, _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
   1. Return _stream_.
 </emu-alg>
 
@@ -3746,14 +3749,12 @@ nothrow>IsWritableStreamDefaultController ( <var>x</var> )</h4>
 </emu-alg>
 
 <h4 id="set-up-writable-stream-default-controller" aoid="SetUpWritableStreamDefaultController"
-throws>SetUpWritableStreamDefaultController ( <var>stream</var>, <var>startAlgorithm</var>, <var>writeAlgorithm</var>,
-<var>closeAlgorithm</var>, <var>abortAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
+throws>SetUpWritableStreamDefaultController ( <var>stream</var>, <var>controller</var>, <var>startAlgorithm</var>,
+<var>writeAlgorithm</var>, <var>closeAlgorithm</var>, <var>abortAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
   1. Assert: ! IsWritableStream(_stream_) is *true*.
   1. Assert: _stream_.[[writableStreamController]] is *undefined*.
-  1. Let _controller_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
-     property).
   1. Set _controller_.[[controlledWritableStream]] to _stream_.
   1. Set _stream_.[[writableStreamController]] to _controller_.
   1. Perform ! ResetQueue(_controller_).
@@ -3783,16 +3784,15 @@ throws>SetUpWritableStreamDefaultControllerFromUnderlyingSink ( <var>stream</var
 <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
+     property).
   1. Let _startAlgorithm_ be the following steps:
-    1. Return ? InvokeOrNoop(_underlyingSink_, `"start"`, « _stream_.[[writableStreamController]] »).
-  1. Let _writeAlgorithm_ be the following steps, taking a _chunk_ argument:
-    1. Return ! PromiseInvokeOrNoop(_underlyingSink_, `"write"`, « _chunk_, _stream_.[[writableStreamController]] »).
-  1. Let _closeAlgorithm_ be the following steps:
-    1. Return ! PromiseInvokeOrNoop(_underlyingSink_, `"close"`, « »).
-  1. Let _abortAlgorithm_ be the following steps, taking a _reason_ argument:
-    1. Return ! PromiseInvokeOrNoop(_underlyingSink_, `"abort"`, « _reason_ »).
-  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
-     _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
+    1. Return ? InvokeOrNoop(_underlyingSink_, `"start"`, « _controller_ »).
+  1. Let _writeAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"write"`, *1*, « _controller_ »).
+  1. Let _closeAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"close"`, *0*, « »).
+  1. Let _abortAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"abort"`, *1*, « »).
+  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _writeAlgorithm_,
+     _closeAlgorithm_, _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-close" aoid="WritableStreamDefaultControllerClose"
@@ -4397,7 +4397,7 @@ nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>
          argument _e_, performs the following steps:
         1. Perform ! TransformStreamError(_stream_, _e_).
         1. Throw _e_.
-  1. Let _flushAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_transformer_, 'flush', 0, « controller »).
+  1. Let _flushAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_transformer_, `"flush"`, *0*, « controller »).
   1. Perform ! SetUpTransformStreamDefaultController(_stream_, _controller_, _transformAlgorithm_, _flushAlgorithm_).
 </emu-alg>
 

--- a/index.bs
+++ b/index.bs
@@ -849,8 +849,10 @@ throws.</p>
   1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
   1. Let _stream_ be ObjectCreate(the original value of `<a idl>ReadableStream</a>`'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
-  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
-     _highWaterMark_, _sizeAlgorithm_).
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableStreamDefaultController</a>`'s `prototype`
+     property).
+  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
+     _cancelAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
   1. Return _stream_.
 </emu-alg>
 
@@ -875,8 +877,10 @@ throws.</p>
     1. Assert: _autoAllocateChunkSize_ is positive.
   1. Let _stream_ be ObjectCreate(the original value of `<a idl>ReadableStream</a>`'s `prototype` property).
   1. Perform ! InitializeReadableStream(_stream_).
-  1. Perform ? SetUpReadableByteStreamController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
-     _highWaterMark_, _autoAllocateChunkSize_).
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableByteStreamController</a>`'s `prototype`
+     property).
+  1. Perform ? SetUpReadableByteStreamController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
+     _cancelAlgorithm_, _highWaterMark_, _autoAllocateChunkSize_).
   1. Return _stream_.
 </emu-alg>
 
@@ -1875,13 +1879,11 @@ nothrow>ReadableStreamDefaultControllerCanCloseOrEnqueue ( <var>controller</var>
 </div>
 
 <h4 id="set-up-readable-stream-default-controller" aoid="SetUpReadableStreamDefaultController"
-throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>startAlgorithm</var>, <var>pullAlgorithm</var>,
-<var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
+throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>controller</var>, <var>startAlgorithm</var>,
+<var>pullAlgorithm</var>, <var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
   1. Assert: _stream_.[[readableStreamController]] is *undefined*.
-  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableStreamDefaultController</a>`'s `prototype`
-     property).
   1. Set _controller_.[[controlledReadableStream]] to _stream_.
   1. Set _controller_.[[queue]] and _controller_.[[queueSize]] to *undefined*, then perform ! ResetQueue(_controller_).
   1. Set _controller_.[[started]], _controller_.[[closeRequested]], _controller_.[[pullAgain]], and
@@ -1907,14 +1909,14 @@ throws>SetUpReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var
 <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableStreamDefaultController</a>`'s `prototype`
+     property).
   1. Let _startAlgorithm_ be the following steps:
-    1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _stream_.[[readableStreamController]] »).
-  1. Let _pullAlgorithm_ be the following steps:
-    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
-  1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
-    1. Return ! PromiseInvokeOrNoop(_underlyingSource_, `"cancel"`, « _reason_ »).
-  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
-     _highWaterMark_, _sizeAlgorithm_)
+    1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _controller_ »).
+  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"pull"`, 0, « _controller_ »).
+  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"cancel"`, 1, « » ).
+  1. Perform ? SetUpReadableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
+     _cancelAlgorithm_, _highWaterMark_, _sizeAlgorithm_)
 </emu-alg>
 
 <h3 id="rbs-controller-class" interface lt="ReadableByteStreamController">Class
@@ -2645,16 +2647,14 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
 </emu-alg>
 
 <h4 id="set-up-readable-byte-stream-controller" aoid="SetUpReadableByteStreamController"
-throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>startAlgorithm</var>, <var>pullAlgorithm</var>,
-<var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>autoAllocateChunkSize</var> )</h4>
+throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>controller</var>, <var>startAlgorithm</var>,
+<var>pullAlgorithm</var>, <var>cancelAlgorithm</var>, <var>highWaterMark</var>, <var>autoAllocateChunkSize</var> )</h4>
 
 <emu-alg>
   1. Assert: _stream_.[[readableStreamController]] is *undefined*.
   1. If _autoAllocateChunkSize_ is not *undefined*,
     1. Assert: ! IsInteger(_autoAllocateChunkSize_) is *true*.
     1. Assert: _autoAllocateChunkSize_ is positive.
-  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableByteStreamController</a>`'s `prototype`
-     property).
   1. Set _controller_.[[controlledReadableByteStream]] to _stream_.
   1. Set _controller_.[[pullAgain]] and _controller_.[[pulling]] to *false*.
   1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(_controller_).
@@ -2683,18 +2683,18 @@ throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>
 <var>highWaterMark</var> )</h4>
 
 <emu-alg>
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableByteStreamController</a>`'s `prototype`
+     property).
   1. Let _startAlgorithm_ be the following steps:
-    1. Return ? InvokeOrNoop(_underlyingByteSource_, `"start"`, « _stream_.[[readableStreamController]] »).
-  1. Let _pullAlgorithm_ be the following steps:
-    1. Return ! PromiseInvokeOrNoop(_underlyingByteSource_, `"pull"`, « _stream_.[[readableStreamController]] »).
-  1. Let _cancelAlgorithm_ be the following steps, taking a _reason_ argument:
-    1. Return ! PromiseInvokeOrNoop(_underlyingByteSource_, `"cancel"`, « _reason_ »).
+    1. Return ? InvokeOrNoop(_underlyingByteSource_, `"start"`, « _controller_ »).
+  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"pull"`, 0, « _controller_ »).
+  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"cancel"`, 1, « »).
   1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
   1. If _autoAllocateChunkSize_ is not *undefined*,
     1. If ! IsInteger(_autoAllocateChunkSize_) is *false*, or if _autoAllocateChunkSize_ ≤ *0*, throw a *RangeError*
        exception.
-  1. Perform ! SetUpReadableByteStreamController(_stream_, _startAlgorithm_, _pullAlgorithm_, _cancelAlgorithm_,
-     _highWaterMark_, _autoAllocateChunkSize_).
+  1. Perform ! SetUpReadableByteStreamController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
+     _cancelAlgorithm_, _highWaterMark_, _autoAllocateChunkSize_).
 </emu-alg>
 
 <h2 id="ws">Writable Streams</h2>

--- a/index.bs
+++ b/index.bs
@@ -4756,16 +4756,6 @@ throws>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>m
   1. Return an algorithm which returns <a>a promise resolved with</a> *undefined*.
 </emu-alg>
 
-<h4 id="get-method" aoid="GetMethod" throws>GetMethod ( <var>V</var>, <var>methodName</var> )</h4>
-
-<emu-alg>
-  1. Assert: _V_ is not *undefined*.
-  1. Assert: ! IsPropertyKey(_methodName_) is *true*.
-  1. Let _method_ be ? GetV(_O_, _P_).
-  1. If _method_ is not *undefined* and ! IsCallable(_method_) is *false*, throw a *TypeError* exception.
-  1. Return _method_.
-</emu-alg>
-
 <h4 id="invoke-or-noop" aoid="InvokeOrNoop" throws>InvokeOrNoop ( <var>O</var>, <var>P</var>, <var>args</var> )</h4>
 
 <div class="note">

--- a/index.bs
+++ b/index.bs
@@ -4389,8 +4389,9 @@ throws>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>,
     1. Let _result_ be TransformStreamDefaultControllerEnqueue(_controller_, _chunk_).
     1. If _result_ is an abrupt completion, return <a>a promise rejected with</a> _result_.[[Value]].
     1. Otherwise, return <a>a promise resolved with</a> *undefined*.
-  1. Let _transformMethod_ be ? GetMethod(_transformer_, `"transform"`).
+  1. Let _transformMethod_ be ? GetV(_transformer_, `"transform"`).
   1. If _transformMethod_ is not *undefined*,
+    1. If ! IsCallable(_transformMethod_) is *false*, throw a *TypeError* exception.
     1. Set _transformAlgorithm_ to the following steps, taking a _chunk_ argument:
       1. Let _transformPromise_ be ! PromiseCall(_transformMethod_, _transformer_, « chunk, _controller_ »).
       1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
@@ -4746,8 +4747,9 @@ throws>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>m
   1. Assert: ! IsPropertyKey(_methodName_) is *true*.
   1. Assert: _algoArgCount_ is *0* or *1*.
   1. Assert: _extraArgs_ is a List.
-  1. Let _method_ be ? GetMethod(_underlyingObject_, _methodName_).
+  1. Let _method_ be ? GetV(_underlyingObject_, _methodName_).
   1. If _method_ is not *undefined*,
+    1. If ! IsCallable(_method_) is *false*, throw a *TypeError* exception.
     1. If _algoArgCount_ is *0*, return an algorithm that performs the following steps:
       1. Return ! PromiseCall(_method_, _underlyingObject_, _extraArgs_).
     1. Otherwise, return an algorithm that performs the following steps, taking an _arg_ argument:

--- a/index.bs
+++ b/index.bs
@@ -3000,7 +3000,7 @@ throws.</p>
   1. Assert: ! IsNonNegativeNumber(_highWaterMark_) is *true*.
   1. Let _stream_ be ObjectCreate(the original value of `<a idl>WritableStream</a>`'s `prototype` property).
   1. Perform ! InitializeWritableStream(_stream_).
-  1. Let _stream_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
      property).
   1. Perform ! SetUpWritableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _writeAlgorithm_,
      _closeAlgorithm_, _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
@@ -4150,7 +4150,7 @@ throws.</p>
   1. Let _startPromise_ be <a>a new promise</a>.
   1. Perform ! InitializeTransformStream(_stream_, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
-  1. Let _stream_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
      property).
   1. Perform ! SetUpTransformStreamDefaultController(_stream_, _controller_, _transformAlgorithm_, _flushAlgorithm_).
   1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)

--- a/index.bs
+++ b/index.bs
@@ -4755,6 +4755,40 @@ chunks, or when trillions of chunks are enqueued.)</p>
 
 A few abstract operations are used in this specification for utility purposes. We define them here.
 
+<h4 id="create-algorithm-from-underlying-method" aoid="CreateAlgorithmFromUnderlyingMethod"
+nothrow>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>methodName</var>,
+<var>algoArgCount</var>, <var>extraArgs</var> )</h4>
+
+<emu-alg>
+  1. Assert: _underlyingObject_ is not *undefined*.
+  1. Assert: ! IsPropertyKey(_methodName_) is *true*.
+  1. Assert: _algoArgCount_ is *0* or *1*.
+  1. Assert: _extraArgs_ is a List.
+  1. Let _method_ be ! GetMethod(_underlyingObject_, _methodName_).
+  1. If _method_ is not *undefined*,
+    1. If _algoArgCount_ is *0*, return an algorithm that performs the following steps:
+      1. Return ! PromiseCall(_method_, _underlyingObject_, _extraArgs_).
+    1. Otherwise, return an algorithm that performs the following steps, taking an *arg* argument:
+      1. Let _fullArgs_ be a List consisting of _arg_ followed by the elements of _extraArgs_ in order.
+      1. Return ! PromiseCall(_method_, _underlyingObject_, _fullArgs_).
+  1. Return an algorithm which returns <a>a promise resolved with</a> *undefined*.
+</emu-alg>
+
+<h4 id="get-method" aoid="GetMethod" throws>GetMethod ( <var>V</var>, <var>methodName</var> )</h4>
+
+<div class="note">
+  GetMethod is a small wrapper around the [[!ECMASCRIPT]] <a abstract-op>GetV</a> abstract operation that throws
+  an exception if the value is not undefined and not a function.
+</div>
+
+<emu-alg>
+  1. Assert: _V_ is not *undefined*.
+  1. Assert: ! IsPropertyKey(_methodName_) is *true*.
+  1. Let _method_ be ? GetV(_O_, _P_).
+  1. If _method_ is not *undefined* and ! IsCallable(_method_) is *false*, throw a *TypeError* exception.
+  1. Return _method_.
+</emu-alg>
+
 <h4 id="invoke-or-noop" aoid="InvokeOrNoop" throws>InvokeOrNoop ( <var>O</var>, <var>P</var>, <var>args</var> )</h4>
 
 <div class="note">
@@ -4789,19 +4823,17 @@ A few abstract operations are used in this specification for utility purposes. W
   1. Return *true*.
 </emu-alg>
 
-<h4 id="promise-invoke-or-noop" aoid="PromiseInvokeOrNoop" nothrow>PromiseInvokeOrNoop ( <var>O</var>, <var>P</var>,
-<var>args</var> )</h4>
+<h4 id="promise-call" aoid="PromiseCall" nothrow>PromiseCall ( <var>F</var>, <var>V</var>, <var>args</var> )</h4>
 
 <div class="note">
-  PromiseInvokeOrNoop is a specialized version of <a>promise-calling</a> that both works on methods and returns a
-  promise for <emu-val>undefined</emu-val> when the method is not present.
+  PromiseCall is a variant of <a>promise-calling</a> that works on methods.
 </div>
 
 <emu-alg>
-  1. Assert: _O_ is not *undefined*.
-  1. Assert: ! IsPropertyKey(_P_) is *true*.
+  1. Assert: ! IsCallable(_F_) is *true*.
+  1. Assert: _V_ is not *undefined*.
   1. Assert: _args_ is a List.
-  1. Let _returnValue_ be InvokeOrNoop(_O_, _P_, _args_).
+  1. Let _returnValue_ be Call(_F_, _V_, _args_).
   1. If _returnValue_ is an abrupt completion, return <a>a promise rejected with</a> _returnValue_.[[Value]].
   1. Otherwise, return <a>a promise resolved with</a> _returnValue_.[[Value]].
 </emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -4147,7 +4147,9 @@ throws.</p>
   1. Let _startPromise_ be <a>a new promise</a>.
   1. Perform ! InitializeTransformStream(_stream_, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
-  1. Perform ! SetUpTransformStreamDefaultController(_stream_, _transformAlgorithm_, _flushAlgorithm_).
+  1. Let _stream_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
+     property).
+  1. Perform ! SetUpTransformStreamDefaultController(_stream_, _controller_, _transformAlgorithm_, _flushAlgorithm_).
   1. Let _startResult_ be the result of performing _startAlgorithm_. (This may throw an exception.)
   1. <a>Resolve</a> _startPromise_ with _startResult_.
   1. Return _stream_.
@@ -4360,14 +4362,12 @@ nothrow>IsTransformStreamDefaultController ( <var>x</var> )</h4>
 </emu-alg>
 
 <h4 id="set-up-transform-stream-default-controller" aoid="SetUpTransformStreamDefaultController"
-nothrow>SetUpTransformStreamDefaultController ( <var>stream</var>, <var>transformAlgorithm</var>,
+nothrow>SetUpTransformStreamDefaultController ( <var>stream</var>, <var>controller</var>, <var>transformAlgorithm</var>,
 <var>flushAlgorithm</var> )</h4>
 
 <emu-alg>
   1. Assert: ! IsTransformStream(_stream_) is *true*.
   1. Assert: _stream_.[[writableStreamController]] is *undefined*.
-  1. Let _controller_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
-     property).
   1. Set _controller_.[[controlledTransformStream]] to _stream_.
   1. Set _stream_.[[transformStreamController]] to _controller_.
   1. Set _controller_.[[transformAlgorithm]] to _transformAlgorithm_.
@@ -4379,25 +4379,26 @@ aoid="SetUpTransformStreamDefaultControllerFromTransformer"
 nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>, <var>transformer</var> )</h4>
 
 <emu-alg>
-  1. Let _transformAlgorithm_ be the following steps, taking a _chunk_ argument:
-    1. Return ! TransformStreamDefaultControllerPromiseCallTransform(_stream_, _transformer_, _chunk_).
-  1. Let _flushAlgorithm_ be the following steps:
-    1. Return ! PromiseInvokeOrNoop(_transformer_, `"flush"`, « _stream_.[[transformStreamController]] »).
-  1. Perform ! SetUpTransformStreamDefaultController(_stream_, _transformAlgorithm_, _flushAlgorithm_).
-</emu-alg>
-
-<h4 id="transform-stream-default-controller-call-transform-or-fallback"
-aoid="TransformStreamDefaultControllerCallTransformOrFallback"
-throws>TransformStreamDefaultControllerCallTransformOrFallback ( <var>stream</var>, <var>transformer</var>,
-<var>chunk</var> )</h4>
-
-<emu-alg>
-  1. Let _controller_ be _stream_.[[transformStreamController]].
-  1. Let _method_ be ? GetV(_transformer_, `"transform"`).
-  1. If _method_ is *undefined*,
-    1. Perform ? TransformStreamDefaultControllerEnqueue(_controller_, _chunk_).
-    1. Return *undefined*.
-  1. Return ? Call(_method_, _transformer_, « _chunk_, _controller_ »).
+  1. Let _controller_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
+     property).
+  1. Let _transformAlgorithm_ be the following steps, taking a_chunk_ argument:
+    1. Let _result_ be TransformStreamDefaultControllerEnqueue(_controller_, _chunk_).
+    1. If _result_ is an abrupt completion, return <a>a promise rejected with</a> _result_.[[Value]].
+    1. Otherwise, return <a>a promise resolved with</a> *undefined*.
+  1. Let _transformMethod_ be ? GetMethod(_transformer_, `"transform"`).
+  1. If _transformMethod_ is not *undefined*,
+    1. Set _transformAlgorithm_ to the following steps, taking a_chunk_ argument:
+      1. Let _transformResult_ be Call(_transformMethod_, _transformer_, « chunk, _controller_ »).
+      1. If _transformResult_ is an abrupt completion,
+        1. Perform ! TransformStreamError(_stream_, _transformResult_.[[Value]]).
+        1. Return <a>a promise rejected with</a> _transformResult_.[[Value]].
+      1. Let _transformPromise_ be <a>a promise resolved with</a> _transformResult_.
+      1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
+         argument _e_, performs the following steps:
+        1. Perform ! TransformStreamError(_stream_, _e_).
+        1. Throw _e_.
+  1. Let _flushAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_transformer_, 'flush', 0, « controller »).
+  1. Perform ! SetUpTransformStreamDefaultController(_stream_, _controller_, _transformAlgorithm_, _flushAlgorithm_).
 </emu-alg>
 
 <h4 id="transform-stream-default-controller-enqueue" aoid="TransformStreamDefaultControllerEnqueue"
@@ -4447,25 +4448,6 @@ this to streams they did not create.
      ReadableStreamDefaultControllerClose(_readableController_).
   1. Let _error_ be a *TypeError* exception indicating that the stream has been terminated.
   1. Perform ! TransformStreamErrorWritableAndUnblockWrite(_stream_, _error_).
-</emu-alg>
-
-<h4 id="transform-stream-default-controller-promise-call-transform"
-aoid="TransformStreamDefaultControllerPromiseCallTransform"
-nothrow>TransformStreamDefaultControllerPromiseCallTransform ( <var>stream</var>, <var>transformer</var>,
-<var>chunk</var> )</h4>
-
-<emu-alg>
-  1. Assert: _stream_.[[readable]].[[state]] is not `"errored"`.
-  1. Assert: _stream_.[[backpressure]] is *false*.
-  1. Let _transformPromise_ be *undefined*.
-  1. Let _transformResult_ be TransformStreamDefaultControllerCallTransformOrFallback(_stream_, _transformer_, _chunk_).
-  1. If _transformResult_ is an abrupt completion, set _transformPromise_ to <a>a promise rejected with</a>
-     _transformResult_.[[Value]].
-  1. Otherwise, set _transformPromise_ to <a>a promise resolved with</a> _transformResult_.[[Value]].
-  1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
-     argument _e_, performs the following steps:
-    1. Perform ! TransformStreamError(_stream_, _e_).
-    1. Throw _e_.
 </emu-alg>
 
 <h3 id="ts-default-sink-abstract-ops">Transform Stream Default Sink Abstract Operations</h3>
@@ -4764,7 +4746,7 @@ nothrow>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>
   1. Assert: ! IsPropertyKey(_methodName_) is *true*.
   1. Assert: _algoArgCount_ is *0* or *1*.
   1. Assert: _extraArgs_ is a List.
-  1. Let _method_ be ! GetMethod(_underlyingObject_, _methodName_).
+  1. Let _method_ be ? GetMethod(_underlyingObject_, _methodName_).
   1. If _method_ is not *undefined*,
     1. If _algoArgCount_ is *0*, return an algorithm that performs the following steps:
       1. Return ! PromiseCall(_method_, _underlyingObject_, _extraArgs_).

--- a/index.bs
+++ b/index.bs
@@ -1914,8 +1914,8 @@ throws>SetUpReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var
      property).
   1. Let _startAlgorithm_ be the following steps:
     1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _controller_ »).
-  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"pull"`, *0*, « _controller_ »).
-  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"cancel"`, *1*, « » ).
+  1. Let _pullAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"pull"`, *0*, « _controller_ »).
+  1. Let _cancelAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"cancel"`, *1*, « » ).
   1. Perform ? SetUpReadableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
      _cancelAlgorithm_, _highWaterMark_, _sizeAlgorithm_)
 </emu-alg>
@@ -2689,14 +2689,14 @@ throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>
      property).
   1. Let _startAlgorithm_ be the following steps:
     1. Return ? InvokeOrNoop(_underlyingByteSource_, `"start"`, « _controller_ »).
-  1. Let _pullAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"pull"`, *0*, « _controller_
+  1. Let _pullAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"pull"`, *0*, « _controller_
      »).
-  1. Let _cancelAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"cancel"`, *1*, « »).
+  1. Let _cancelAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"cancel"`, *1*, « »).
   1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
   1. If _autoAllocateChunkSize_ is not *undefined*,
     1. If ! IsInteger(_autoAllocateChunkSize_) is *false*, or if _autoAllocateChunkSize_ ≤ *0*, throw a *RangeError*
        exception.
-  1. Perform ! SetUpReadableByteStreamController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
+  1. Perform ? SetUpReadableByteStreamController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
      _cancelAlgorithm_, _highWaterMark_, _autoAllocateChunkSize_).
 </emu-alg>
 
@@ -2922,7 +2922,7 @@ WritableStream(<var>underlyingSink</var> = {}, { <var>size</var>, <var>highWater
      potential types in the future, without backward-compatibility concerns.</p>
   1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
   1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
-  1. Perform ! SetUpWritableStreamDefaultControllerFromUnderlyingSink(*this*, _underlyingSink_, _highWaterMark_,
+  1. Perform ? SetUpWritableStreamDefaultControllerFromUnderlyingSink(*this*, _underlyingSink_, _highWaterMark_,
      _sizeAlgorithm_).
 </emu-alg>
 
@@ -3002,7 +3002,7 @@ throws.</p>
   1. Perform ! InitializeWritableStream(_stream_).
   1. Let _controller_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
      property).
-  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _writeAlgorithm_,
+  1. Perform ? SetUpWritableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _writeAlgorithm_,
      _closeAlgorithm_, _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
   1. Return _stream_.
 </emu-alg>
@@ -3791,10 +3791,10 @@ throws>SetUpWritableStreamDefaultControllerFromUnderlyingSink ( <var>stream</var
      property).
   1. Let _startAlgorithm_ be the following steps:
     1. Return ? InvokeOrNoop(_underlyingSink_, `"start"`, « _controller_ »).
-  1. Let _writeAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"write"`, *1*, « _controller_ »).
-  1. Let _closeAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"close"`, *0*, « »).
-  1. Let _abortAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"abort"`, *1*, « »).
-  1. Perform ! SetUpWritableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _writeAlgorithm_,
+  1. Let _writeAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"write"`, *1*, « _controller_ »).
+  1. Let _closeAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"close"`, *0*, « »).
+  1. Let _abortAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSink_, `"abort"`, *1*, « »).
+  1. Perform ? SetUpWritableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _writeAlgorithm_,
      _closeAlgorithm_, _abortAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
 </emu-alg>
 
@@ -4094,7 +4094,7 @@ readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var>writabl
   1. Let _startPromise_ be <a>a new promise</a>.
   1. Perform ! InitializeTransformStream(*this*, _startPromise_, _writableHighWaterMark_, _writableSizeAlgorithm_,
      _readableHighWaterMark_, _readableSizeAlgorithm_).
-  1. Perform ! SetUpTransformStreamDefaultControllerFromTransformer(*this*, _transformer_).
+  1. Perform ? SetUpTransformStreamDefaultControllerFromTransformer(*this*, _transformer_).
   1. Let _startResult_ be ? InvokeOrNoop(_transformer_, `"start"`, « *this*.[[transformStreamController]] »).
   1. <a>Resolve</a> _startPromise_ with _startResult_.
 </emu-alg>
@@ -4379,7 +4379,7 @@ nothrow>SetUpTransformStreamDefaultController ( <var>stream</var>, <var>controll
 
 <h4 id="set-up-transform-stream-default-controller-from-transformer"
 aoid="SetUpTransformStreamDefaultControllerFromTransformer"
-nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>, <var>transformer</var> )</h4>
+throws>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>, <var>transformer</var> )</h4>
 
 <emu-alg>
   1. Assert: _transformer_ is not *undefined*.
@@ -4397,7 +4397,7 @@ nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>
          argument _e_, performs the following steps:
         1. Perform ! TransformStreamError(_stream_, _e_).
         1. Throw _e_.
-  1. Let _flushAlgorithm_ be ! CreateAlgorithmFromUnderlyingMethod(_transformer_, `"flush"`, *0*, « controller »).
+  1. Let _flushAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_transformer_, `"flush"`, *0*, « controller »).
   1. Perform ! SetUpTransformStreamDefaultController(_stream_, _controller_, _transformAlgorithm_, _flushAlgorithm_).
 </emu-alg>
 
@@ -4738,7 +4738,7 @@ chunks, or when trillions of chunks are enqueued.)</p>
 A few abstract operations are used in this specification for utility purposes. We define them here.
 
 <h4 id="create-algorithm-from-underlying-method" aoid="CreateAlgorithmFromUnderlyingMethod"
-nothrow>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>methodName</var>,
+throws>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>methodName</var>,
 <var>algoArgCount</var>, <var>extraArgs</var> )</h4>
 
 <emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -1909,6 +1909,7 @@ throws>SetUpReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var
 <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
+  1. Assert: _underlyingSource_ is not *undefined*.
   1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableStreamDefaultController</a>`'s `prototype`
      property).
   1. Let _startAlgorithm_ be the following steps:
@@ -2679,10 +2680,11 @@ throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>controller</v
 
 <h4 id="set-up-readable-byte-stream-controller-from-underlying-source"
 aoid="SetUpReadableByteStreamControllerFromUnderlyingSource"
-throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>, <var>underylingByteSource</var>,
+throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>, <var>underlyingByteSource</var>,
 <var>highWaterMark</var> )</h4>
 
 <emu-alg>
+  1. Assert: _underlyingByteSource_ is not *undefined*.
   1. Let _controller_ be ObjectCreate(the original value of `<a idl>ReadableByteStreamController</a>`'s `prototype`
      property).
   1. Let _startAlgorithm_ be the following steps:
@@ -3784,6 +3786,7 @@ throws>SetUpWritableStreamDefaultControllerFromUnderlyingSink ( <var>stream</var
 <var>highWaterMark</var>, <var>sizeAlgorithm</var> )</h4>
 
 <emu-alg>
+  1. Assert: _underlyingSink_ is not *undefined*.
   1. Let _controller_ be ObjectCreate(the original value of `<a idl>WritableStreamDefaultController</a>`'s `prototype`
      property).
   1. Let _startAlgorithm_ be the following steps:
@@ -4379,6 +4382,7 @@ aoid="SetUpTransformStreamDefaultControllerFromTransformer"
 nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>, <var>transformer</var> )</h4>
 
 <emu-alg>
+  1. Assert: _transformer_ is not *undefined*.
   1. Let _controller_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
      property).
   1. Let _transformAlgorithm_ be the following steps, taking a_chunk_ argument:

--- a/index.bs
+++ b/index.bs
@@ -1915,9 +1915,9 @@ throws>SetUpReadableStreamDefaultControllerFromUnderlyingSource(<var>stream</var
   1. Let _startAlgorithm_ be the following steps:
     1. Return ? InvokeOrNoop(_underlyingSource_, `"start"`, « _controller_ »).
   1. Let _pullAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"pull"`, *0*, « _controller_ »).
-  1. Let _cancelAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"cancel"`, *1*, « » ).
+  1. Let _cancelAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingSource_, `"cancel"`, *1*, « »).
   1. Perform ? SetUpReadableStreamDefaultController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
-     _cancelAlgorithm_, _highWaterMark_, _sizeAlgorithm_)
+     _cancelAlgorithm_, _highWaterMark_, _sizeAlgorithm_).
 </emu-alg>
 
 <h3 id="rbs-controller-class" interface lt="ReadableByteStreamController">Class
@@ -4750,7 +4750,7 @@ throws>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>m
   1. If _method_ is not *undefined*,
     1. If _algoArgCount_ is *0*, return an algorithm that performs the following steps:
       1. Return ! PromiseCall(_method_, _underlyingObject_, _extraArgs_).
-    1. Otherwise, return an algorithm that performs the following steps, taking an *arg* argument:
+    1. Otherwise, return an algorithm that performs the following steps, taking an _arg_ argument:
       1. Let _fullArgs_ be a List consisting of _arg_ followed by the elements of _extraArgs_ in order.
       1. Return ! PromiseCall(_method_, _underlyingObject_, _fullArgs_).
   1. Return an algorithm which returns <a>a promise resolved with</a> *undefined*.

--- a/index.bs
+++ b/index.bs
@@ -4385,18 +4385,14 @@ nothrow>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>
   1. Assert: _transformer_ is not *undefined*.
   1. Let _controller_ be ObjectCreate(the original value of `<a idl>TransformStreamDefaultController</a>`'s `prototype`
      property).
-  1. Let _transformAlgorithm_ be the following steps, taking a_chunk_ argument:
+  1. Let _transformAlgorithm_ be the following steps, taking a _chunk_ argument:
     1. Let _result_ be TransformStreamDefaultControllerEnqueue(_controller_, _chunk_).
     1. If _result_ is an abrupt completion, return <a>a promise rejected with</a> _result_.[[Value]].
     1. Otherwise, return <a>a promise resolved with</a> *undefined*.
   1. Let _transformMethod_ be ? GetMethod(_transformer_, `"transform"`).
   1. If _transformMethod_ is not *undefined*,
-    1. Set _transformAlgorithm_ to the following steps, taking a_chunk_ argument:
-      1. Let _transformResult_ be Call(_transformMethod_, _transformer_, « chunk, _controller_ »).
-      1. If _transformResult_ is an abrupt completion,
-        1. Perform ! TransformStreamError(_stream_, _transformResult_.[[Value]]).
-        1. Return <a>a promise rejected with</a> _transformResult_.[[Value]].
-      1. Let _transformPromise_ be <a>a promise resolved with</a> _transformResult_.
+    1. Set _transformAlgorithm_ to the following steps, taking a _chunk_ argument:
+      1. Let _transformPromise_ be ! PromiseCall(_transformMethod_, _transformer_, « chunk, _controller_ »).
       1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
          argument _e_, performs the following steps:
         1. Perform ! TransformStreamError(_stream_, _e_).

--- a/index.bs
+++ b/index.bs
@@ -4758,11 +4758,6 @@ nothrow>CreateAlgorithmFromUnderlyingMethod ( <var>underlyingObject</var>, <var>
 
 <h4 id="get-method" aoid="GetMethod" throws>GetMethod ( <var>V</var>, <var>methodName</var> )</h4>
 
-<div class="note">
-  GetMethod is a small wrapper around the [[!ECMASCRIPT]] <a abstract-op>GetV</a> abstract operation that throws
-  an exception if the value is not undefined and not a function.
-</div>
-
 <emu-alg>
   1. Assert: _V_ is not *undefined*.
   1. Assert: ! IsPropertyKey(_methodName_) is *true*.

--- a/reference-implementation/.eslintrc.json
+++ b/reference-implementation/.eslintrc.json
@@ -154,7 +154,7 @@
     "consistent-this": "off",
     "eol-last": "error",
     "func-names": "off",
-    "func-style": ["error", "declaration"],
+    "func-style": "off",
     "id-blacklist": "off",
     "id-length": "off",
     "id-match": "off",

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -83,7 +83,7 @@ exports.InvokeOrNoop = (O, P, args) => {
   return Call(method, O, args);
 };
 
-function PromiseInvoke(F, V, args) {
+function PromiseCall(F, V, args) {
   try {
     return Promise.resolve(Call(F, V, args));
   } catch (value) {
@@ -103,7 +103,7 @@ exports.CreateAlgorithmWithNoParametersFromUnderlyingMethod = (underlyingObject,
   const method = exports.GetMethod(underlyingObject, methodName);
   if (method !== undefined) {
     return () => {
-      return PromiseInvoke(method, underlyingObject, args);
+      return PromiseCall(method, underlyingObject, args);
     };
   }
   return () => Promise.resolve();
@@ -113,7 +113,7 @@ exports.CreateAlgorithmWithOneParameterFromUnderlyingMethod = (underlyingObject,
   const method = exports.GetMethod(underlyingObject, methodName);
   if (method !== undefined) {
     return arg => {
-      return PromiseInvoke(method, underlyingObject, [arg].concat(extraArgs));
+      return PromiseCall(method, underlyingObject, [arg].concat(extraArgs));
     };
   }
   return () => Promise.resolve();

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -83,13 +83,13 @@ exports.InvokeOrNoop = (O, P, args) => {
   return Call(method, O, args);
 };
 
-exports.PromiseInvoke = (F, V, args) => {
+function PromiseInvoke(F, V, args) {
   try {
     return Promise.resolve(Call(F, V, args));
   } catch (value) {
     return Promise.reject(value);
   }
-};
+}
 
 exports.GetMethod = (V, methodName) => {
   const method = V[methodName];
@@ -97,6 +97,26 @@ exports.GetMethod = (V, methodName) => {
     throw new TypeError(`${methodName} is not a function`);
   }
   return method;
+};
+
+exports.CreateAlgorithmWithNoParametersFromUnderlyingMethod = (underlyingObject, methodName, args) => {
+  const method = exports.GetMethod(underlyingObject, methodName);
+  if (method !== undefined) {
+    return () => {
+      return PromiseInvoke(method, underlyingObject, args);
+    };
+  }
+  return () => Promise.resolve();
+};
+
+exports.CreateAlgorithmWithOneParameterFromUnderlyingMethod = (underlyingObject, methodName, extraArgs) => {
+  const method = exports.GetMethod(underlyingObject, methodName);
+  if (method !== undefined) {
+    return arg => {
+      return PromiseInvoke(method, underlyingObject, [arg].concat(extraArgs));
+    };
+  }
+  return () => Promise.resolve();
 };
 
 // Not implemented correctly

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -95,14 +95,18 @@ exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, alg
   return () => Promise.resolve();
 };
 
-exports.GetMethod = (V, methodName) => {
+exports.GetMethod = (V, P) => {
   assert(V !== undefined);
-  assert(IsPropertyKey(methodName) === true);
-  const method = V[methodName];
-  if (method !== undefined && typeof method !== 'function') {
-    throw new TypeError(`${methodName} is not a function`);
+  assert(IsPropertyKey(P) === true);
+  const func = V[P];
+  if (func === undefined || func === null) {
+    return undefined;
   }
-  return method;
+
+  if (typeof func !== 'function') {
+    throw new TypeError(`${P} is not a function`);
+  }
+  return func;
 };
 
 exports.InvokeOrNoop = (O, P, args) => {

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -75,8 +75,11 @@ exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, alg
   assert(IsPropertyKey(methodName));
   assert(algoArgCount === 0 || algoArgCount === 1);
   assert(Array.isArray(extraArgs));
-  const method = exports.GetMethod(underlyingObject, methodName);
+  const method = underlyingObject[methodName];
   if (method !== undefined) {
+    if (typeof method !== 'function') {
+      throw new TypeError(`${method} is not a method`);
+    }
     switch (algoArgCount) {
       case 0: {
         return () => {
@@ -93,20 +96,6 @@ exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, alg
     }
   }
   return () => Promise.resolve();
-};
-
-exports.GetMethod = (V, P) => {
-  assert(V !== undefined);
-  assert(IsPropertyKey(P) === true);
-  const func = V[P];
-  if (func === undefined || func === null) {
-    return undefined;
-  }
-
-  if (typeof func !== 'function') {
-    throw new TypeError(`${P} is not a function`);
-  }
-  return func;
 };
 
 exports.InvokeOrNoop = (O, P, args) => {

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -129,6 +129,8 @@ function PromiseCall(F, V, args) {
   }
 }
 
+exports.PromiseCall = PromiseCall;
+
 // Not implemented correctly
 exports.TransferArrayBuffer = O => {
   assert(!exports.IsDetachedBuffer(O));

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -99,22 +99,23 @@ exports.GetMethod = (V, methodName) => {
   return method;
 };
 
-exports.CreateAlgorithmWithNoParametersFromUnderlyingMethod = (underlyingObject, methodName, args) => {
+exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, algoArgCount, extraArgs) => {
+  assert(algoArgCount === 0 || algoArgCount === 1);
   const method = exports.GetMethod(underlyingObject, methodName);
   if (method !== undefined) {
-    return () => {
-      return PromiseCall(method, underlyingObject, args);
-    };
-  }
-  return () => Promise.resolve();
-};
+    switch (algoArgCount) {
+      case 0: {
+        return () => {
+          return PromiseCall(method, underlyingObject, extraArgs);
+        };
+      }
 
-exports.CreateAlgorithmWithOneParameterFromUnderlyingMethod = (underlyingObject, methodName, extraArgs) => {
-  const method = exports.GetMethod(underlyingObject, methodName);
-  if (method !== undefined) {
-    return arg => {
-      return PromiseCall(method, underlyingObject, [arg].concat(extraArgs));
-    };
+      case 1: {
+        return arg => {
+          return PromiseCall(method, underlyingObject, [arg].concat(extraArgs));
+        };
+      }
+    }
   }
   return () => Promise.resolve();
 };

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -83,15 +83,20 @@ exports.InvokeOrNoop = (O, P, args) => {
   return Call(method, O, args);
 };
 
-exports.PromiseInvokeOrNoop = (O, P, args) => {
-  assert(O !== undefined);
-  assert(IsPropertyKey(P));
-  assert(Array.isArray(args));
+exports.PromiseInvoke = (F, V, args) => {
   try {
-    return Promise.resolve(exports.InvokeOrNoop(O, P, args));
-  } catch (returnValueE) {
-    return Promise.reject(returnValueE);
+    return Promise.resolve(Call(F, V, args));
+  } catch (value) {
+    return Promise.reject(value);
   }
+};
+
+exports.GetMethod = (V, methodName) => {
+  const method = V[methodName];
+  if (method !== undefined && typeof method !== 'function') {
+    throw new TypeError(`${methodName} is not a function`);
+  }
+  return method;
 };
 
 // Not implemented correctly

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('better-assert');
-const { ArrayBufferCopy, CreateIterResultObject, IsFiniteNonNegativeNumber, InvokeOrNoop, IsDetachedBuffer,
-        PromiseInvokeOrNoop, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
+const { ArrayBufferCopy, CreateIterResultObject, GetMethod, IsFiniteNonNegativeNumber, InvokeOrNoop, IsDetachedBuffer,
+        PromiseInvoke, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
@@ -1156,12 +1156,22 @@ function SetUpReadableStreamDefaultControllerFromUnderlyingSource(stream, underl
     return InvokeOrNoop(underlyingSource, 'start', [stream._readableStreamController]);
   }
 
-  function pullAlgorithm() {
-    return PromiseInvokeOrNoop(underlyingSource, 'pull', [stream._readableStreamController]);
+  // eslint-disable-next-line func-style
+  let pullAlgorithm = () => Promise.resolve();
+  const pullMethod = GetMethod(underlyingSource, 'pull');
+  if (pullMethod !== undefined) {
+    pullAlgorithm = () => {
+      return PromiseInvoke(pullMethod, underlyingSource, [stream._readableStreamController]);
+    };
   }
 
-  function cancelAlgorithm(reason) {
-    return PromiseInvokeOrNoop(underlyingSource, 'cancel', [reason]);
+  // eslint-disable-next-line func-style
+  let cancelAlgorithm = () => Promise.resolve();
+  const cancelMethod = GetMethod(underlyingSource, 'cancel');
+  if (cancelMethod !== undefined) {
+    cancelAlgorithm = reason => {
+      return PromiseInvoke(cancelMethod, underlyingSource, [reason]);
+    };
   }
 
   SetUpReadableStreamDefaultController(stream, startAlgorithm, pullAlgorithm, cancelAlgorithm,
@@ -1896,12 +1906,22 @@ function SetUpReadableByteStreamControllerFromUnderlyingSource(stream, underlyin
     return InvokeOrNoop(underlyingByteSource, 'start', [stream._readableStreamController]);
   }
 
-  function pullAlgorithm() {
-    return PromiseInvokeOrNoop(underlyingByteSource, 'pull', [stream._readableStreamController]);
+  // eslint-disable-next-line func-style
+  let pullAlgorithm = () => Promise.resolve();
+  const pullMethod = GetMethod(underlyingByteSource, 'pull');
+  if (pullMethod !== undefined) {
+    pullAlgorithm = () => {
+      return PromiseInvoke(pullMethod, underlyingByteSource, [stream._readableStreamController]);
+    };
   }
 
-  function cancelAlgorithm(reason) {
-    return PromiseInvokeOrNoop(underlyingByteSource, 'cancel', [reason]);
+  // eslint-disable-next-line func-style
+  let cancelAlgorithm = () => Promise.resolve();
+  const cancelMethod = GetMethod(underlyingByteSource, 'cancel');
+  if (cancelMethod !== undefined) {
+    cancelAlgorithm = reason => {
+      return PromiseInvoke(cancelMethod, underlyingByteSource, [reason]);
+    };
   }
 
   const autoAllocateChunkSize = underlyingByteSource.autoAllocateChunkSize;

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,7 +1,6 @@
 'use strict';
 const assert = require('better-assert');
-const { ArrayBufferCopy, CreateAlgorithmWithNoParametersFromUnderlyingMethod,
-        CreateAlgorithmWithOneParameterFromUnderlyingMethod, CreateIterResultObject, IsFiniteNonNegativeNumber,
+const { ArrayBufferCopy, CreateAlgorithmFromUnderlyingMethod, CreateIterResultObject, IsFiniteNonNegativeNumber,
         InvokeOrNoop, IsDetachedBuffer, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
@@ -1160,8 +1159,8 @@ function SetUpReadableStreamDefaultControllerFromUnderlyingSource(stream, underl
     return InvokeOrNoop(underlyingSource, 'start', [controller]);
   }
 
-  const pullAlgorithm = CreateAlgorithmWithNoParametersFromUnderlyingMethod(underlyingSource, 'pull', [controller]);
-  const cancelAlgorithm = CreateAlgorithmWithOneParameterFromUnderlyingMethod(underlyingSource, 'cancel', []);
+  const pullAlgorithm = CreateAlgorithmFromUnderlyingMethod(underlyingSource, 'pull', 0, [controller]);
+  const cancelAlgorithm = CreateAlgorithmFromUnderlyingMethod(underlyingSource, 'cancel', 1, []);
 
   SetUpReadableStreamDefaultController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm,
                                        highWaterMark, sizeAlgorithm);
@@ -1895,8 +1894,8 @@ function SetUpReadableByteStreamControllerFromUnderlyingSource(stream, underlyin
     return InvokeOrNoop(underlyingByteSource, 'start', [controller]);
   }
 
-  const pullAlgorithm = CreateAlgorithmWithNoParametersFromUnderlyingMethod(underlyingByteSource, 'pull', [controller]);
-  const cancelAlgorithm = CreateAlgorithmWithOneParameterFromUnderlyingMethod(underlyingByteSource, 'cancel', []);
+  const pullAlgorithm = CreateAlgorithmFromUnderlyingMethod(underlyingByteSource, 'pull', 0, [controller]);
+  const cancelAlgorithm = CreateAlgorithmFromUnderlyingMethod(underlyingByteSource, 'cancel', 1, []);
 
   const autoAllocateChunkSize = underlyingByteSource.autoAllocateChunkSize;
   if (autoAllocateChunkSize !== undefined) {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1154,6 +1154,8 @@ function SetUpReadableStreamDefaultController(
 
 function SetUpReadableStreamDefaultControllerFromUnderlyingSource(stream, underlyingSource, highWaterMark,
                                                                   sizeAlgorithm) {
+  assert(underlyingSource !== undefined);
+
   const controller = Object.create(ReadableStreamDefaultController.prototype);
   function startAlgorithm() {
     return InvokeOrNoop(underlyingSource, 'start', [controller]);
@@ -1889,6 +1891,8 @@ function SetUpReadableByteStreamController(stream, controller, startAlgorithm, p
 }
 
 function SetUpReadableByteStreamControllerFromUnderlyingSource(stream, underlyingByteSource, highWaterMark) {
+  assert(underlyingByteSource !== undefined);
+
   const controller = Object.create(ReadableByteStreamController.prototype);
   function startAlgorithm() {
     return InvokeOrNoop(underlyingByteSource, 'start', [controller]);

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -299,6 +299,7 @@ function CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, hi
   InitializeReadableStream(stream);
 
   const controller = Object.create(ReadableStreamDefaultController.prototype);
+
   SetUpReadableStreamDefaultController(
       stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, sizeAlgorithm
   );
@@ -1157,6 +1158,7 @@ function SetUpReadableStreamDefaultControllerFromUnderlyingSource(stream, underl
   assert(underlyingSource !== undefined);
 
   const controller = Object.create(ReadableStreamDefaultController.prototype);
+
   function startAlgorithm() {
     return InvokeOrNoop(underlyingSource, 'start', [controller]);
   }
@@ -1894,6 +1896,7 @@ function SetUpReadableByteStreamControllerFromUnderlyingSource(stream, underlyin
   assert(underlyingByteSource !== undefined);
 
   const controller = Object.create(ReadableByteStreamController.prototype);
+
   function startAlgorithm() {
     return InvokeOrNoop(underlyingByteSource, 'start', [controller]);
   }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -262,7 +262,6 @@ function SetUpTransformStreamDefaultController(stream, controller, transformAlgo
 function SetUpTransformStreamDefaultControllerFromTransformer(stream, transformer) {
   const controller = Object.create(TransformStreamDefaultController.prototype);
 
-  // eslint-disable-next-line func-style
   let transformAlgorithm = chunk => {
     try {
       TransformStreamDefaultControllerEnqueue(controller, chunk);

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -4,7 +4,7 @@ const assert = require('better-assert');
 // Calls to verbose() are purely for debugging the reference implementation and tests. They are not part of the standard
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:transform-stream:verbose');
-const { Call, InvokeOrNoop, GetMethod, CreateAlgorithmWithNoParametersFromUnderlyingMethod, typeIsObject,
+const { Call, InvokeOrNoop, GetMethod, CreateAlgorithmFromUnderlyingMethod, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
@@ -287,7 +287,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
     };
   }
 
-  const flushAlgorithm = CreateAlgorithmWithNoParametersFromUnderlyingMethod(transformer, 'flush', [controller]);
+  const flushAlgorithm = CreateAlgorithmFromUnderlyingMethod(transformer, 'flush', 0, [controller]);
 
   SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm);
 }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -260,6 +260,8 @@ function SetUpTransformStreamDefaultController(stream, controller, transformAlgo
 }
 
 function SetUpTransformStreamDefaultControllerFromTransformer(stream, transformer) {
+  assert(transformer !== undefined);
+
   const controller = Object.create(TransformStreamDefaultController.prototype);
 
   let transformAlgorithm = chunk => {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -4,7 +4,7 @@ const assert = require('better-assert');
 // Calls to verbose() are purely for debugging the reference implementation and tests. They are not part of the standard
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:transform-stream:verbose');
-const { InvokeOrNoop, GetMethod, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
+const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
@@ -273,8 +273,11 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
       return Promise.reject(transformResultE);
     }
   };
-  const transformMethod = GetMethod(transformer, 'transform');
+  const transformMethod = transformer.transform;
   if (transformMethod !== undefined) {
+    if (typeof transformMethod !== 'function') {
+      throw new TypeError('transform is not a method');
+    }
     transformAlgorithm = chunk => {
       const transformPromise = PromiseCall(transformMethod, transformer, [chunk, controller]);
       return transformPromise.catch(e => {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -94,6 +94,7 @@ function CreateTransformStream(startAlgorithm, transformAlgorithm, flushAlgorith
                             readableSizeAlgorithm);
 
   const controller = Object.create(TransformStreamDefaultController.prototype);
+
   SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm);
 
   const startResult = startAlgorithm();

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -87,6 +87,7 @@ function CreateWritableStream(startAlgorithm, writeAlgorithm, closeAlgorithm, ab
   InitializeWritableStream(stream);
 
   const controller = Object.create(WritableStreamDefaultController.prototype);
+
   SetUpWritableStreamDefaultController(stream, controller, startAlgorithm, writeAlgorithm, closeAlgorithm,
                                        abortAlgorithm, highWaterMark, sizeAlgorithm);
   return stream;

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -5,9 +5,8 @@ const assert = require('better-assert');
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:writable-stream:verbose');
 
-const { CreateAlgorithmWithNoParametersFromUnderlyingMethod,
-        CreateAlgorithmWithOneParameterFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark,
-        IsNonNegativeNumber, MakeSizeAlgorithmFromSizeFunction, typeIsObject } = require('./helpers.js');
+const { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
+        MakeSizeAlgorithmFromSizeFunction, typeIsObject } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
@@ -785,9 +784,9 @@ function SetUpWritableStreamDefaultControllerFromUnderlyingSink(stream, underlyi
     return InvokeOrNoop(underlyingSink, 'start', [controller]);
   }
 
-  const writeAlgorithm = CreateAlgorithmWithOneParameterFromUnderlyingMethod(underlyingSink, 'write', [controller]);
-  const closeAlgorithm = CreateAlgorithmWithNoParametersFromUnderlyingMethod(underlyingSink, 'close', []);
-  const abortAlgorithm = CreateAlgorithmWithOneParameterFromUnderlyingMethod(underlyingSink, 'abort', []);
+  const writeAlgorithm = CreateAlgorithmFromUnderlyingMethod(underlyingSink, 'write', 1, [controller]);
+  const closeAlgorithm = CreateAlgorithmFromUnderlyingMethod(underlyingSink, 'close', 0, []);
+  const abortAlgorithm = CreateAlgorithmFromUnderlyingMethod(underlyingSink, 'abort', 1, []);
 
   SetUpWritableStreamDefaultController(stream, controller, startAlgorithm, writeAlgorithm, closeAlgorithm,
                                        abortAlgorithm, highWaterMark, sizeAlgorithm);

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -778,6 +778,8 @@ function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm
 }
 
 function SetUpWritableStreamDefaultControllerFromUnderlyingSink(stream, underlyingSink, highWaterMark, sizeAlgorithm) {
+  assert(underlyingSink !== undefined);
+
   const controller = Object.create(WritableStreamDefaultController.prototype);
 
   function startAlgorithm() {


### PR DESCRIPTION
Lookup methods on underlyingSource, underlyingSink and transformer in
the constructor. The main benefit is that identity transforms can be
simply implemented without touching Javascript. Other less critical
optimisation opportunities are unlocked for other stream types.

The algorithm construction for used-supplied methods is changed so that
a different algorithm is constructed depending on whether or not the
method was supplied. Two new abstract operations are added:

* GetMethod works like GetV but throws if the value is neither undefined
  nor a function.
* PromiseInvoke works like PromiseInvokeOrNoop but doesn't check for
  undefined.

PromiseInvokeOrNoop is no longer used and has been removed.

Constructors now throw for invalid method parameters, which results in
some test expectation changes. Changing the methods or prototype on the
underlying object after construction no longer does anything. Other than
these edge cases there are no web-developer visible changes.

Fixes https://github.com/whatwg/streams/issues/691.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/860.html" title="Last updated on Dec 6, 2017, 9:32 AM GMT (b90b687)">Preview</a> | <a href="https://whatpr.org/streams/860/5b9f39d...b90b687.html" title="Last updated on Dec 6, 2017, 9:32 AM GMT (b90b687)">Diff</a>