### PR TITLE
Fix example for identity transform

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3945,8 +3945,9 @@ nothrow>WritableStreamDefaultControllerError ( <var>controller</var>, <var>error
     const { writable, readable } = new TransformStream();
     fetch("...", { body: readable }).then(response => /* ... */);
 
-    writable.write(new Uint8Array([0x73, 0x74, 0x72, 0x65, 0x61, 0x6D, 0x73, 0x21]));
-    writable.close();
+    const writer = writable.getWriter();
+    writer.write(new Uint8Array([0x73, 0x74, 0x72, 0x65, 0x61, 0x6D, 0x73, 0x21]));
+    writer.close();
   </code></pre>
 
   Another use of identity transform streams is to add additional buffering to a <a>pipe</a>. In this example we add


### PR DESCRIPTION
The example code for using an identity transform streams is wrong. It should use a writer in order to write to the stream.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/881.html" title="Last updated on Feb 13, 2018, 9:33 PM GMT (4bf5c6c)">Preview</a> | <a href="https://whatpr.org/streams/881/d7a57bb...4bf5c6c.html" title="Last updated on Feb 13, 2018, 9:33 PM GMT (4bf5c6c)">Diff</a>