### PR TITLE
Give pipeTo more latitude about byob chunk sizes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1147,8 +1147,10 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
      * <strong>Backpressure must be enforced:</strong>
        * While WritableStreamDefaultWriterGetDesiredSize(_writer_) is ≤ *0* or is *null*, the user agent must not read
          from _reader_.
-       * If _reader_ is a <a>BYOB reader</a>, WritableStreamDefaultWriterGetDesiredSize(_writer_) should be used to
-         determine the size of the chunks read from _reader_.
+       * If _reader_ is a <a>BYOB reader</a>, WritableStreamDefaultWriterGetDesiredSize(_writer_) should be used as a
+         basis to determine the size of the chunks read from _reader_.
+         <p class="note">It's frequently inefficient to read chunks that are too small or too large. Other information
+         might be factored in to determine the optimal chunk size.</p>
        * Reads or writes should not be delayed for reasons other than these backpressure signals.
          <p class="example" id="example-bad-backpressure">An implementation that waits for each write to successfully
          complete before proceeding to the next read/write operation violates this recommendation. In doing so, such an


### PR DESCRIPTION
If pipeTo() uses a BYOB reader, it is required to use
WritableStreamDefaultWriterGetDesiredSize(writer) to determine chunk
sizes. However, if, for example, the HWM is too low, the resulting value
may be an unsuitable chunk size. Relax the language to give
implementations latitude to use other information to choose an
appropriate chunk size.

Closes #938.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/989.html" title="Last updated on Feb 18, 2019, 2:38 PM UTC (5fc648a)">Preview</a> | <a href="https://whatpr.org/streams/989/9730669...5fc648a.html" title="Last updated on Feb 18, 2019, 2:38 PM UTC (5fc648a)">Diff</a>