### PR TITLE
Make rejections from transformAlgorithm error the readable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4725,11 +4725,7 @@ throws>SetUpTransformStreamDefaultControllerFromTransformer ( <var>stream</var>,
   1. If _transformMethod_ is not *undefined*,
     1. If ! IsCallable(_transformMethod_) is *false*, throw a *TypeError* exception.
     1. Set _transformAlgorithm_ to the following steps, taking a _chunk_ argument:
-      1. Let _transformPromise_ be ! PromiseCall(_transformMethod_, _transformer_, « chunk, _controller_ »).
-      1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
-         argument _e_, performs the following steps:
-        1. Perform ! TransformStreamError(_stream_, _e_).
-        1. Throw _e_.
+      1. Return ! PromiseCall(_transformMethod_, _transformer_, « _chunk_, _controller_ »).
   1. Let _flushAlgorithm_ be ? CreateAlgorithmFromUnderlyingMethod(_transformer_, `"flush"`, *0*, « controller »).
   1. Perform ! SetUpTransformStreamDefaultController(_stream_, _controller_, _transformAlgorithm_, _flushAlgorithm_).
 </emu-alg>
@@ -4783,6 +4779,17 @@ in the same way a developer would error a stream using its associated controller
   1. Perform ! TransformStreamError(_controller_.[[controlledTransformStream]], _e_).
 </emu-alg>
 
+<h4 id="transform-stream-default-controller-perform-transform" aoid="TransformStreamDefaultControllerPerformTransform"
+nothrow>TransformStreamDefaultControllerPerformTransform ( <var>controller</var>, <var>chunk</var> )</h4>
+
+<emu-alg>
+  1. Let _transformPromise_ be the result of performing _controller_.[[transformAlgorithm]], passing _chunk_.
+  1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
+     argument _r_, performs the following steps:
+    1. Perform ! TransformStreamError(_controller_.[[controlledTransformStream]], _r_).
+    1. Throw _r_.
+</emu-alg>
+
 <h4 id="transform-stream-default-controller-terminate" aoid="TransformStreamDefaultControllerTerminate"
 nothrow export>TransformStreamDefaultControllerTerminate ( <var>controller</var> )</h4>
 
@@ -4816,8 +4823,8 @@ nothrow>TransformStreamDefaultSinkWriteAlgorithm ( <var>stream</var>, <var>chunk
       1. Let _state_ be _writable_.[[state]].
       1. If _state_ is `"erroring"`, throw _writable_.[[storedError]].
       1. Assert: _state_ is `"writable"`.
-      1. Return the result of performing _controller_.[[transformAlgorithm]], passing _chunk_.
-  1. Return the result of performing _controller_.[[transformAlgorithm]], passing _chunk_.
+      1. Return ! TransformStreamDefaultControllerPerformTransform(_controller_, _chunk_).
+  1. Return ! TransformStreamDefaultControllerPerformTransform(_controller_, _chunk_).
 </emu-alg>
 
 <h4 id="transform-stream-default-sink-abort-algorithm" aoid="TransformStreamDefaultSinkAbortAlgorithm"


### PR DESCRIPTION
Currently rejections from transformAlgorithm error the writable side of
a transform stream but don't error the readable side. This is an
unexpected difference from the behaviour of transformer.transform.

Make the behaviour consistent so a rejection from transformAlgorithm
errors both sides.

This only affects other standards which create TransformStream objects.
The change is not visible to user JavaScript or web platform tests.

Fixes #946.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/948.html" title="Last updated on Jul 31, 2018, 1:31 PM GMT (bd4d398)">Preview</a> | <a href="https://whatpr.org/streams/948/9098b5d...bd4d398.html" title="Last updated on Jul 31, 2018, 1:31 PM GMT (bd4d398)">Diff</a>