### PR TITLE
Remove preconditions from ReadableStreamDefaultControllerError

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1876,8 +1876,7 @@ export>ReadableStreamDefaultControllerError ( <var>controller</var>, <var>e</var
 
 This abstract operation can be called by other specifications that wish to move a readable stream to an errored state,
 in the same way a developer would error a stream using its associated controller object. Specifications should
-<em>not</em> do this to streams they did not create, and must ensure they have obeyed the precondition (listed here as
-an assert).
+<em>not</em> do this to streams they did not create.
 
 <emu-alg>
   1. Let _stream_ be _controller_.[[controlledReadableStream]].


### PR DESCRIPTION
ReadableStreamDefaultControllerError had a note that specifications should
respect the preconditions (listed as asserts). However, it doesn't have any
asserts. Remove mention of preconditions.

No functional changes.

Fixes #920.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/925.html" title="Last updated on May 14, 2018, 3:13 PM GMT (8917829)">Preview</a> | <a href="https://whatpr.org/streams/925/af48a18...8917829.html" title="Last updated on May 14, 2018, 3:13 PM GMT (8917829)">Diff</a>