### PR TITLE
Use multi-global tests

### DIFF
--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -18,7 +18,7 @@
     "minimatch": "^3.0.4",
     "nyc": "^13.0.1",
     "opener": "^1.5.1",
-    "wpt-runner": "^2.6.0"
+    "wpt-runner": "^2.7.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
* Update `wpt-runner` to version 2.7.0, which adds support for running multi-global `*.any.js` tests (domenic/wpt-runner#12)
* Update to the newly refactored tests from web-platform-tests/wpt#14172