### PR TITLE
Demos: Add lang="en" to html files

### DIFF
--- a/demos/append-child.html
+++ b/demos/append-child.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <meta charset="utf-8">
 <title>Append child writable stream demo</title>
 

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <meta charset="utf-8">
 <title>Streams Demos</title>
 <link rel=stylesheet href="resources/common.css">

--- a/demos/streaming-element-backpressure.html
+++ b/demos/streaming-element-backpressure.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <meta charset="utf-8">
 <title>Streaming element with backpressure demo</title>
 

--- a/demos/streaming-element.html
+++ b/demos/streaming-element.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <meta charset="utf-8">
 <title>Streaming element demo</title>
 


### PR DESCRIPTION
The Nu Html Checker really wants <html lang="en"> to be included in all
HTML files, and will exit with an error if it is not present. The deploy
script will not proceed if the Html Checker exits with an error.

Add an <html lang="en"> tag to all the demo HTML files to keep the Html
Checker happy.