### PR TITLE
Fix a reference to [[queueSize]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1935,7 +1935,8 @@ throws>SetUpReadableStreamDefaultController(<var>stream</var>, <var>controller</
 <emu-alg>
   1. Assert: _stream_.[[readableStreamController]] is *undefined*.
   1. Set _controller_.[[controlledReadableStream]] to _stream_.
-  1. Set _controller_.[[queue]] and _controller_.[[queueSize]] to *undefined*, then perform ! ResetQueue(_controller_).
+  1. Set _controller_.[[queue]] and _controller_.[[queueTotalSize]] to *undefined*, then perform !
+     ResetQueue(_controller_).
   1. Set _controller_.[[started]], _controller_.[[closeRequested]], _controller_.[[pullAgain]], and
      _controller_.[[pulling]] to *false*.
   1. Set _controller_.[[strategySizeAlgorithm]] to _sizeAlgorithm_ and _controller_.[[strategyHWM]] to _highWaterMark_.


### PR DESCRIPTION
The SetUpReadableStreamDefaultController operation referenced the [[queueSize]]
internal slot. It should be [[queueTotalSize]]. Fix it.