### PR TITLE
Match _closeWS parameter name with name used in body

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5771,7 +5771,7 @@ source abstractions.
       return this._closeWS(4000, reason && reason.message);
     }
 
-    _closeWS(code, reason) {
+    _closeWS(code, reasonString) {
       return new Promise((resolve, reject) => {
         this._ws.onclose = e => {
           if (e.wasClean) {
@@ -5983,6 +5983,7 @@ Dominic Tarr,
 Ed Hager,
 Forbes Lindesay,
 Forrest Norvell,
+Gary Blackwood,
 Gorgi Kosev,
 贺师俊 (hax),
 Isaac Schlueter,


### PR DESCRIPTION
`reasonString` is used to match the closeWS(code, reasonString)
function in section 8.6.

Fixed #915


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/971.html" title="Last updated on Dec 4, 2018, 10:57 PM GMT (fa87d3d)">Preview</a> | <a href="https://whatpr.org/streams/971/a6f36b6...fa87d3d.html" title="Last updated on Dec 4, 2018, 10:57 PM GMT (fa87d3d)">Diff</a>