### PR TITLE
In ReadableStreamTee, replace _closedOrErrored_ with _closed_

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1047,7 +1047,7 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Assert: ! IsReadableStream(_stream_) is *true*.
   1. Assert: Type(_cloneForBranch2_) is Boolean.
   1. Let _reader_ be ? AcquireReadableStreamDefaultReader(_stream_).
-  1. Let _closedOrErrored_ be *false*.
+  1. Let _closed_ be *false*.
   1. Let _canceled1_ be *false*.
   1. Let _canceled2_ be *false*.
   1. Let _reason1_ be *undefined*.
@@ -1058,17 +1058,18 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Let _pullAlgorithm_ be the following steps:
     1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
        which takes the argument _result_ and performs the following steps:
+      1. If _closed_ is *true*, return.
       1. Assert: Type(_result_) is Object.
-      1. Let _value_ be ? Get(_result_, `"value"`).
-      1. Let _done_ be ? Get(_result_, `"done"`).
+      1. Let _done_ be ! Get(_result_, `"done"`).
       1. Assert: Type(_done_) is Boolean.
-      1. If _done_ is *true* and _closedOrErrored_ is *false*,
+      1. If _done_ is *true*,
         1. If _canceled1_ is *false*,
           1. Perform ! ReadableStreamDefaultControllerClose(_branch1_.[[readableStreamController]]).
         1. If _canceled2_ is *false*,
           1. Perform ! ReadableStreamDefaultControllerClose(_branch2_.[[readableStreamController]]).
-        1. Set _closedOrErrored_ to *true*.
-      1. If _closedOrErrored_ is *true*, return.
+        1. Set _closed_ to *true*.
+        1. Return.
+      1. Let _value_ be ! Get(_result_, `"value"`).
       1. Let _value1_ and _value2_ be _value_.
       1. If _canceled2_ is *false* and _cloneForBranch2_ is *true*, set _value2_ to ? <a
          abstract-op>StructuredDeserialize</a>(? <a abstract-op>StructuredSerialize</a>(_value2_), the current Realm
@@ -1097,10 +1098,8 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Set _branch1_ to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel1Algorithm_).
   1. Set _branch2_ to ! CreateReadableStream(_startAlgorithm_, _pullAlgorithm_, _cancel2Algorithm_).
   1. <a>Upon rejection</a> of _reader_.[[closedPromise]] with reason _r_,
-    1. If _closedOrErrored_ is *false*, then:
-      1. Perform ! ReadableStreamDefaultControllerError(_branch1_.[[readableStreamController]], _r_).
-      1. Perform ! ReadableStreamDefaultControllerError(_branch2_.[[readableStreamController]], _r_).
-      1. Set _closedOrErrored_ to *true*.
+    1. Perform ! ReadableStreamDefaultControllerError(_branch1_.[[readableStreamController]], _r_).
+    1. Perform ! ReadableStreamDefaultControllerError(_branch2_.[[readableStreamController]], _r_).
   1. Return « _branch1_, _branch2_ ».
 </emu-alg>
 


### PR DESCRIPTION
DefaultReaderRead will never resolve after the [[closedPromise]] has rejected,
therefore setting _closedOrErrored_ on rejection makes no difference. Rename the
variable to just _closed_ and only use it to signal that a read has returned
with "done" set to true.

Also change the lookups of "done" and "value" in ReadableStreamTee from "? Get"
to "! Get" as they can never throw, and pullAlgorithm returning an abrupt
completion is not supported anyway.

Rearrange the steps slightly to reduce redundant work.

Closes #991.