### PR TITLE
Fix internal links for class ReadableStreamBYOBRequest

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2231,12 +2231,12 @@ would look like
 
 <pre><code class="lang-javascript">
   class ReadableStreamBYOBRequest {
-    <a href="rs-byob-request-constructor">constructor</a>(controller, view)
+    <a href="#rs-byob-request-constructor">constructor</a>(controller, view)
 
-    get <a href="rs-byob-request-view">view</a>()
+    get <a href="#rs-byob-request-view">view</a>()
 
-    <a href="rs-byob-request-respond">respond</a>(bytesWritten)
-    <a href="rs-byob-request-respond-with-new-view">respondWithNewView</a>(view)
+    <a href="#rs-byob-request-respond">respond</a>(bytesWritten)
+    <a href="#rs-byob-request-respond-with-new-view">respondWithNewView</a>(view)
   }
 </code></pre>
 


### PR DESCRIPTION
The ECMASCRIPT-style class description for ReadableStreamBYOBRequest had broken
links. Fix them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/923.html" title="Last updated on Apr 24, 2018, 10:03 AM GMT (db07acf)">Preview</a> | <a href="https://whatpr.org/streams/923/6f97246...db07acf.html" title="Last updated on Apr 24, 2018, 10:03 AM GMT (db07acf)">Diff</a>