### PR TITLE
Initialize ReadableByteStreamController.[[byobRequest]] to undefined

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2247,7 +2247,8 @@ Instances of {{ReadableByteStreamController}} are created with the internal slot
   </tr>
   <tr>
     <td>\[[byobRequest]]
-    <td class="non-normative">A {{ReadableStreamBYOBRequest}} instance representing the current BYOB pull request
+    <td class="non-normative">A {{ReadableStreamBYOBRequest}} instance representing the current BYOB pull request,
+      or <emu-val>undefined</emu-val> if there are no pending requests
   </tr>
   <tr>
     <td>\[[cancelAlgorithm]]
@@ -2965,6 +2966,7 @@ throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>controller</v
     1. Assert: _autoAllocateChunkSize_ is positive.
   1. Set _controller_.[[controlledReadableByteStream]] to _stream_.
   1. Set _controller_.[[pullAgain]] and _controller_.[[pulling]] to *false*.
+  1. Set _controller_.[[byobRequest]] to *undefined*.
   1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(_controller_).
   1. Perform ! ResetQueue(_controller_).
   1. Set _controller_.[[closeRequested]] and _controller_.[[started]] to *false*.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -2049,6 +2049,7 @@ function SetUpReadableByteStreamController(stream, controller, startAlgorithm, p
   controller._pullAgain = false;
   controller._pulling = false;
 
+  controller._byobRequest = undefined;
   ReadableByteStreamControllerClearPendingPullIntos(controller);
 
   // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.


### PR DESCRIPTION
`SetUpReadableByteStreamController` calls `ReadableByteStreamControllerClearPendingPullIntos`, which in turn calls `ReadableByteStreamControllerInvalidateBYOBRequest`. This last function returns early if `controller.[[byobRequest]]` is already `undefined`, which holds **even if we don't explicitly set it** to `undefined`. This means the internal slot is never really "initialized" to `undefined`, so if I understand correctly looking up the slot's value would mean going through the prototype chain to find out that the slot does not exist. (At least, until the first BYOB request comes in and gives it an actual value.)

This change explicitly initializes `ReadableByteStreamController.[[byobRequest]]` to `undefined`. We already do this for other internal slots (such as `ReadableStream.[[storedError]]` or `WritableStream.[[closeRequest]]`), so it seemed appropriate to also do it for `[[byobRequest]]`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/990.html" title="Last updated on Feb 18, 2019, 11:25 PM UTC (0560f36)">Preview</a> | <a href="https://whatpr.org/streams/990/ddfba5f...0560f36.html" title="Last updated on Feb 18, 2019, 11:25 PM UTC (0560f36)">Diff</a>