### PR TITLE
Update Makefile to copy top-level demos files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ local: index.bs
 
 deploy: index.bs
 	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh
-	EXTRA_FILES="demos/**/*" \
+	EXTRA_FILES="demos/* demos/**/*" \
 	POST_BUILD_STEP='node_modules/.bin/emu-algify --throwing-indicators < "$$DIR/index.html" > "$$DIR/index.html.tmp"; mv "$$DIR/index.html.tmp" "$$DIR/index.html"' \
 	bash ./deploy.sh
 


### PR DESCRIPTION
Top-level files in the top-level "demos/" directory were not being
copied as they did not match the expression "demos/**/*". Change the
expression to "demos/* demos/**/*" to cause all the files to be copied.

This solution is ugly and causes (harmless) "skipping directory"
warnings to be output by rsync.

It may be better to add the --recursive flag to rsync as a long-term
solution.