### PR TITLE
Revise property access order

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -457,19 +457,19 @@ ReadableStream(<var>underlyingSource</var> = {}, <var>strategy</var> = {})</h4>
 
 <emu-alg>
   1. Perform ! InitializeReadableStream(*this*).
-  1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _size_ be ? GetV(_strategy_, `"size"`).
   1. Let _highWaterMark_ be ? GetV(_strategy_, `"highWaterMark"`).
+  1. Let _type_ be ? GetV(_underlyingSource_, `"type"`).
   1. Let _typeString_ be ? ToString(_type_).
   1. If _typeString_ is `"bytes"`,
+    1. If _size_ is not *undefined*, throw a *RangeError* exception.
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *0*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
-    1. If _size_ is not *undefined*, throw a *RangeError* exception.
     1. Perform ? SetUpReadableByteStreamControllerFromUnderlyingSource(*this*, _underlyingSource_, _highWaterMark_).
   1. Otherwise, if _type_ is *undefined*,
+    1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
     1. If _highWaterMark_ is *undefined*, let _highWaterMark_ be *1*.
     1. Set _highWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
-    1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
     1. Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource(*this*, _underlyingSource_, _highWaterMark_,
        _sizeAlgorithm_).
   1. Otherwise, throw a *RangeError* exception.
@@ -2748,6 +2748,7 @@ throws>SetUpReadableByteStreamControllerFromUnderlyingSource ( <var>stream</var>
   1. Let _cancelAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_underlyingByteSource_, `"cancel"`, *1*, « »).
   1. Let _autoAllocateChunkSize_ be ? GetV(_underlyingByteSource_, `"autoAllocateChunkSize"`).
   1. If _autoAllocateChunkSize_ is not *undefined*,
+    1. Set _autoAllocateChunkSize_ to ? ToNumber(_autoAllocateChunkSize_).
     1. If ! IsInteger(_autoAllocateChunkSize_) is *false*, or if _autoAllocateChunkSize_ ≤ *0*, throw a *RangeError*
        exception.
   1. Perform ? SetUpReadableByteStreamController(_stream_, _controller_, _startAlgorithm_, _pullAlgorithm_,
@@ -3001,9 +3002,9 @@ WritableStream(<var>underlyingSink</var> = {}, <var>strategy</var> = {})</h4>
 
 <emu-alg>
   1. Perform ! InitializeWritableStream(_this_).
-  1. Let _type_ be ? GetV(_underlyingSink_, `"type"`).
   1. Let _size_ be ? GetV(_strategy_, `"size"`).
   1. Let _highWaterMark_ be ? GetV(_strategy_, `"highWaterMark"`).
+  1. Let _type_ be ? GetV(_underlyingSink_, `"type"`).
   1. If _type_ is not *undefined*, throw a *RangeError* exception. <p class="note">This is to allow us to add new
      potential types in the future, without backward-compatibility concerns.</p>
   1. Let _sizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_size_).
@@ -4225,18 +4226,18 @@ readableStrategy)">new TransformStream(<var>transformer</var> = {}, <var ignore>
 </div>
 
 <emu-alg>
-  1. Let _readableType_ be ? GetV(_transformer_, `"readableType"`).
-  1. If _readableType_ is not *undefined*, throw a *RangeError* exception.
+  1. Let _writableSizeFunction_ be ? GetV(_writableStrategy_, `"size"`).
+  1. Let _writableHighWaterMark_ be ? GetV(_writableStrategy_, `"highWaterMark"`).
+  1. Let _readableSizeFunction_ be ? GetV(_readableStrategy_, `"size"`).
+  1. Let _readableHighWaterMark_ be ? GetV(_readableStrategy_, `"highWaterMark"`).
   1. Let _writableType_ be ? GetV(_transformer_, `"writableType"`).
   1. If _writableType_ is not *undefined*, throw a *RangeError* exception.
-  1. Let _writableSizeFunction_ be ? GetV(_writableStrategy_, `"size"`).
   1. Let _writableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_writableSizeFunction_).
-  1. Let _writableHighWaterMark_ be ? GetV(_writableStrategy_, `"highWaterMark"`).
   1. If _writableHighWaterMark_ is *undefined*, set _writableHighWaterMark_ to *1*.
   1. Set _writableHighWaterMark_ to ? ValidateAndNormalizeHighWaterMark(_writableHighWaterMark_).
