### PR TITLE
Disambiguate links to "resolve"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,6 +10,11 @@ Translation: ja https://triple-underscore.github.io/Streams-ja.html
 Opaque Elements: emu-alg
 </pre>
 
+<pre class=link-defaults>
+spec:promises-guide; type:dfn;
+    text:resolve
+</pre>
+
 <pre class="anchors">
 urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: %Uint8Array%; url: #sec-typedarray-objects; type: constructor


### PR DESCRIPTION
"Resolve" has started to be exported by the Blob Standard, and Bikeshed has
started sending links to "resolve" there. Add a link-defaults section to
explicitly direct all links to "resolve" to the promises guide.