### PR TITLE
Editorial: add some more cross-references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -235,10 +235,11 @@ For readable streams, an underlying source can use this desired size as a backpr
 generation so as to try to keep the desired size above or at zero. For writable streams, a producer can behave
 similarly, avoiding writes that would cause the desired size to go negative.
 
-Concretely, a queuing strategy for web developer–created streams is given by any JavaScript object with a
-<code>highWaterMark</code> property. For byte streams the <code>highWaterMark</code> always has units of bytes. For
-other streams the default unit is <a>chunks</a>, but a <code>size()</code> function can be included in the strategy
-object which returns the size for a given chunk. This permits the <code>highWaterMark</code> to be specified in
+<a href="#qs-api">Concretely</a>, a queuing strategy for web developer–created streams is given by any JavaScript object
+with a <code><a for="queuing strategy">highWaterMark</a></code> property. For byte streams the <code><a for="queuing
+strategy">highWaterMark</a></code> always has units of bytes. For other streams the default unit is <a>chunks</a>, but a
+<code><a for="queuing strategy">size()</a></code> function can be included in the strategy object which returns the size
+for a given chunk. This permits the <code><a for="queuing strategy">highWaterMark</a></code> to be specified in
 arbitrary floating-point units.
 <!-- TODO: https://github.com/whatwg/streams/issues/427 -->
 
@@ -5533,8 +5534,8 @@ With this in hand, we can create and use <a>BYOB readers</a> for the returned {{
 also create <a>default readers</a>, using them in the same simple and generic manner as usual. The adaptation between
 the low-level byte tracking of the <a>underlying byte source</a> shown here, and the higher-level chunk-based
 consumption of a <a>default reader</a>, is all taken care of automatically by the streams implementation. The
-auto-allocation feature, via the <code>autoAllocateChunkSize</code> option, even allows us to write less code, compared
-to the manual branching in [[#example-rbs-push]].
+auto-allocation feature, via the <code><a for="underlying source">autoAllocateChunkSize</a></code> option, even allows
+us to write less code, compared to the manual branching in [[#example-rbs-push]].
 
 <h3 id="example-ws-no-backpressure">A writable stream with no backpressure or success signals</h3>
 


### PR DESCRIPTION
In particular this avoids a Bikeshed warning about unused definitions.

Note that later we will switch to using https://github.com/tabatkins/bikeshed/issues/1346. This cross-linking is a bit manual and funny at the moment due to the problems discussed there.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/953.html" title="Last updated on Sep 4, 2018, 7:53 PM GMT (febbe20)">Preview</a> | <a href="https://whatpr.org/streams/953/5d9498e...febbe20.html" title="Last updated on Sep 4, 2018, 7:53 PM GMT (febbe20)">Diff</a>