-  1. Let _readableSizeFunction_ be ? GetV(_readableStrategy_, `"size"`).
+  1. Let _readableType_ be ? GetV(_transformer_, `"readableType"`).
+  1. If _readableType_ is not *undefined*, throw a *RangeError* exception.
   1. Let _readableSizeAlgorithm_ be ? MakeSizeAlgorithmFromSizeFunction(_readableSizeFunction_).
-  1. Let _readableHighWaterMark_ be ? GetV(_readableStrategy_, `"highWaterMark"`).
   1. If _readableHighWaterMark_ is *undefined*, set _readableHighWaterMark_ to *0*.
   1. Set _readableHighWaterMark_ be ? ValidateAndNormalizeHighWaterMark(_readableHighWaterMark_).
   1. Let _startPromise_ be <a>a new promise</a>.

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -17,11 +17,10 @@ const { CreateWritableStream, WritableStreamDefaultControllerErrorIfNeeded } = r
 
 class TransformStream {
   constructor(transformer = {}, writableStrategy = {}, readableStrategy = {}) {
-    const readableType = transformer.readableType;
-
-    if (readableType !== undefined) {
-      throw new RangeError('Invalid readable type specified');
-    }
+    const writableSizeFunction = writableStrategy.size;
+    let writableHighWaterMark = writableStrategy.highWaterMark;
+    const readableSizeFunction = readableStrategy.size;
+    let readableHighWaterMark = readableStrategy.highWaterMark;
 
     const writableType = transformer.writableType;
 
@@ -29,17 +28,19 @@ class TransformStream {
       throw new RangeError('Invalid writable type specified');
     }
 
-    const writableSizeFunction = writableStrategy.size;
     const writableSizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(writableSizeFunction);
-    let writableHighWaterMark = writableStrategy.highWaterMark;
     if (writableHighWaterMark === undefined) {
       writableHighWaterMark = 1;
     }
     writableHighWaterMark = ValidateAndNormalizeHighWaterMark(writableHighWaterMark);
 
-    const readableSizeFunction = readableStrategy.size;
+    const readableType = transformer.readableType;
+
+    if (readableType !== undefined) {
+      throw new RangeError('Invalid readable type specified');
+    }
+
     const readableSizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(readableSizeFunction);
-    let readableHighWaterMark = readableStrategy.highWaterMark;
     if (readableHighWaterMark === undefined) {
       readableHighWaterMark = 0;
     }

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -14,8 +14,11 @@ const AbortSteps = Symbol('[[AbortSteps]]');
 const ErrorSteps = Symbol('[[ErrorSteps]]');
 
 class WritableStream {
-  constructor(underlyingSink = {}, { size, highWaterMark = 1 } = {}) {
+  constructor(underlyingSink = {}, strategy = {}) {
     InitializeWritableStream(this);
+
+    const size = strategy.size;
+    let highWaterMark = strategy.highWaterMark;
 
     const type = underlyingSink.type;
 
@@ -24,6 +27,9 @@ class WritableStream {
     }
 
     const sizeAlgorithm = MakeSizeAlgorithmFromSizeFunction(size);
+    if (highWaterMark === undefined) {
+      highWaterMark = 1;
+    }
     highWaterMark = ValidateAndNormalizeHighWaterMark(highWaterMark);
 
     SetUpWritableStreamDefaultControllerFromUnderlyingSink(this, underlyingSink, highWaterMark, sizeAlgorithm);


### PR DESCRIPTION
Make the order that properties are accessed on the underlying
source, underlying sink, transformer and strategy objects more
consistent. Also make the order that properties are validated more
consistent.

The general order of lookups is now size, highWaterMark, type,
methods. In general values are validated immediately after lookup, but
size and highWaterMark are exceptions. They are always looked up, but
the validation needed depends on the value of "type", so lookup and
validation are separated. This applies even to WritableStream and
TransformStream, to allow for the addition of byte types to those in
future.

The order of lookups in the reference implementation now matches the
standard.

Also convert autoAllocateChunkSize to a number before checking whether
it is integer, for consistency with the way other numeric input is
handled.

Fixes: #917, #921


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/922.html" title="Last updated on Apr 24, 2018, 9:56 AM GMT (827d8a9)">Preview</a> | <a href="https://whatpr.org/streams/922/c3a23ee...827d8a9.html" title="Last updated on Apr 24, 2018, 9:56 AM GMT (827d8a9)">Diff</a>