### PR TITLE
Stop using better-assert

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('better-assert');
+const assert = require('assert');
 
 const isFakeDetached = Symbol('is "detached" for our purposes');
 

--- a/reference-implementation/lib/queue-with-sizes.js
+++ b/reference-implementation/lib/queue-with-sizes.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('better-assert');
+const assert = require('assert');
 const { IsFiniteNonNegativeNumber } = require('./helpers.js');
 
 exports.DequeueValue = container => {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global AbortSignal:false */
 
-const assert = require('better-assert');
+const assert = require('assert');
 const { ArrayBufferCopy, CreateAlgorithmFromUnderlyingMethod, IsFiniteNonNegativeNumber, InvokeOrNoop,
         IsDetachedBuffer, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject, WaitForAllPromise } =

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('better-assert');
+const assert = require('assert');
 
 // Calls to verbose() are purely for debugging the reference implementation and tests. They are not part of the standard
 // and do not appear in the standard text.

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('better-assert');
+const assert = require('assert');
 
 // Calls to verbose() are purely for debugging the reference implementation and tests. They are not part of the standard
 // and do not appear in the standard text.

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -11,7 +11,6 @@
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "license": "(CC0-1.0 OR MIT)",
   "devDependencies": {
-    "better-assert": "^1.0.2",
     "browserify": "^16.2.3",
     "debug": "^4.1.0",
     "eslint": "^5.12.1",


### PR DESCRIPTION
The "better-assert" implementation of assert() no longer works now that we use
browserify. Go back to using the standard "assert" implementation.