### PR TITLE
Refactor exports

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -7,24 +7,24 @@ function IsPropertyKey(argument) {
   return typeof argument === 'string' || typeof argument === 'symbol';
 }
 
-exports.typeIsObject = x => (typeof x === 'object' && x !== null) || typeof x === 'function';
+const typeIsObject = x => (typeof x === 'object' && x !== null) || typeof x === 'function';
 
-exports.createDataProperty = (o, p, v) => {
-  assert(exports.typeIsObject(o));
+const createDataProperty = (o, p, v) => {
+  assert(typeIsObject(o));
   Object.defineProperty(o, p, { value: v, writable: true, enumerable: true, configurable: true });
 };
 
-exports.createArrayFromList = elements => {
+const createArrayFromList = elements => {
   // We use arrays to represent lists, so this is basically a no-op.
   // Do a slice though just in case we happen to depend on the unique-ness.
   return elements.slice();
 };
 
-exports.ArrayBufferCopy = (dest, destOffset, src, srcOffset, n) => {
+const ArrayBufferCopy = (dest, destOffset, src, srcOffset, n) => {
   new Uint8Array(dest).set(new Uint8Array(src, srcOffset, n), destOffset);
 };
 
-exports.CreateIterResultObject = (value, done) => {
+const CreateIterResultObject = (value, done) => {
   assert(typeof done === 'boolean');
   const obj = {};
   Object.defineProperty(obj, 'value', { value, enumerable: true, writable: true, configurable: true });
@@ -32,8 +32,8 @@ exports.CreateIterResultObject = (value, done) => {
   return obj;
 };
 
-exports.IsFiniteNonNegativeNumber = v => {
-  if (exports.IsNonNegativeNumber(v) === false) {
+const IsFiniteNonNegativeNumber = v => {
+  if (IsNonNegativeNumber(v) === false) {
     return false;
   }
 
@@ -44,7 +44,7 @@ exports.IsFiniteNonNegativeNumber = v => {
   return true;
 };
 
-exports.IsNonNegativeNumber = v => {
+const IsNonNegativeNumber = v => {
   if (typeof v !== 'number') {
     return false;
   }
@@ -68,9 +68,7 @@ function Call(F, V, args) {
   return Function.prototype.apply.call(F, V, args);
 }
 
-exports.Call = Call;
-
-exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, algoArgCount, extraArgs) => {
+const CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, algoArgCount, extraArgs) => {
   assert(underlyingObject !== undefined);
   assert(IsPropertyKey(methodName));
   assert(algoArgCount === 0 || algoArgCount === 1);
@@ -98,7 +96,7 @@ exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, alg
   return () => Promise.resolve();
 };
 
-exports.InvokeOrNoop = (O, P, args) => {
+const InvokeOrNoop = (O, P, args) => {
   assert(O !== undefined);
   assert(IsPropertyKey(P));
   assert(Array.isArray(args));
@@ -122,11 +120,9 @@ function PromiseCall(F, V, args) {
   }
 }
 
-exports.PromiseCall = PromiseCall;
-
 // Not implemented correctly
-exports.TransferArrayBuffer = O => {
-  assert(!exports.IsDetachedBuffer(O));
+const TransferArrayBuffer = O => {
+  assert(!IsDetachedBuffer(O));
   const transferredIshVersion = O.slice();
 
   // This is specifically to fool tests that test "is transferred" by taking a non-zero-length
@@ -142,11 +138,11 @@ exports.TransferArrayBuffer = O => {
 };
 
 // Not implemented correctly
-exports.IsDetachedBuffer = O => {
+const IsDetachedBuffer = O => {
   return isFakeDetached in O;
 };
 
-exports.ValidateAndNormalizeHighWaterMark = highWaterMark => {
+const ValidateAndNormalizeHighWaterMark = highWaterMark => {
   highWaterMark = Number(highWaterMark);
   if (Number.isNaN(highWaterMark) || highWaterMark < 0) {
     throw new RangeError('highWaterMark property of a queuing strategy must be non-negative and non-NaN');
@@ -155,7 +151,7 @@ exports.ValidateAndNormalizeHighWaterMark = highWaterMark => {
   return highWaterMark;
 };
 
-exports.MakeSizeAlgorithmFromSizeFunction = size => {
+const MakeSizeAlgorithmFromSizeFunction = size => {
   if (size === undefined) {
     return () => 1;
   }
@@ -163,4 +159,22 @@ exports.MakeSizeAlgorithmFromSizeFunction = size => {
     throw new TypeError('size property of a queuing strategy must be a function');
   }
   return chunk => size(chunk);
+};
+
+module.exports = {
+  typeIsObject,
+  createDataProperty,
+  createArrayFromList,
+  ArrayBufferCopy,
+  CreateIterResultObject,
+  IsFiniteNonNegativeNumber,
+  IsNonNegativeNumber,
+  Call,
+  CreateAlgorithmFromUnderlyingMethod,
+  InvokeOrNoop,
+  PromiseCall,
+  TransferArrayBuffer,
+  IsDetachedBuffer,
+  ValidateAndNormalizeHighWaterMark,
+  MakeSizeAlgorithmFromSizeFunction
 };

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -2,7 +2,7 @@
 const assert = require('better-assert');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
-exports.DequeueValue = container => {
+const DequeueValue = container => {
   assert('_queue' in container && '_queueTotalSize' in container);
   assert(container._queue.length > 0);
 
@@ -15,7 +15,7 @@ exports.DequeueValue = container => {
   return pair.value;
 };
 
-exports.EnqueueValueWithSize = (container, value, size) => {
+const EnqueueValueWithSize = (container, value, size) => {
   assert('_queue' in container && '_queueTotalSize' in container);
 
   size = Number(size);
@@ -27,7 +27,7 @@ exports.EnqueueValueWithSize = (container, value, size) => {
   container._queueTotalSize += size;
 };
 
-exports.PeekQueueValue = container => {
+const PeekQueueValue = container => {
   assert('_queue' in container && '_queueTotalSize' in container);
   assert(container._queue.length > 0);
 
@@ -35,9 +35,16 @@ exports.PeekQueueValue = container => {
   return pair.value;
 };
 
-exports.ResetQueue = container => {
+const ResetQueue = container => {
   assert('_queue' in container && '_queueTotalSize' in container);
 
   container._queue = [];
   container._queueTotalSize = 0;
+};
+
+module.exports = {
+  DequeueValue,
+  EnqueueValueWithSize,
+  PeekQueueValue,
+  ResetQueue
 };

--- a/reference-implementation/lib/utils.js
+++ b/reference-implementation/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('better-assert');
 
-exports.rethrowAssertionErrorRejection = e => {
+const rethrowAssertionErrorRejection = e => {
   // Used throughout the reference implementation, as `.catch(rethrowAssertionErrorRejection)`, to ensure any errors
   // get shown. There are places in the spec where we do promise transformations and purposefully ignore or don't
   // expect any errors, but assertion errors are always problematic.
@@ -11,3 +11,5 @@ exports.rethrowAssertionErrorRejection = e => {
     }, 0);
   }
 };
+
+module.exports = { rethrowAssertionErrorRejection };


### PR DESCRIPTION
I'm working on an updated polyfill for streams over at [MattiasBuelens/web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill). I use Rollup to convert the reference implementation from CommonJS to ES2015 modules, and then bundle it in a nice UMD wrapper.

This works great, but unfortunately the [Rollup CommonJS plugin](https://github.com/rollup/rollup-plugin-commonjs) fails to optimally transform some parts of the code. For example, it has trouble with this function in `helpers.js`:
```js
exports.createDataProperty = (o, p, v) => {
  assert(exports.typeIsObject(o));
  Object.defineProperty(o, p, { value: v, writable: true, enumerable: true, configurable: true });
};
```
Because `exports.typeIsObject` might be re-assigned externally, the plugin must retain the `exports` object and wrap the whole module with a `createCommonJS` call. This prevents further optimizations such as tree-shaking.

This PR changes all instances of `exports.foo = ...` with `const foo = ...; module.exports = { foo };` so that internal functions can use `foo` instead of `exports.foo`. This prevents externally re-assigned exports from changing the behavior of internal functions, and allows Rollup to transform the CommonJS module into a "proper" ES2015 module.

I realize that this is not immediately relevant for the reference implementation, but it helps to shave off a couple of bytes in the polyfill. I could keep this in my fork of the reference implementation, but I'd prefer not to need a fork. 😅 