### PR TITLE
Remove call to ClearPendingPullIntos from SetUpReadableByteSC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2967,7 +2967,6 @@ throws>SetUpReadableByteStreamController ( <var>stream</var>, <var>controller</v
   1. Set _controller_.[[controlledReadableByteStream]] to _stream_.
   1. Set _controller_.[[pullAgain]] and _controller_.[[pulling]] to *false*.
   1. Set _controller_.[[byobRequest]] to *undefined*.
-  1. Perform ! ReadableByteStreamControllerClearPendingPullIntos(_controller_).
   1. Perform ! ResetQueue(_controller_).
   1. Set _controller_.[[closeRequested]] and _controller_.[[started]] to *false*.
   1. Set _controller_.[[strategyHWM]] to ? ValidateAndNormalizeHighWaterMark(_highWaterMark_).
@@ -6118,6 +6117,7 @@ isonmad,
 Jake Archibald,
 Jake Verbaten,
 Janessa Det,
+Jason Orendorff,
 Jens Nockert,
 Lennart Grahl,
 Mangala Sadhu Sangeet Singh Khalsa,

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -2050,7 +2050,6 @@ function SetUpReadableByteStreamController(stream, controller, startAlgorithm, p
   controller._pulling = false;
 
   controller._byobRequest = undefined;
-  ReadableByteStreamControllerClearPendingPullIntos(controller);
 
   // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
   controller._queue = controller._queueTotalSize = undefined;


### PR DESCRIPTION
SetUpReadableByteStreamController calls
ReadableByteStreamControllerClearPendingPullIntos to initialise the
[[byobRequest]] and [[pendingPullIntos]] internal slots. However, these
slots are also initialised directly, so the call is unneeded. Remove it.

Also add Jason Orendorff to the acknowledgements.

No functional changes.

Fixes #975.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/993.html" title="Last updated on Feb 19, 2019, 3:02 PM UTC (7a80ab0)">Preview</a> | <a href="https://whatpr.org/streams/993/fd9827d...7a80ab0.html" title="Last updated on Feb 19, 2019, 3:02 PM UTC (7a80ab0)">Diff</a>