### PR TITLE
ReadableStreamTee: do not read when already pulling

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1058,8 +1058,8 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Let _pullAlgorithm_ be the following steps:
     1. If _reading_ is *true*, return <a>a promise resolved with</a> *undefined*.
     1. Set _reading_ to *true*.
-    1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
-       which takes the argument _result_ and performs the following steps:
+    1. Let _readPromise_ be the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a
+       fulfillment handler which takes the argument _result_ and performs the following steps:
       1. Set _reading_ to *false*.
       1. Assert: Type(_result_) is Object.
       1. Let _done_ be ! Get(_result_, `"done"`).
@@ -1079,6 +1079,8 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
          ReadableStreamDefaultControllerEnqueue(_branch1_.[[readableStreamController]], _value1_).
       1. If _canceled2_ is *false*, perform ?
          ReadableStreamDefaultControllerEnqueue(_branch2_.[[readableStreamController]], _value2_).
+    1. Set _readPromise_.[[PromiseIsHandled]] to *true*.
+    1. Return <a>a promise resolved with</a> *undefined*.
   1. Let _cancel1Algorithm_ be the following steps, taking a _reason_ argument:
     1. Set _canceled1_ to *true*.
     1. Set _reason1_ to _reason_.

--- a/index.bs
+++ b/index.bs
@@ -1048,7 +1048,6 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Assert: Type(_cloneForBranch2_) is Boolean.
   1. Let _reader_ be ? AcquireReadableStreamDefaultReader(_stream_).
   1. Let _pulling_ be *false*.
-  1. Let _closed_ be *false*.
   1. Let _canceled1_ be *false*.
   1. Let _canceled2_ be *false*.
   1. Let _reason1_ be *undefined*.
@@ -1062,7 +1061,6 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
     1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
        which takes the argument _result_ and performs the following steps:
       1. Set _pulling_ to *false*.
-      1. If _closed_ is *true*, return.
       1. Assert: Type(_result_) is Object.
       1. Let _done_ be ! Get(_result_, `"done"`).
       1. Assert: Type(_done_) is Boolean.
@@ -1071,7 +1069,6 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
           1. Perform ! ReadableStreamDefaultControllerClose(_branch1_.[[readableStreamController]]).
         1. If _canceled2_ is *false*,
           1. Perform ! ReadableStreamDefaultControllerClose(_branch2_.[[readableStreamController]]).
-        1. Set _closed_ to *true*.
         1. Return.
       1. Let _value_ be ! Get(_result_, `"value"`).
       1. Let _value1_ and _value2_ be _value_.

--- a/index.bs
+++ b/index.bs
@@ -1047,7 +1047,7 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Assert: ! IsReadableStream(_stream_) is *true*.
   1. Assert: Type(_cloneForBranch2_) is Boolean.
   1. Let _reader_ be ? AcquireReadableStreamDefaultReader(_stream_).
-  1. Let _pulling_ be *false*.
+  1. Let _reading_ be *false*.
   1. Let _canceled1_ be *false*.
   1. Let _canceled2_ be *false*.
   1. Let _reason1_ be *undefined*.
@@ -1056,11 +1056,11 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Let _branch2_ be *undefined*.
   1. Let _cancelPromise_ be <a>a new promise</a>.
   1. Let _pullAlgorithm_ be the following steps:
-    1. If _pulling_ is *true*, return <a>a promise resolved with</a> *undefined*.
-    1. Set _pulling_ to *true*.
+    1. If _reading_ is *true*, return <a>a promise resolved with</a> *undefined*.
+    1. Set _reading_ to *true*.
     1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
        which takes the argument _result_ and performs the following steps:
-      1. Set _pulling_ to *false*.
+      1. Set _reading_ to *false*.
       1. Assert: Type(_result_) is Object.
       1. Let _done_ be ! Get(_result_, `"done"`).
       1. Assert: Type(_done_) is Boolean.

--- a/index.bs
+++ b/index.bs
@@ -1047,6 +1047,7 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Assert: ! IsReadableStream(_stream_) is *true*.
   1. Assert: Type(_cloneForBranch2_) is Boolean.
   1. Let _reader_ be ? AcquireReadableStreamDefaultReader(_stream_).
+  1. Let _pulling_ be *false*.
   1. Let _closed_ be *false*.
   1. Let _canceled1_ be *false*.
   1. Let _canceled2_ be *false*.
