### PR TITLE
Clear [[strategySizeAlgorithm]] slot when no longer needed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1892,6 +1892,7 @@ implementations will likely want to include similar steps.</p>
 <emu-alg>
   1. Set _controller_.[[pullAlgorithm]] to *undefined*.
   1. Set _controller_.[[cancelAlgorithm]] to *undefined*.
+  1. Set _controller_.[[strategySizeAlgorithm]] to *undefined*.
 </emu-alg>
 
 <h4 id="readable-stream-default-controller-close" aoid="ReadableStreamDefaultControllerClose" nothrow
@@ -4079,6 +4080,7 @@ nothing.</p>
   1. Set _controller_.[[writeAlgorithm]] to *undefined*.
   1. Set _controller_.[[closeAlgorithm]] to *undefined*.
   1. Set _controller_.[[abortAlgorithm]] to *undefined*.
+  1. Set _controller_.[[strategySizeAlgorithm]] to *undefined*.
 </emu-alg>
 
 <h4 id="writable-stream-default-controller-close" aoid="WritableStreamDefaultControllerClose"

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1039,6 +1039,7 @@ function ReadableStreamDefaultControllerShouldCallPull(controller) {
 function ReadableStreamDefaultControllerClearAlgorithms(controller) {
   controller._pullAlgorithm = undefined;
   controller._cancelAlgorithm = undefined;
+  controller._strategySizeAlgorithm = undefined;
 }
 
 // A client of ReadableStreamDefaultController may use these functions directly to bypass state check.

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -805,6 +805,7 @@ function WritableStreamDefaultControllerClearAlgorithms(controller) {
   controller._writeAlgorithm = undefined;
   controller._closeAlgorithm = undefined;
   controller._abortAlgorithm = undefined;
+  controller._strategySizeAlgorithm = undefined;
 }
 
 function WritableStreamDefaultControllerClose(controller) {


### PR DESCRIPTION
When clearing out the other algorithms, also clear out the
[[strategySizeAlgorithm]] slot. It will not be called after the stream
is errored or closed.

Part of #932.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/947.html" title="Last updated on Jul 31, 2018, 12:12 PM GMT (ead3527)">Preview</a> | <a href="https://whatpr.org/streams/947/9098b5d...ead3527.html" title="Last updated on Jul 31, 2018, 12:12 PM GMT (ead3527)">Diff</a>