### PR TITLE
Add two missing <var>s to the pipeTo definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -790,7 +790,7 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
          1. Otherwise, <a href="#rs-pipeTo-shutdown">shutdown</a> with _destClosed_.
      * <i id="rs-pipeTo-shutdown-with-action">Shutdown with an action</i>: if any of the above requirements ask to
        shutdown with an action _action_, optionally with an error _originalError_, then:
-       1. If _dest_.[[state]] is `"writable"` and ! WritableStreamCloseQueuedOrInFlight(dest) is *false*,
+       1. If _dest_.[[state]] is `"writable"` and ! WritableStreamCloseQueuedOrInFlight(_dest_) is *false*,
          1. If any <a>chunks</a> have been read but not yet written, write them to _dest_.
          1. Wait until every <a>chunk</a> that has been read has been written (i.e. the corresponding promises have
             settled).
@@ -803,7 +803,7 @@ option. If <code><a for="underlying source">type</a></code> is set to <code>unde
           _newError_.
      * <i id="rs-pipeTo-shutdown">Shutdown</i>: if any of the above requirements or steps ask to shutdown, optionally
        with an error _error_, then:
-       1. If _dest_.[[state]] is `"writable"` and ! WritableStreamCloseQueuedOrInFlight(dest) is *false*,
+       1. If _dest_.[[state]] is `"writable"` and ! WritableStreamCloseQueuedOrInFlight(_dest_) is *false*,
          1. If any <a>chunks</a> have been read but not yet written, write them to _dest_.
          1. Wait until every <a>chunk</a> that has been read has been written (i.e. the corresponding promises have
             settled).


### PR DESCRIPTION
No semantic changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/906.html" title="Last updated on Mar 9, 2018, 7:55 AM GMT (40349c7)">Preview</a> | <a href="https://whatpr.org/streams/906/8e99a69...40349c7.html" title="Last updated on Mar 9, 2018, 7:55 AM GMT (40349c7)">Diff</a>