### PR TITLE
Don't create iterators with Object.prototype for internal use

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -24,14 +24,6 @@ exports.ArrayBufferCopy = (dest, destOffset, src, srcOffset, n) => {
   new Uint8Array(dest).set(new Uint8Array(src, srcOffset, n), destOffset);
 };
 
-exports.CreateIterResultObject = (value, done) => {
-  assert(typeof done === 'boolean');
-  const obj = {};
-  Object.defineProperty(obj, 'value', { value, enumerable: true, writable: true, configurable: true });
-  Object.defineProperty(obj, 'done', { value: done, enumerable: true, writable: true, configurable: true });
-  return obj;
-};
-
 exports.IsFiniteNonNegativeNumber = v => {
   if (exports.IsNonNegativeNumber(v) === false) {
     return false;


### PR DESCRIPTION
An iterator object which inherits from Object.prototype can make calls
to Promise.resolve observable to use code. This is inappropriate when
the promise is being resolved internally, so make the behaviour be
controlled by a parameter that defaults to false.

Fixes #933.