### PR TITLE
Add a text encoding step to example 8.9

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5703,7 +5703,9 @@ The class would be used in code like:
         // Decode the binary-encoded response to string
         .pipeThrough(new TextDecoderStream())
         // Apply the LipFuzzTransformer
-        .pipeThrough(ts);
+        .pipeThrough(ts)
+        // Encode the transformed string
+        .pipeThrough(new TextEncoderStream());
       return new Response(transformedBody);
     })
   );


### PR DESCRIPTION
In #924, a text decoding step was added to example 8.9 so it could run in the browser. However, the reverse needs to happen in order to construct a valid `Response` with the transformed stream. Specifically, in step 3 of "read all bytes from a ReadableStream" from [the Fetch specification](https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream), the stream must produce `Uint8Array` objects for it to be consumed correctly.

This PR fixes this by adding an extra pipe through a `TextEncoderStream`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/930.html" title="Last updated on Jun 7, 2018, 7:51 PM GMT (6a14699)">Preview</a> | <a href="https://whatpr.org/streams/930/08145be...6a14699.html" title="Last updated on Jun 7, 2018, 7:51 PM GMT (6a14699)">Diff</a>