### PR TITLE
Set stored error from |reason| in abort(reason)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3207,7 +3207,6 @@ writable stream is <a>locked to a writer</a>.
   1. Let _state_ be _stream_.[[state]].
   1. If _state_ is `"closed"` or `"errored"`, return <a>a promise resolved with</a> *undefined*.
   1. If _stream_.[[pendingAbortRequest]] is not *undefined*, return _stream_.[[pendingAbortRequest]].[[promise]].
-  1. Let _error_ be a new *TypeError* indicating that the stream has been requested to abort.
   1. Assert: _state_ is `"writable"` or `"erroring"`.
   1. Let _wasAlreadyErroring_ be *false*.
   1. If _state_ is `"erroring"`,
@@ -3216,7 +3215,7 @@ writable stream is <a>locked to a writer</a>.
   1. Let _promise_ be <a>a new promise</a>.
   1. Set _stream_.[[pendingAbortRequest]] to Record {[[promise]]: _promise_, [[reason]]: _reason_,
      [[wasAlreadyErroring]]: _wasAlreadyErroring_}.
-  1. If _wasAlreadyErroring_ is *false*, perform ! WritableStreamStartErroring(_stream_, _error_).
+  1. If _wasAlreadyErroring_ is *false*, perform ! WritableStreamStartErroring(_stream_, _reason_).
   1. Return _promise_.
 </emu-alg>
 
@@ -4372,8 +4371,8 @@ throws.</p>
   1. Let _startAlgorithm_ be an algorithm that returns _startPromise_.
   1. Let _writeAlgorithm_ be the following steps, taking a _chunk_ argument:
     1. Return ! TransformStreamDefaultSinkWriteAlgorithm(_stream_, _chunk_).
-  1. Let _abortAlgorithm_ be the following steps:
-    1. Return ! TransformStreamDefaultSinkAbortAlgorithm(_stream_).
+  1. Let _abortAlgorithm_ be the following steps, taking a _reason_ argument:
+    1. Return ! TransformStreamDefaultSinkAbortAlgorithm(_stream_, _reason_).
   1. Let _closeAlgorithm_ be the following steps:
     1. Return ! TransformStreamDefaultSinkCloseAlgorithm(_stream_).
   1. Set _stream_.[[writable]] to ! CreateWritableStream(_startAlgorithm_, _writeAlgorithm_, _closeAlgorithm_,
@@ -4678,11 +4677,10 @@ nothrow>TransformStreamDefaultSinkWriteAlgorithm ( <var>stream</var>, <var>chunk
 </emu-alg>
 
 <h4 id="transform-stream-default-sink-abort-algorithm" aoid="TransformStreamDefaultSinkAbortAlgorithm"
-nothrow>TransformStreamDefaultSinkAbortAlgorithm ( <var>stream</var> )</h4>
+nothrow>TransformStreamDefaultSinkAbortAlgorithm ( <var>stream</var>, <var>reason</var> )</h4>
 
 <emu-alg>
-  1. Let _e_ be a *TypeError* exception indicating that the writable stream was aborted.
-  1. Perform ! TransformStreamError(_stream_, _e_).
+  1. Perform ! TransformStreamError(_stream_, _reason_).
   1. Return <a>a promise resolved with</a> *undefined*.
 </emu-alg>
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -112,8 +112,8 @@ function InitializeTransformStream(stream, startPromise, writableHighWaterMark, 
     return TransformStreamDefaultSinkWriteAlgorithm(stream, chunk);
   }
 
-  function abortAlgorithm() {
-    return TransformStreamDefaultSinkAbortAlgorithm(stream);
+  function abortAlgorithm(reason) {
+    return TransformStreamDefaultSinkAbortAlgorithm(stream, reason);
   }
 
   function closeAlgorithm() {
@@ -363,11 +363,10 @@ function TransformStreamDefaultSinkWriteAlgorithm(stream, chunk) {
   return controller._transformAlgorithm(chunk);
 }
 
-function TransformStreamDefaultSinkAbortAlgorithm(stream) {
+function TransformStreamDefaultSinkAbortAlgorithm(stream, reason) {
   // abort() is not called synchronously, so it is possible for abort() to be called when the stream is already
   // errored.
-  const e = new TypeError('Writable side aborted');
-  TransformStreamError(stream, e);
+  TransformStreamError(stream, reason);
   return Promise.resolve();
 }
 

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -160,8 +160,6 @@ function WritableStreamAbort(stream, reason) {
     return stream._pendingAbortRequest._promise;
   }
 
-  const error = new TypeError('Requested to abort');
-
   assert(state === 'writable' || state === 'erroring');
 
   let wasAlreadyErroring = false;
@@ -182,7 +180,7 @@ function WritableStreamAbort(stream, reason) {
   stream._pendingAbortRequest._promise = promise;
 
   if (wasAlreadyErroring === false) {
-    WritableStreamStartErroring(stream, error);
+    WritableStreamStartErroring(stream, reason);
   }
 
   return promise;


### PR DESCRIPTION
Previously, calling abort(reason) on a WritableStream would set the
stored error to a TypeError, meaning that future operations on that
WritableStream would reject with a TypeError. This resulted in losing
the original reason when an error happened in a pipe. Instead, retain
the abort reason in the stored error slot.

Similarly, aborting the writable side of a TransformStream would set the
stored error on the readable side to a TypeError. Make it use the reason
as well to reflect the new behaviour of the writable side.

Closes #896.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/903.html" title="Last updated on Mar 9, 2018, 5:27 AM GMT (30f8d5c)">Preview</a> | <a href="https://whatpr.org/streams/903/8e99a69...30f8d5c.html" title="Last updated on Mar 9, 2018, 5:27 AM GMT (30f8d5c)">Diff</a>