### PR TITLE
A few typo/spelling fixes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4258,11 +4258,11 @@ The {{TransformStream()}} constructor accepts as its first argument a JavaScript
   <dd>
     <p>A function that is called immediately during creation of the {{TransformStream}}.</p>
 
-    <p>Typically this is used enqueue prefix <a>chunks</a>, using
+    <p>Typically this is used to enqueue prefix <a>chunks</a>, using
     {{TransformStreamDefaultController/enqueue()|controller.enqueue()}}. Those chunks will be read from the <a>readable
     side</a> but don't depend on any writes to the <a>writable side</a>.</p>
 
-    <p>If this initial process is asynchronous, for example by virtue of taking some effort to acquire the prefix
+    <p>If this initial process is asynchronous, for example because it takes some effort to acquire the prefix
     chunks, the function can return a promise to signal success or failure; a rejected promise will error the stream.
     Any thrown exceptions will be re-thrown by the {{TransformStream()}} constructor.</p>
   </dd>


### PR DESCRIPTION
I noticed a few wording issues when reading the section on transform streams, and also one spelling change (in three places).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/910.html" title="Last updated on Mar 23, 2018, 5:06 AM GMT (3b800b7)">Preview</a> | <a href="https://whatpr.org/streams/910/3fddaf8...3b800b7.html" title="Last updated on Mar 23, 2018, 5:06 AM GMT (3b800b7)">Diff</a>