### PR TITLE
Export the "transform stream" concept

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -159,7 +159,7 @@ sink</a>, and it discards all writes in the stream's <a>internal queue</a>.
 
 <h3 id="ts-model">Transform streams</h3>
 
-A <dfn>transform stream</dfn> consists of a pair of streams: a <a>writable stream</a>, known as its <dfn>writable
+A <dfn export>transform stream</dfn> consists of a pair of streams: a <a>writable stream</a>, known as its <dfn>writable
 side</dfn>, and a <a>readable stream</a>, known as its <dfn>readable side</dfn>. In a manner specific to the transform
 stream in question, writes to the writable side result in new data being made available for reading from the readable
 side.

--- a/index.bs
+++ b/index.bs
@@ -159,10 +159,10 @@ sink</a>, and it discards all writes in the stream's <a>internal queue</a>.
 
 <h3 id="ts-model">Transform streams</h3>
 
-A <dfn export>transform stream</dfn> consists of a pair of streams: a <a>writable stream</a>, known as its <dfn>writable
-side</dfn>, and a <a>readable stream</a>, known as its <dfn>readable side</dfn>. In a manner specific to the transform
-stream in question, writes to the writable side result in new data being made available for reading from the readable
-side.
+A <dfn export>transform stream</dfn> consists of a pair of streams: a <a>writable stream</a>, known as its <dfn
+export>writable side</dfn>, and a <a>readable stream</a>, known as its <dfn export>readable side</dfn>. In a manner
+specific to the transform stream in question, writes to the writable side result in new data being made available for
+reading from the readable side.
 
 Concretely, any object with a <code>writable</code> property and a <code>readable</code> property can serve as a
 transform stream. However, the standard {{TransformStream}} class makes it much easier to create such a pair that is


### PR DESCRIPTION
The encoding standard needs to refer to the "transform stream" concept.
Export it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/949.html" title="Last updated on Aug 6, 2018, 8:22 AM GMT (d6c10d9)">Preview</a> | <a href="https://whatpr.org/streams/949/f2aa279...d6c10d9.html" title="Last updated on Aug 6, 2018, 8:22 AM GMT (d6c10d9)">Diff</a>