### PR TITLE
Readable byte stream must call pull if needed after receiving new chunk

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2428,6 +2428,7 @@ nothrow>ReadableByteStreamControllerEnqueue ( <var>controller</var>, <var>chunk<
     1. Assert: ! IsReadableStreamLocked(_stream_) is *false*.
     1. Perform ! ReadableByteStreamControllerEnqueueChunkToQueue(_controller_, _transferredBuffer_, _byteOffset_,
        _byteLength_).
+  1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
 </emu-alg>
 
 <h4 id="readable-byte-stream-controller-enqueue-chunk-to-queue" aoid="ReadableByteStreamControllerEnqueueChunkToQueue"
@@ -2654,6 +2655,7 @@ throws>ReadableByteStreamControllerRespondInternal ( <var>controller</var>, <var
   1. Otherwise,
     1. Assert: _stream_.[[state]] is `"readable"`.
     1. Perform ? ReadableByteStreamControllerRespondInReadableState(_controller_, _bytesWritten_, _firstDescriptor_).
+  1. Perform ! ReadableByteStreamControllerCallPullIfNeeded(_controller_).
 </emu-alg>
 
 <h4 id="readable-byte-stream-controller-respond-with-new-view" aoid="ReadableByteStreamControllerRespondWithNewView"

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1671,6 +1671,8 @@ function ReadableByteStreamControllerRespondInternal(controller, bytesWritten) {
 
     ReadableByteStreamControllerRespondInReadableState(controller, bytesWritten, firstDescriptor);
   }
+
+  ReadableByteStreamControllerCallPullIfNeeded(controller);
 }
 
 function ReadableByteStreamControllerShiftPendingPullInto(controller) {
@@ -1764,6 +1766,8 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
     assert(IsReadableStreamLocked(stream) === false);
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
   }
+
+  ReadableByteStreamControllerCallPullIfNeeded(controller);
 }
 
 function ReadableByteStreamControllerError(controller, e) {


### PR DESCRIPTION
This implements the proposed solution for #877.

Two tests are currently failing, but I believe those tests are actually wrong ([see comment](https://github.com/whatwg/streams/issues/877#issuecomment-363941374)). I'll update the web platform tests and submit a PR, then we can further discuss.

Fixes #877.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/904.html" title="Last updated on Mar 20, 2018, 4:21 PM GMT (c3e2e96)">Preview</a> | <a href="https://whatpr.org/streams/904/293de26...c3e2e96.html" title="Last updated on Mar 20, 2018, 4:21 PM GMT (c3e2e96)">Diff</a>