### PR TITLE
Extract length and offset from TypedArray view before transferring its buffer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2501,9 +2501,11 @@ nothrow>ReadableByteStreamControllerPullInto ( <var>controller</var>, <var>view<
        _view_.[[TypedArrayName]].
     1. Set _ctor_ to the constructor specified in <a>the typed array constructors table</a> for
        _view_.[[TypedArrayName]].
+  1. Let _byteOffset_ be _view_.[[ByteOffset]].
+  1. Let _byteLength_ be _view_.[[ByteLength]].
   1. Let _buffer_ be ! TransferArrayBuffer(_view_.[[ViewedArrayBuffer]]).
-  1. Let _pullIntoDescriptor_ be Record {[[buffer]]: _buffer_, [[byteOffset]]:
-     _view_.[[ByteOffset]], [[byteLength]]: _view_.[[ByteLength]], [[bytesFilled]]: *0*, [[elementSize]]: _elementSize_,
+  1. Let _pullIntoDescriptor_ be Record {[[buffer]]: _buffer_, [[byteOffset]]: _byteOffset_,
+     [[byteLength]]: _byteLength_, [[bytesFilled]]: *0*, [[elementSize]]: _elementSize_,
      [[ctor]]: _ctor_, [[readerType]]: `"byob"`}.
   1. If _controller_.[[pendingPullIntos]] is not empty,
     1. Append _pullIntoDescriptor_ as the last element of _controller_.[[pendingPullIntos]].


### PR DESCRIPTION
In #753 I introduced a change that transfers the view's buffer before querying the view's length and offset. Querying those after the buffer transfer obviously won't work, so this PR extracts the values before the transfer.

No test changes because the tests are adequate as they are.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/868.html" title="Last updated on Jan 9, 2018, 4:33 PM GMT (7cd18bc)">Preview</a> | <a href="https://whatpr.org/streams/868/1686cb8...7cd18bc.html" title="Last updated on Jan 9, 2018, 4:33 PM GMT (7cd18bc)">Diff</a>