### PR TITLE
Throw type error in ReadableStreamBYOBRequest ctor if view isn't a non-detached ArrayBuffer view object

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2041,7 +2041,10 @@ ReadableByteStreamController()</h4>
     1. Let _view_ be ! Construct(<a idl>%Uint8Array%</a>, « _firstDescriptor_.[[buffer]],
        _firstDescriptor_.[[byteOffset]] + _firstDescriptor_.[[bytesFilled]], _firstDescriptor_.[[byteLength]] −
        _firstDescriptor_.[[bytesFilled]] »).
-    1. Set *this*.[[byobRequest]] to ! Construct(`<a idl>ReadableStreamBYOBRequest</a>`, « *this*, _view_ »).
+    1. Let _byobRequest_ be ObjectCreate(the original value of `<a idl>ReadableStreamBYOBRequest</a>`'s `prototype`
+      property).
+    1. Perform ? SetUpReadableStreamBYOBRequest(_byobRequest_, _controller_, _view_).
+    1. Set *this*.[[byobRequest]] to _byobRequest_.
   1. Return *this*.[[byobRequest]].
 </emu-alg>
 
@@ -2199,9 +2202,7 @@ lt="ReadableStreamBYOBRequest(controller, view)">new
 ReadableStreamBYOBRequest(<var>controller</var>, <var>view</var>)</h4>
 
 <emu-alg>
-  1. If ! IsReadableByteStreamController(_controller_) is *false*, throw a *TypeError* exception.
-  1. Set *this*.[[associatedReadableByteStreamController]] to _controller_.
-  1. Set *this*.[[view]] to _view_.
+  1. Throw a *TypeError* exception.
 </emu-alg>
 
 <h4 id="rs-byob-request-prototype">Properties of the {{ReadableStreamBYOBRequest}} Prototype</h4>
@@ -2682,6 +2683,20 @@ throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>
        exception.
   1. Perform ? SetUpReadableByteStreamController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
      _cancelAlgorithm_, _highWaterMark_, _autoAllocateChunkSize_).
+</emu-alg>
+
+<h4 id="set-up-readable-stream-byob-request"
+aoid="SetUpReadableStreamBYOBRequest"
+throws>SetUpReadableStreamBYOBRequest ( <var>request</var>, <var>controller</var>, <var>view</var> )</h4>
+
+<emu-alg>
+  1. Assert: ! IsReadableStreamBYOBRequest(_request_) is *true*.
+  1. Assert: ! IsReadableByteStreamController(_controller_) is *true*.
+  1. Assert: Type(_view_) is Object.
+  1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
+  1. Assert: ! IsDetachedBuffer(_view_.[[ViewedArrayBuffer]]) is *false*.
+  1. Set *this*.[[associatedReadableByteStreamController]] to _controller_.
+  1. Set *this*.[[view]] to _view_.
 </emu-alg>
 
 <h2 id="ws">Writable Streams</h2>

--- a/index.bs
+++ b/index.bs
@@ -2043,7 +2043,7 @@ ReadableByteStreamController()</h4>
        _firstDescriptor_.[[bytesFilled]] »).
     1. Let _byobRequest_ be ObjectCreate(the original value of `<a idl>ReadableStreamBYOBRequest</a>`'s `prototype`
       property).
-    1. Perform ? SetUpReadableStreamBYOBRequest(_byobRequest_, _controller_, _view_).
+    1. Perform ! SetUpReadableStreamBYOBRequest(_byobRequest_, *this*, _view_).
     1. Set *this*.[[byobRequest]] to _byobRequest_.
   1. Return *this*.[[byobRequest]].
 </emu-alg>
@@ -2199,7 +2199,7 @@ Instances of {{ReadableStreamBYOBRequest}} are created with the internal slots d
 
 <h4 id="rs-byob-request-constructor" constructor for="ReadableStreamBYOBRequest"
 lt="ReadableStreamBYOBRequest(controller, view)">new
-ReadableStreamBYOBRequest(<var>controller</var>, <var>view</var>)</h4>
+ReadableStreamBYOBRequest()</h4>
 
 <emu-alg>
   1. Throw a *TypeError* exception.
@@ -2687,16 +2687,15 @@ throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>
 
 <h4 id="set-up-readable-stream-byob-request"
 aoid="SetUpReadableStreamBYOBRequest"
-throws>SetUpReadableStreamBYOBRequest ( <var>request</var>, <var>controller</var>, <var>view</var> )</h4>
+nothrow>SetUpReadableStreamBYOBRequest ( <var>request</var>, <var>controller</var>, <var>view</var> )</h4>
 
 <emu-alg>
-  1. Assert: ! IsReadableStreamBYOBRequest(_request_) is *true*.
   1. Assert: ! IsReadableByteStreamController(_controller_) is *true*.
   1. Assert: Type(_view_) is Object.
   1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
   1. Assert: ! IsDetachedBuffer(_view_.[[ViewedArrayBuffer]]) is *false*.
-  1. Set *this*.[[associatedReadableByteStreamController]] to _controller_.
-  1. Set *this*.[[view]] to _view_.
+  1. Set _request_.[[associatedReadableByteStreamController]] to _controller_.
+  1. Set _request_.[[view]] to _view_.
 </emu-alg>
 
 <h2 id="ws">Writable Streams</h2>

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1171,13 +1171,8 @@ function SetUpReadableStreamDefaultControllerFromUnderlyingSource(stream, underl
 }
 
 class ReadableStreamBYOBRequest {
-  constructor(controller, view) {
-    if (IsReadableByteStreamController(controller) === false) {
-      throw new TypeError('Cannot construct a ReadableStreamBYOBRequest without a ReadableByteStreamController');
-    }
-
-    this._associatedReadableByteStreamController = controller;
-    this._view = view;
+  constructor() {
+    throw new TypeError('ReadableStreamBYOBRequest cannot be used directly');
   }
 
   get view() {
@@ -1241,7 +1236,9 @@ class ReadableByteStreamController {
                                   firstDescriptor.byteOffset + firstDescriptor.bytesFilled,
                                   firstDescriptor.byteLength - firstDescriptor.bytesFilled);
 
-      this._byobRequest = new ReadableStreamBYOBRequest(this, view);
+      const byobRequest = Object.create(ReadableStreamBYOBRequest.prototype);
+      SetUpReadableStreamBYOBRequest(byobRequest, this, view);
+      this._byobRequest = byobRequest;
     }
 
     return this._byobRequest;
@@ -1913,6 +1910,15 @@ function SetUpReadableByteStreamControllerFromUnderlyingSource(stream, underlyin
 
   SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark,
                                     autoAllocateChunkSize);
+}
+
+function SetUpReadableStreamBYOBRequest(request, controller, view) {
+  assert(IsReadableByteStreamController(controller) === true);
+  assert(typeof view === 'object');
+  assert(ArrayBuffer.isView(view) === true);
+  assert(IsDetachedBuffer(view.buffer) === false);
+  request._associatedReadableByteStreamController = controller;
+  request._view = view;
 }
 
 // Helper functions for the ReadableStream.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/870.html" title="Last updated on Feb 9, 2018, 3:13 PM GMT (926dbc6)">Preview</a> | <a href="https://whatpr.org/streams/870/98b9be7...926dbc6.html" title="Last updated on Feb 9, 2018, 3:13 PM GMT (926dbc6)">Diff</a>