### PR TITLE
Have WS's abort() fulfill, instead of reject, under error conditions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3205,10 +3205,9 @@ writable stream is <a>locked to a writer</a>.
 
 <emu-alg>
   1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"closed"`, return <a>a promise resolved with</a> *undefined*.
-  1. If _state_ is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
+  1. If _state_ is not `"closed"` or `"errored"`, return <a>a promise resolved with</a> *undefined*.
+  1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return _stream_.[[pendingAbortRequest]].[[promise]].
   1. Let _error_ be a new *TypeError* indicating that the stream has been requested to abort.
-  1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return <a>a promise rejected with</a> _error_.
   1. Assert: _state_ is `"writable"` or `"erroring"`.
   1. Let _wasAlreadyErroring_ be *false*.
   1. If _state_ is `"erroring"`,

--- a/index.bs
+++ b/index.bs
@@ -3205,7 +3205,7 @@ writable stream is <a>locked to a writer</a>.
 
 <emu-alg>
   1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is not `"closed"` or `"errored"`, return <a>a promise resolved with</a> *undefined*.
+  1. If _state_ is `"closed"` or `"errored"`, return <a>a promise resolved with</a> *undefined*.
   1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return _stream_.[[pendingAbortRequest]].[[promise]].
   1. Let _error_ be a new *TypeError* indicating that the stream has been requested to abort.
   1. Assert: _state_ is `"writable"` or `"erroring"`.


### PR DESCRIPTION
* If the stream is errored, abort() now returns a promise resolved with undefined, instead of returning a promise rejected with the stored error.
* If the stream has a pending abort, abort() now returns that pending abort's promise (which will eventually resolve with undefined, unless aborting fails), instead of returning a promise rejected with a TypeError.

Fixes #900.

Tests: https://github.com/w3c/web-platform-tests/pull/9917


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/901.html" title="Last updated on Mar 8, 2018, 3:20 PM GMT (0db3090)">Preview</a> | <a href="https://whatpr.org/streams/901/ec2a957...0db3090.html" title="Last updated on Mar 8, 2018, 3:20 PM GMT (0db3090)">Diff</a>