### PR TITLE
Add missing check for WritableStream...ClearAlgorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4141,7 +4141,7 @@ nothrow>WritableStreamDefaultControllerProcessWrite ( <var>controller</var>, <va
       1. Perform ! WritableStreamUpdateBackpressure(_stream_, _backpressure_).
     1. Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(_controller_).
   1. <a>Upon rejection</a> of _sinkWritePromise_ with _reason_,
-    1. Perform ! WritableStreamDefaultControllerClearAlgorithms(_controller_).
+    1. If _stream_.[[state]] is `"writable"`, perform ! WritableStreamDefaultControllerClearAlgorithms(_controller_).
     1. Perform ! WritableStreamFinishInFlightWriteWithError(_stream_, _reason_).
 </emu-alg>
 


### PR DESCRIPTION
When an underlying sink write is rejected but an abort is already in
process, the underlying sink abort() method still needs to be called, so
the algorithms cannot be cleared yet.

This was correct in the reference implementation but the corresponding
condition was missing from the standard text.

Add the missing check.

Thanks to @MattiasBuelens for pointing out the issue.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/943.html" title="Last updated on Jul 14, 2018, 3:06 PM GMT (0cd0a3d)">Preview</a> | <a href="https://whatpr.org/streams/943/323223e...0cd0a3d.html" title="Last updated on Jul 14, 2018, 3:06 PM GMT (0cd0a3d)">Diff</a>