### PR TITLE
Editorial: fix incorrect linkage for transformer's start()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4395,7 +4395,7 @@ throws.</p>
      <p class="note">The [[backpressure]] slot is set to *undefined* so that it can be initialized by
      TransformStreamSetBackpressure. Alternatively, implementations can use a strictly boolean value for
      [[backpressure]] and change the way it is initialized. This will not be visible to user code so long as the
-     initialization is correctly completed before _transformer_'s {{transformer/start()}} method is called.</p>
+     initialization is correctly completed before _transformer_'s <l>{{transformer/start()}}</l> method is called.</p>
   1. Perform ! TransformStreamSetBackpressure(_stream_, *true*).
   1. Set _stream_.[[transformStreamController]] to *undefined*.
 </emu-alg>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/909.html" title="Last updated on Mar 16, 2018, 7:01 AM GMT (80b24d9)">Preview</a> | <a href="https://whatpr.org/streams/909/53efcd0...80b24d9.html" title="Last updated on Mar 16, 2018, 7:01 AM GMT (80b24d9)">Diff</a>