### PR TITLE
ShouldCallPull: Assert desiredSize is not null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1826,6 +1826,7 @@ nothrow>ReadableStreamDefaultControllerShouldCallPull ( <var>controller</var> )<
   1. If ! IsReadableStreamLocked(_stream_) is *true* and ! ReadableStreamGetNumReadRequests(_stream_) > *0*, return
      *true*.
   1. Let _desiredSize_ be ReadableStreamDefaultControllerGetDesiredSize(_controller_).
+  1. Assert: _desiredSize_ is not *null*.
   1. If _desiredSize_ > *0*, return *true*.
   1. Return *false*.
 </emu-alg>
@@ -2696,7 +2697,9 @@ nothrow>ReadableByteStreamControllerShouldCallPull ( <var>controller</var> )</h4
      return *true*.
   1. If ! ReadableStreamHasBYOBReader(_stream_) is *true* and ! ReadableStreamGetNumReadIntoRequests(_stream_) > *0*,
      return *true*.
-  1. If ! ReadableByteStreamControllerGetDesiredSize(_controller_) > *0*, return *true*.
+  1. Let _desiredSize_ be  ! ReadableByteStreamControllerGetDesiredSize(_controller_).
+  1. Assert: _desiredSize_ is not *null*.
+  1. If _desiredSize_ > *0*, return *true*.
   1. Return *false*.
 </emu-alg>
 

--- a/index.bs
+++ b/index.bs
@@ -1825,7 +1825,7 @@ nothrow>ReadableStreamDefaultControllerShouldCallPull ( <var>controller</var> )<
   1. If _controller_.[[started]] is *false*, return *false*.
   1. If ! IsReadableStreamLocked(_stream_) is *true* and ! ReadableStreamGetNumReadRequests(_stream_) > *0*, return
      *true*.
-  1. Let _desiredSize_ be ReadableStreamDefaultControllerGetDesiredSize(_controller_).
+  1. Let _desiredSize_ be ! ReadableStreamDefaultControllerGetDesiredSize(_controller_).
   1. Assert: _desiredSize_ is not *null*.
   1. If _desiredSize_ > *0*, return *true*.
   1. Return *false*.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1011,6 +1011,7 @@ function ReadableStreamDefaultControllerShouldCallPull(controller) {
   }
 
   const desiredSize = ReadableStreamDefaultControllerGetDesiredSize(controller);
+  assert(desiredSize !== null);
   if (desiredSize > 0) {
     return true;
   }
@@ -1708,7 +1709,9 @@ function ReadableByteStreamControllerShouldCallPull(controller) {
     return true;
   }
 
-  if (ReadableByteStreamControllerGetDesiredSize(controller) > 0) {
+  const desiredSize = ReadableByteStreamControllerGetDesiredSize(controller);
+  assert(desiredSize !== null);
+  if (desiredSize > 0) {
     return true;
   }
 


### PR DESCRIPTION
ReadableStreamDefaultControllerShouldCallPull implicitly assumes that
desiredSize is not null when it compares it to 0. This is guaranteed by
the check of
ReadableStreamDefaultControllerCanCloseOrEnqueue(controller), but it's
not obvious. Add an assert to make it explicit.

Also do the same for ReadableByteStreamControllerShouldCallPull.

No functional changes.

Closes #919.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/926.html" title="Last updated on May 23, 2018, 7:05 AM GMT (edcef0a)">Preview</a> | <a href="https://whatpr.org/streams/926/d98f243...edcef0a.html" title="Last updated on May 23, 2018, 7:05 AM GMT (edcef0a)">Diff</a>