### PR TITLE
Add some missing exclamation marks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1048,8 +1048,8 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
       1. <a>Resolve</a> _cancelPromise_ with _cancelResult_.
     1. Return _cancelPromise_.
   1. Let _startAlgorithm_ be an algorithm that returns *undefined*.
-  1. Set _branch1_ to CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel1Algorithm_).
-  1. Set _branch2_ to CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel2Algorithm_).
+  1. Set _branch1_ to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel1Algorithm_).
+  1. Set _branch2_ to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel2Algorithm_).
   1. <a>Upon rejection</a> of _reader_.[[closedPromise]] with reason _r_,
     1. If _closedOrErrored_ is *false*, then:
       1. Perform ! ReadableStreamDefaultControllerError(_branch1_.[[readableStreamController]], _r_).
@@ -2104,7 +2104,7 @@ ReadableByteStreamController()</h4>
 </div>
 
 <emu-alg>
-  1. If IsReadableByteStreamController(*this*) is *false*, throw a *TypeError* exception.
+  1. If ! IsReadableByteStreamController(*this*) is *false*, throw a *TypeError* exception.
   1. If *this*.[[byobRequest]] is *undefined* and *this*.[[pendingPullIntos]] is not empty,
     1. Let _firstDescriptor_ be the first element of *this*.[[pendingPullIntos]].
     1. Let _view_ be ! Construct(<a idl>%Uint8Array%</a>, « _firstDescriptor_.[[buffer]],
@@ -2615,7 +2615,7 @@ nothrow>ReadableByteStreamControllerRespondInClosedState ( <var>controller</var>
   1. Set _firstDescriptor_.[[buffer]] to ! TransferArrayBuffer(_firstDescriptor_.[[buffer]]).
   1. Assert: _firstDescriptor_.[[bytesFilled]] is *0*.
   1. Let _stream_ be _controller_.[[controlledReadableByteStream]].
-  1. If ReadableStreamHasBYOBReader(_stream_) is *true*,
+  1. If ! ReadableStreamHasBYOBReader(_stream_) is *true*,
     1. Repeat the following steps while ! ReadableStreamGetNumReadIntoRequests(_stream_) > *0*,
       1. Let _pullIntoDescriptor_ be ! ReadableByteStreamControllerShiftPendingPullInto(_controller_).
       1. Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(_stream_, _pullIntoDescriptor_).
@@ -3297,7 +3297,7 @@ nothrow>WritableStreamDealWithRejection ( <var>stream</var>, <var>error</var> )<
     1. <a>Reject</a> _writeRequest_ with _storedError_.
   1. Set _stream_.[[writeRequests]] to an empty List.
   1. if _stream_.[[pendingAbortRequest]] is *undefined*,
-    1. Perform !  WritableStreamRejectCloseAndClosedPromiseIfNeeded(_stream_).
+    1. Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(_stream_).
     1. Return.
   1. Let _abortRequest_ be _stream_.[[pendingAbortRequest]].
   1. Set _stream_.[[pendingAbortRequest]] to *undefined*.


### PR DESCRIPTION
Some invocations of abstract operations were missing the ! prefix to
assert that they never return an abrupt completion. Add the missing !
prefixes.

No semantic changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/935.html" title="Last updated on Jul 2, 2018, 12:09 PM GMT (ce761a6)">Preview</a> | <a href="https://whatpr.org/streams/935/a6de38e...ce761a6.html" title="Last updated on Jul 2, 2018, 12:09 PM GMT (ce761a6)">Diff</a>