### PR TITLE
Fix typo in SetUpTransformStreamDefaultController

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5522,6 +5522,7 @@ Jens Nockert,
 Mangala Sadhu Sangeet Singh Khalsa,
 Marcos Caceres,
 Marvin Hagemeister,
+Mattias Buelens,
 Michael Mior,
 Mihai Potra,
 Romain Bellessort, <!-- rombel on GitHub -->

--- a/index.bs
+++ b/index.bs
@@ -4370,7 +4370,7 @@ nothrow>SetUpTransformStreamDefaultController ( <var>stream</var>, <var>controll
 
 <emu-alg>
   1. Assert: ! IsTransformStream(_stream_) is *true*.
-  1. Assert: _stream_.[[writableStreamController]] is *undefined*.
+  1. Assert: _stream_.[[transformStreamController]] is *undefined*.
   1. Set _controller_.[[controlledTransformStream]] to _stream_.
   1. Set _stream_.[[transformStreamController]] to _controller_.
   1. Set _controller_.[[transformAlgorithm]] to _transformAlgorithm_.

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -251,7 +251,7 @@ function IsTransformStreamDefaultController(x) {
 
 function SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm) {
   assert(IsTransformStream(stream) === true);
-  assert(stream._writableStreamController === undefined);
+  assert(stream._transformStreamController === undefined);
 
   controller._controlledTransformStream = stream;
   stream._transformStreamController = controller;


### PR DESCRIPTION
`SetUpTransformStreamDefaultController` should change the `[[transformStreamController]]` internal slot of the input `TransformStream` from `undefined` to the given controller. However, currently the assertion is checking a non-existent `[[writableStreamController]]` slot, most likely due to a typo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/863.html" title="Last updated on Dec 19, 2017, 10:42 AM GMT (e6aede5)">Preview</a> | <a href="https://whatpr.org/streams/863/b046c93...e6aede5.html" title="Last updated on Dec 19, 2017, 10:42 AM GMT (e6aede5)">Diff</a>