### PR TITLE
Simplify [@@asyncIterator]().next()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -866,10 +866,10 @@ prototype, are created with the internal slots described in the following table:
   1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
      which takes the argument _result_ and performs the following steps:
     1. Assert: Type(_result_) is Object.
-    1. Let _value_ be ? Get(_result_, `"value"`).
-    1. Let _done_ be ? Get(_result_, `"done"`).
+    1. Let _done_ be ! Get(_result_, `"done"`).
     1. Assert: Type(_done_) is Boolean.
     1. If _done_ is *true*, perform ! ReadableStreamReaderGenericRelease(_reader_).
+    1. Let _value_ be ! Get(_result_, `"value"`).
     1. Return ! ReadableStreamCreateReadResult(_value_, _done_, *true*).
 </emu-alg>
 

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -183,12 +183,12 @@ const ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf({
     }
     return ReadableStreamDefaultReaderRead(reader).then(result => {
       assert(typeIsObject(result));
-      const value = result.value;
       const done = result.done;
       assert(typeof done === 'boolean');
       if (done) {
         ReadableStreamReaderGenericRelease(reader);
       }
+      const value = result.value;
       return ReadableStreamCreateReadResult(value, done, true);
     });
   },


### PR DESCRIPTION
See [this comment](https://github.com/whatwg/streams/pull/994#discussion_r258917942) on #994.

- Assert that getting `value` and `done` from `result` cannot throw.
- Rearrange the steps slightly to reduce redundant work.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/995.html" title="Last updated on Feb 21, 2019, 8:35 PM UTC (c2e92b1)">Preview</a> | <a href="https://whatpr.org/streams/995/a441f59...c2e92b1.html" title="Last updated on Feb 21, 2019, 8:35 PM UTC (c2e92b1)">Diff</a>