### PR TITLE
Changes to Example 8.9: Fix code issue, add const, add text decode step

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5692,25 +5692,16 @@ useful when there is instance data to track.
 The class would be used in code like:
 
 <pre><code class="lang-javascript">
-  function textDecoderStream() {
-    const td = new TextDecoder();
-    return new TransformStream({
-      transform(chunk, controller) {
-        controller.enqueue(td.decode(chunk));
-      }
-    });
-  }
-
   const data = { userName, displayName, icon, date };
   const ts = new TransformStream(new LipFuzzTransformer(data));
-  const { url } = fetchEvent.request;
 
   fetchEvent.respondWith(
-    fetch(url).then(response => {
-      // Decode the binary-encoded response to string
-      const decodedBody = response.body.pipeThrough(textDecoderStream());
-      // Apply the LipFuzzTransformer
-      const transformedBody = decodedBody.pipeThrough(ts);
+    fetch(fetchEvent.request.url).then(response => {
+      const transformedBody = response.body
+        // Decode the binary-encoded response to string
+        .pipeThrough(new TextDecoderStream())
+        // Apply the LipFuzzTransformer
+        .pipeThrough(ts);
       return new Response(transformedBody);
     })
   );

--- a/index.bs
+++ b/index.bs
@@ -5694,6 +5694,7 @@ The class would be used in code like:
 <pre><code class="lang-javascript">
   const data = { userName, displayName, icon, date };
   const ts = new TransformStream(new LipFuzzTransformer(data));
+  const { url } = fetchEvent.request;
 
   fetchEvent.respondWith(
     fetch(url).then(response => {

--- a/index.bs
+++ b/index.bs
@@ -5699,7 +5699,7 @@ The class would be used in code like:
     fetch(url).then(response => {
       const transformedBody = response.body.pipeThrough(ts);
       return new Response(transformedBody);
-    )
+    })
   );
 </code></pre>
 

--- a/index.bs
+++ b/index.bs
@@ -5692,13 +5692,25 @@ useful when there is instance data to track.
 The class would be used in code like:
 
 <pre><code class="lang-javascript">
+  function textDecoderStream() {
+    const td = new TextDecoder();
+    return new TransformStream({
+      transform(chunk, controller) {
+        controller.enqueue(td.decode(chunk));
+      }
+    });
+  }
+
   const data = { userName, displayName, icon, date };
   const ts = new TransformStream(new LipFuzzTransformer(data));
   const { url } = fetchEvent.request;
 
   fetchEvent.respondWith(
     fetch(url).then(response => {
-      const transformedBody = response.body.pipeThrough(ts);
+      // Decode the binary-encoded response to string
+      const decodedBody = response.body.pipeThrough(textDecoderStream());
+      // Apply the LipFuzzTransformer
+      const transformedBody = decodedBody.pipeThrough(ts);
       return new Response(transformedBody);
     })
   );


### PR DESCRIPTION
Hi WHATWG team, I want to propose the following changes to example 8.9 in order to clarify it to the reader:
- There was a closing brace missing which I've added.
- The `url` variable is used out of nowhere; I would recommend to take the one coming from the `fetchEvent` which comes close to a real world scenario when using a ServiceWorker.
- The example won't work in browsers as the response body is binary-encoded but the `LipFuzzTransformer` requires string chunks. Therefor, I would recommend adding a text decoding step before applying the former. Hence, the reader is able to try the example out in her/his browser.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/924.html" title="Last updated on May 15, 2018, 9:22 PM GMT (dfb3701)">Preview</a> | <a href="https://whatpr.org/streams/924/af48a18...dfb3701.html" title="Last updated on May 15, 2018, 9:22 PM GMT (dfb3701)">Diff</a>