### PR TITLE
Fix typo in WritableStream constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2997,8 +2997,8 @@ WritableStream(<var>underlyingSink</var> = {}, <var>strategy</var> = {})</h4>
 <emu-alg>
   1. Perform ! InitializeWritableStream(_this_).
   1. Let _type_ be ? GetV(_underlyingSink_, `"type"`).
-  1. Let _size_ be ? GetV(_readableStrategy_, `"size"`).
-  1. Let _highWaterMark_ be ? GetV(_readableStrategy_, `"highWaterMark"`).
+  1. Let _size_ be ? GetV(_strategy_, `"size"`).
+  1. Let _highWaterMark_ be ? GetV(_strategy_, `"highWaterMark"`).
   1. If _type_ is not *undefined*, throw a *RangeError* exception. <p class="note">This is to allow us to add new
      potential types in the future, without backward-compatibility concerns.</p>
   1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).


### PR DESCRIPTION
"_readableStrategy_" should have been just "_strategy_".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/908.html" title="Last updated on Mar 13, 2018, 12:56 PM GMT (b646879)">Preview</a> | <a href="https://whatpr.org/streams/908/7b8dffe...b646879.html" title="Last updated on Mar 13, 2018, 12:56 PM GMT (b646879)">Diff</a>