@@ -1056,8 +1057,11 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Let _branch2_ be *undefined*.
   1. Let _cancelPromise_ be <a>a new promise</a>.
   1. Let _pullAlgorithm_ be the following steps:
+    1. If _pulling_ is *true*, return <a>a promise resolved with</a> *undefined*.
+    1. Set _pulling_ to *true*.
     1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
        which takes the argument _result_ and performs the following steps:
+      1. Set _pulling_ to *false*.
       1. If _closed_ is *true*, return.
       1. Assert: Type(_result_) is Object.
       1. Let _done_ be ! Get(_result_, `"done"`).

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -540,6 +540,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
 
   const reader = AcquireReadableStreamDefaultReader(stream);
 
+  let pulling = false;
   let closed = false;
   let canceled1 = false;
   let canceled2 = false;
@@ -554,7 +555,15 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   });
 
   function pullAlgorithm() {
+    if (pulling === true) {
+      return Promise.resolve();
+    }
+
+    pulling = true;
+
     return ReadableStreamDefaultReaderRead(reader).then(result => {
+      pulling = false;
+
       if (closed === true) {
         return;
       }

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -560,7 +560,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
 
     reading = true;
 
-    const pullPromise = ReadableStreamDefaultReaderRead(reader).then(result => {
+    const readPromise = ReadableStreamDefaultReaderRead(reader).then(result => {
       reading = false;
 
       assert(typeIsObject(result));
@@ -596,12 +596,9 @@ function ReadableStreamTee(stream, cloneForBranch2) {
       }
     });
 
-    // If pullPromise rejects with an AssertionError, but the branch is already closed or errored,
-    // the rejection will be silently ignored by ReadableStreamDefaultControllerError.
-    // We have to manually rethrow any AssertionError to make sure they are not ignored.
-    pullPromise.catch(rethrowAssertionErrorRejection);
+    readPromise.catch(rethrowAssertionErrorRejection);
 
-    return pullPromise;
+    return Promise.resolve();
   }
 
   function cancel1Algorithm(reason) {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -540,7 +540,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
 
   const reader = AcquireReadableStreamDefaultReader(stream);
 
-  let pulling = false;
+  let reading = false;
   let canceled1 = false;
   let canceled2 = false;
   let reason1;
@@ -554,14 +554,14 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   });
 
   function pullAlgorithm() {
-    if (pulling === true) {
+    if (reading === true) {
       return Promise.resolve();
     }
 
-    pulling = true;
+    reading = true;
 
     const pullPromise = ReadableStreamDefaultReaderRead(reader).then(result => {
-      pulling = false;
+      reading = false;
 
       assert(typeIsObject(result));
       const done = result.done;

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -541,7 +541,6 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   const reader = AcquireReadableStreamDefaultReader(stream);
 
   let pulling = false;
-  let closed = false;
   let canceled1 = false;
   let canceled2 = false;
   let reason1;
@@ -564,10 +563,6 @@ function ReadableStreamTee(stream, cloneForBranch2) {
     return ReadableStreamDefaultReaderRead(reader).then(result => {
       pulling = false;
 
-      if (closed === true) {
-        return;
-      }
-
       assert(typeIsObject(result));
       const done = result.done;
       assert(typeof done === 'boolean');
@@ -579,7 +574,6 @@ function ReadableStreamTee(stream, cloneForBranch2) {
         if (canceled2 === false) {
           ReadableStreamDefaultControllerClose(branch2._readableStreamController);
         }
-        closed = true;
         return;
       }
 


### PR DESCRIPTION
Currently, when one branch calls `pull()`, it is possible that we call `read()` - even though a `read()` is still pending from a previous `pull()` call by the other branch. This can lead to reading too many chunks from the original streams, and unnecessarily filling up the queues of the branches past their high water mark.

This PR fixes that issue by *only* starting a new `read()` if the previous `read()` was resolved. As a bonus, there will now be only one `read()` that resolves with `{ done: true }` when the original stream closes, so we no longer need to keep track of whether we already closed the two branches.

WPT PR: web-platform-tests/wpt#16167

Fixes #996


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/997.html" title="Last updated on Apr 2, 2019, 5:36 AM UTC (71ccbcd)">Preview</a> | <a href="https://whatpr.org/streams/997/2c8f35e...71ccbcd.html" title="Last updated on Apr 2, 2019, 5:36 AM UTC (71ccbcd)">Diff</a>