### PR TITLE
Fix pipe not aborting when both preventAbort and preventCancel are set

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -175,6 +175,10 @@ exports.WaitForAll = (promises, successSteps, failureSteps) => {
   let fulfilledCount = 0;
   const total = promises.length;
   const result = new Array(total);
+  if (total === 0) {
+    queueMicrotask(() => successSteps(result));
+    return;
+  }
   for (const promise of promises) {
     const promiseIndex = index;
     const fulfillmentHandler = arg => {

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -37,6 +37,7 @@ async function main() {
   const failures = await wptRunner(testsPath, {
     rootURL: 'streams/',
     setup(window) {
+      window.queueMicrotask = queueMicrotask;
       window.eval(bundledJS);
     },
     filter(testPath) {


### PR DESCRIPTION
When both flags are set, the _abortAlgorithm_ passes an empty list of actions to ["wait for all"](https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all). This helper should immediately resolve the returned promise when no promises are given, but instead the promise remained pending forever.

This fixes the reference implementation of the "wait for all" helper to resolve correctly when given an empty list of promises. This matches the spec change in w3ctag/promises-guide#58.

Originally reported in [this comment](https://github.com/whatwg/streams/issues/1004#issuecomment-511037767) on #1004.

WPT: web-platform-tests/wpt#17816