### PR TITLE
Added fetch-progress Examples to Demos

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -22,6 +22,9 @@
 
   <dt><a href="https://server-stjntslidj.now.sh/">Streaming response from a service worker that instantly populates the DOM</a> | <a href="https://github.com/TejasQ/basically-streams/tree/master/examples/streaming-pwa">(Source Code)</a>
   <dd>A book search app that caches responses from an API and streams them to the DOM, allowing for offline streaming responses and making use of the browser's streaming HTML parser.
+
+  <dt><a href="https://fetch-progress.anthum.com/">Progress indicators with Service Workers and Fetch</a> | <a href="https://github.com/AnthumChris/fetch-progress-indicators">(Source Code)</a>
+  <dd>Streams intercept Service Worker <code>FetchEvent</code> and <code>fetch()</code> statements to show progress indicators. See <a href="https://github.com/AnthumChris/fetch-progress-indicators#browser-support">browser support</a> notes.
 </dl>
 
 <p>Feel free to submit more demos by sending a pull request to the


### PR DESCRIPTION
Added Stream progress indicator examples with explicit note to see browser support link to enable functionality in current Firefox version

https://fetch-progress.anthum.com/