### PR TITLE
Replace impossible condition with assert

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4282,7 +4282,7 @@ aoid="WritableStreamDefaultControllerAdvanceQueueIfNeeded" nothrow>WritableStrea
   1. If _controller_.[[started]] is *false*, return.
   1. If _stream_.[[inFlightWriteRequest]] is not *undefined*, return.
   1. Let _state_ be _stream_.[[state]].
-  1. If _state_ is `"closed"` or `"errored"`, return.
+  1. Assert: _state_ is not `"closed"` or `"errored"`.
   1. If _state_ is `"erroring"`,
     1. Perform ! WritableStreamFinishErroring(_stream_).
     1. Return.

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -859,9 +859,7 @@ function WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller) {
   }
 
   const state = stream._state;
-  if (state === 'closed' || state === 'errored') {
-    return;
-  }
+  assert(state !== 'closed' && state !== 'errored');
   if (state === 'erroring') {
     WritableStreamFinishErroring(stream);
     return;


### PR DESCRIPTION
It is not possible for
WritableStreamDefaultControllerAdvanceQueueIfNeeded to be called when
the state is "closed" or "errored". Replace the condition with an
assert.

No functional changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/987.html" title="Last updated on Feb 18, 2019, 12:49 PM UTC (3e7964f)">Preview</a> | <a href="https://whatpr.org/streams/987/bf2cac8...3e7964f.html" title="Last updated on Feb 18, 2019, 12:49 PM UTC (3e7964f)">Diff</a>