### PR TITLE
Editorial: fix some double-word typos

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1213,7 +1213,7 @@ lt="ReadableStreamDefaultReader(stream)">new ReadableStreamDefaultReader(<var>st
 
 <div class="note">
   The <code>ReadableStreamDefaultReader</code> constructor is generally not meant to be used directly; instead, a
-  stream's {{ReadableStream/getReader()}} method ought to be be used.
+  stream's {{ReadableStream/getReader()}} method ought to be used.
 </div>
 
 <emu-alg>
@@ -3329,7 +3329,7 @@ lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(<var>st
 
 <div class="note">
   The <code>WritableStreamDefaultWriter</code> constructor is generally not meant to be used directly; instead, a
-  stream's {{WritableStream/getWriter()}} method ought to be be used.
+  stream's {{WritableStream/getWriter()}} method ought to be used.
 </div>
 
 <emu-alg>
@@ -4193,7 +4193,7 @@ throws.</p>
      <p class="note">The [[backpressure]] slot is set to *undefined* so that it can be initialized by
      TransformStreamSetBackpressure. Alternatively, implementations can use a strictly boolean value for
      [[backpressure]] and change the way it is initialized. This will not be visible to user code so long as the
-     initialization is correctly completed before _transformer_'s <code>start()</code> method is is called.</p>
+     initialization is correctly completed before _transformer_'s <code>start()</code> method is called.</p>
   1. Perform ! TransformStreamSetBackpressure(_stream_, *true*).
   1. Set _stream_.[[transformStreamController]] to *undefined*.
 </emu-alg>


### PR DESCRIPTION
Noticed by the new-ish linter in the WHATWG deploy script.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/887.html" title="Last updated on Feb 20, 2018, 8:29 PM GMT (f96fe5f)">Preview</a> | <a href="https://whatpr.org/streams/887/f5afedc...f96fe5f.html" title="Last updated on Feb 20, 2018, 8:29 PM GMT (f96fe5f)">Diff</a>