### PR TITLE
Add helpers to use initial values of Promise methods

### DIFF
--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -200,12 +200,17 @@ function uponRejection(promise, onRejected) {
   uponPromise(promise, undefined, onRejected);
 }
 
+function setPromiseIsHandledToTrue(promise) {
+  PerformPromiseThen(promise, undefined, rethrowAssertionErrorRejection);
+}
+
 exports.newPromise = newPromise;
 exports.promiseResolvedWith = promiseResolvedWith;
 exports.promiseRejectedWith = promiseRejectedWith;
 exports.uponPromise = uponPromise;
 exports.uponFulfillment = uponFulfillment;
 exports.uponRejection = uponRejection;
+exports.setPromiseIsHandledToTrue = setPromiseIsHandledToTrue;
 
 exports.PerformPromiseThen = PerformPromiseThen;
 exports.PerformPromiseCatch = PerformPromiseCatch;

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -110,7 +110,7 @@ function PromiseCall(F, V, args) {
   try {
     return PromiseResolve(Call(F, V, args));
   } catch (value) {
-    return Promise.reject(value);
+    return PromiseReject(value);
   }
 }
 

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -1,5 +1,6 @@
 'use strict';
 const assert = require('assert');
+const { rethrowAssertionErrorRejection } = require('./utils.js');
 
 const isFakeDetached = Symbol('is "detached" for our purposes');
 
@@ -184,9 +185,28 @@ function PerformPromiseCatch(promise, onRejected) {
   return PerformPromiseThen(promise, undefined, onRejected);
 }
 
+function uponPromise(promise, onFulfilled, onRejected) {
+  PerformPromiseCatch(
+    PerformPromiseThen(promise, onFulfilled, onRejected),
+    rethrowAssertionErrorRejection
+  );
+}
+
+function uponFulfillment(promise, onFulfilled) {
+  uponPromise(promise, onFulfilled);
+}
+
+function uponRejection(promise, onRejected) {
+  uponPromise(promise, undefined, onRejected);
+}
+
 exports.newPromise = newPromise;
 exports.promiseResolvedWith = promiseResolvedWith;
 exports.promiseRejectedWith = promiseRejectedWith;
+exports.uponPromise = uponPromise;
+exports.uponFulfillment = uponFulfillment;
+exports.uponRejection = uponRejection;
+
 exports.PerformPromiseThen = PerformPromiseThen;
 exports.PerformPromiseCatch = PerformPromiseCatch;
 

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -88,7 +88,7 @@ exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, alg
       }
     }
   }
-  return () => promiseResolvedWith();
+  return () => promiseResolvedWith(undefined);
 };
 
 exports.InvokeOrNoop = (O, P, args) => {

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -218,7 +218,7 @@ exports.WaitForAll = (promises, successSteps, failureSteps) => {
 exports.WaitForAllPromise = (promises, successSteps, failureSteps = undefined) => {
   let resolvePromise;
   let rejectPromise;
-  const promise = new Promise((resolve, reject) => {
+  const promise = CreatePromise((resolve, reject) => {
     resolvePromise = resolve;
     rejectPromise = reject;
   });

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -180,10 +180,15 @@ function PerformPromiseThen(promise, onFulfilled, onRejected) {
   return originalPromiseThen.call(promise, onFulfilled, onRejected);
 }
 
+function PerformPromiseCatch(promise, onRejected) {
+  return PerformPromiseThen(promise, undefined, onRejected);
+}
+
 exports.CreatePromise = CreatePromise;
 exports.PromiseResolve = PromiseResolve;
 exports.PromiseReject = PromiseReject;
 exports.PerformPromiseThen = PerformPromiseThen;
+exports.PerformPromiseCatch = PerformPromiseCatch;
 
 exports.WaitForAll = (promises, successSteps, failureSteps) => {
   let rejected = false;

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -181,13 +181,10 @@ function PerformPromiseThen(promise, onFulfilled, onRejected) {
   return originalPromiseThen.call(promise, onFulfilled, onRejected);
 }
 
-function PerformPromiseCatch(promise, onRejected) {
-  return PerformPromiseThen(promise, undefined, onRejected);
-}
-
 function uponPromise(promise, onFulfilled, onRejected) {
-  PerformPromiseCatch(
+  PerformPromiseThen(
     PerformPromiseThen(promise, onFulfilled, onRejected),
+    undefined,
     rethrowAssertionErrorRejection
   );
 }
@@ -211,9 +208,7 @@ exports.uponPromise = uponPromise;
 exports.uponFulfillment = uponFulfillment;
 exports.uponRejection = uponRejection;
 exports.setPromiseIsHandledToTrue = setPromiseIsHandledToTrue;
-
 exports.PerformPromiseThen = PerformPromiseThen;
-exports.PerformPromiseCatch = PerformPromiseCatch;
 
 exports.WaitForAll = (promises, successSteps, failureSteps) => {
   let rejected = false;

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -162,7 +162,7 @@ const originalPromiseThen = Promise.prototype.then;
 const originalPromiseResolve = Promise.resolve;
 const originalPromiseReject = Promise.reject;
 
-function CreatePromise(executor) {
+function newPromise(executor) {
   return new originalPromise(executor);
 }
 
@@ -184,7 +184,7 @@ function PerformPromiseCatch(promise, onRejected) {
   return PerformPromiseThen(promise, undefined, onRejected);
 }
 
-exports.CreatePromise = CreatePromise;
+exports.newPromise = newPromise;
 exports.PromiseResolve = PromiseResolve;
 exports.PromiseReject = PromiseReject;
 exports.PerformPromiseThen = PerformPromiseThen;
@@ -223,7 +223,7 @@ exports.WaitForAll = (promises, successSteps, failureSteps) => {
 exports.WaitForAllPromise = (promises, successSteps, failureSteps = undefined) => {
   let resolvePromise;
   let rejectPromise;
-  const promise = CreatePromise((resolve, reject) => {
+  const promise = newPromise((resolve, reject) => {
     resolvePromise = resolve;
     rejectPromise = reject;
   });

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -87,7 +87,7 @@ exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, alg
       }
     }
   }
-  return () => PromiseResolve();
+  return () => promiseResolvedWith();
 };
 
 exports.InvokeOrNoop = (O, P, args) => {
@@ -108,7 +108,7 @@ function PromiseCall(F, V, args) {
   assert(V !== undefined);
   assert(Array.isArray(args));
   try {
-    return PromiseResolve(Call(F, V, args));
+    return promiseResolvedWith(Call(F, V, args));
   } catch (value) {
     return PromiseReject(value);
   }
@@ -166,7 +166,7 @@ function newPromise(executor) {
   return new originalPromise(executor);
 }
 
-function PromiseResolve(value) {
+function promiseResolvedWith(value) {
   return originalPromiseResolve.call(originalPromise, value);
 }
 
@@ -185,7 +185,7 @@ function PerformPromiseCatch(promise, onRejected) {
 }
 
 exports.newPromise = newPromise;
-exports.PromiseResolve = PromiseResolve;
+exports.promiseResolvedWith = promiseResolvedWith;
 exports.PromiseReject = PromiseReject;
 exports.PerformPromiseThen = PerformPromiseThen;
 exports.PerformPromiseCatch = PerformPromiseCatch;

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -213,7 +213,6 @@ exports.uponFulfillment = uponFulfillment;
 exports.uponRejection = uponRejection;
 exports.transformPromiseWith = transformPromiseWith;
 exports.setPromiseIsHandledToTrue = setPromiseIsHandledToTrue;
-exports.PerformPromiseThen = PerformPromiseThen;
 
 exports.WaitForAll = (promises, successSteps, failureSteps) => {
   let rejected = false;
@@ -240,7 +239,7 @@ exports.WaitForAll = (promises, successSteps, failureSteps) => {
         successSteps(result);
       }
     };
-    exports.PerformPromiseThen(promise, fulfillmentHandler, rejectionHandler);
+    PerformPromiseThen(promise, fulfillmentHandler, rejectionHandler);
     ++index;
   }
 };

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -87,7 +87,7 @@ exports.CreateAlgorithmFromUnderlyingMethod = (underlyingObject, methodName, alg
       }
     }
   }
-  return () => Promise.resolve();
+  return () => PromiseResolve();
 };
 
 exports.InvokeOrNoop = (O, P, args) => {
@@ -108,7 +108,7 @@ function PromiseCall(F, V, args) {
   assert(V !== undefined);
   assert(Array.isArray(args));
   try {
-    return Promise.resolve(Call(F, V, args));
+    return PromiseResolve(Call(F, V, args));
   } catch (value) {
     return Promise.reject(value);
   }

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -197,6 +197,10 @@ function uponRejection(promise, onRejected) {
   uponPromise(promise, undefined, onRejected);
 }
 
+function transformPromiseWith(promise, fulfillmentHandler, rejectionHandler) {
+  return PerformPromiseThen(promise, fulfillmentHandler, rejectionHandler);
+}
+
 function setPromiseIsHandledToTrue(promise) {
   PerformPromiseThen(promise, undefined, rethrowAssertionErrorRejection);
 }
@@ -207,6 +211,7 @@ exports.promiseRejectedWith = promiseRejectedWith;
 exports.uponPromise = uponPromise;
 exports.uponFulfillment = uponFulfillment;
 exports.uponRejection = uponRejection;
+exports.transformPromiseWith = transformPromiseWith;
 exports.setPromiseIsHandledToTrue = setPromiseIsHandledToTrue;
 exports.PerformPromiseThen = PerformPromiseThen;
 

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -110,7 +110,7 @@ function PromiseCall(F, V, args) {
   try {
     return promiseResolvedWith(Call(F, V, args));
   } catch (value) {
-    return PromiseReject(value);
+    return promiseRejectedWith(value);
   }
 }
 
@@ -170,7 +170,7 @@ function promiseResolvedWith(value) {
   return originalPromiseResolve.call(originalPromise, value);
 }
 
-function PromiseReject(reason) {
+function promiseRejectedWith(reason) {
   return originalPromiseReject.call(originalPromise, reason);
 }
 
@@ -186,7 +186,7 @@ function PerformPromiseCatch(promise, onRejected) {
 
 exports.newPromise = newPromise;
 exports.promiseResolvedWith = promiseResolvedWith;
-exports.PromiseReject = PromiseReject;
+exports.promiseRejectedWith = promiseRejectedWith;
 exports.PerformPromiseThen = PerformPromiseThen;
 exports.PerformPromiseCatch = PerformPromiseCatch;
 

--- a/reference-implementation/lib/helpers.js
+++ b/reference-implementation/lib/helpers.js
@@ -157,11 +157,33 @@ exports.MakeSizeAlgorithmFromSizeFunction = size => {
   return chunk => size(chunk);
 };
 
-exports.PerformPromiseThen = (promise, onFulfilled, onRejected) => {
+const originalPromise = Promise;
+const originalPromiseThen = Promise.prototype.then;
+const originalPromiseResolve = Promise.resolve;
+const originalPromiseReject = Promise.reject;
+
+function CreatePromise(executor) {
+  return new originalPromise(executor);
+}
+
+function PromiseResolve(value) {
+  return originalPromiseResolve.call(originalPromise, value);
+}
+
+function PromiseReject(reason) {
+  return originalPromiseReject.call(originalPromise, reason);
+}
+
+function PerformPromiseThen(promise, onFulfilled, onRejected) {
   // There doesn't appear to be any way to correctly emulate the behaviour from JavaScript, so this is just an
   // approximation.
-  return Promise.prototype.then.call(promise, onFulfilled, onRejected);
-};
+  return originalPromiseThen.call(promise, onFulfilled, onRejected);
+}
+
+exports.CreatePromise = CreatePromise;
+exports.PromiseResolve = PromiseResolve;
+exports.PromiseReject = PromiseReject;
+exports.PerformPromiseThen = PerformPromiseThen;
 
 exports.WaitForAll = (promises, successSteps, failureSteps) => {
   let rejected = false;

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -522,10 +522,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       shuttingDown = true;
 
       if (dest._state === 'writable' && WritableStreamCloseQueuedOrInFlight(dest) === false) {
-        uponFulfillment(
-          waitForWritesToFinish(),
-          () => finalize(isError, error)
-        );
+        uponFulfillment(waitForWritesToFinish(), () => finalize(isError, error));
       } else {
         finalize(isError, error);
       }

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -6,7 +6,7 @@ const { ArrayBufferCopy, CreateAlgorithmFromUnderlyingMethod, IsFiniteNonNegativ
         IsDetachedBuffer, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject, WaitForAllPromise,
         newPromise, promiseResolvedWith, promiseRejectedWith, PerformPromiseThen,
-        PerformPromiseCatch, uponPromise, uponRejection } = require('./helpers.js');
+        PerformPromiseCatch, uponPromise, uponRejection, setPromiseIsHandledToTrue } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStream, IsWritableStreamLocked,
@@ -119,7 +119,7 @@ class ReadableStream {
 
     const promise = ReadableStreamPipeTo(this, writable, preventClose, preventAbort, preventCancel, signal);
 
-    PerformPromiseCatch(promise, () => {});
+    setPromiseIsHandledToTrue(promise);
 
     return readable;
   }
@@ -467,7 +467,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       }
     }
 
-    PerformPromiseCatch(pipeLoop(), rethrowAssertionErrorRejection);
+    setPromiseIsHandledToTrue(pipeLoop());
 
     function waitForWritesToFinish() {
       // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait
@@ -619,7 +619,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
       }
     });
 
-    PerformPromiseCatch(readPromise, rethrowAssertionErrorRejection);
+    setPromiseIsHandledToTrue(readPromise);
 
     return promiseResolvedWith();
   }
@@ -772,7 +772,7 @@ function ReadableStreamError(stream, e) {
   }
 
   defaultReaderClosedPromiseReject(reader, e);
-  PerformPromiseCatch(reader._closedPromise, () => {});
+  setPromiseIsHandledToTrue(reader._closedPromise);
 }
 
 function ReadableStreamFulfillReadIntoRequest(stream, chunk, done) {
@@ -1013,7 +1013,7 @@ function ReadableStreamReaderGenericInitialize(reader, stream) {
     assert(stream._state === 'errored');
 
     defaultReaderClosedPromiseInitializeAsRejected(reader, stream._storedError);
-    PerformPromiseCatch(reader._closedPromise, () => {});
+    setPromiseIsHandledToTrue(reader._closedPromise);
   }
 }
 
@@ -1039,7 +1039,7 @@ function ReadableStreamReaderGenericRelease(reader) {
       reader,
       new TypeError('Reader was released and can no longer be used to monitor the stream\'s closedness'));
   }
-  PerformPromiseCatch(reader._closedPromise, () => {});
+  setPromiseIsHandledToTrue(reader._closedPromise);
 
   reader._ownerReadableStream._reader = undefined;
   reader._ownerReadableStream = undefined;

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -359,7 +359,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
   let shuttingDown = false;
 
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
-  let currentWrite = promiseResolvedWith();
+  let currentWrite = promiseResolvedWith(undefined);
 
   return newPromise((resolve, reject) => {
     let abortAlgorithm;
@@ -372,7 +372,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
             if (dest._state === 'writable') {
               return WritableStreamAbort(dest, error);
             }
-            return promiseResolvedWith();
+            return promiseResolvedWith(undefined);
           });
         }
         if (preventCancel === false) {
@@ -380,7 +380,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
             if (source._state === 'readable') {
               return ReadableStreamCancel(source, error);
             }
-            return promiseResolvedWith();
+            return promiseResolvedWith(undefined);
           });
         }
         shutdownWithAction(() => WaitForAllPromise(actions.map(action => action()), results => results), true, error);
@@ -568,7 +568,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
 
   function pullAlgorithm() {
     if (reading === true) {
-      return promiseResolvedWith();
+      return promiseResolvedWith(undefined);
     }
 
     reading = true;
@@ -611,7 +611,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
 
     setPromiseIsHandledToTrue(readPromise);
 
-    return promiseResolvedWith();
+    return promiseResolvedWith(undefined);
   }
 
   function cancel1Algorithm(reason) {

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const { ArrayBufferCopy, CreateAlgorithmFromUnderlyingMethod, IsFiniteNonNegativeNumber, InvokeOrNoop,
         IsDetachedBuffer, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject, WaitForAllPromise,
-        CreatePromise, PromiseResolve, PromiseReject, PerformPromiseThen,
+        newPromise, PromiseResolve, PromiseReject, PerformPromiseThen,
         PerformPromiseCatch } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
@@ -356,7 +356,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
   let currentWrite = PromiseResolve();
 
-  return CreatePromise((resolve, reject) => {
+  return newPromise((resolve, reject) => {
     let abortAlgorithm;
     if (signal !== undefined) {
       abortAlgorithm = () => {
@@ -393,7 +393,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     // - Backpressure must be enforced
     // - Shutdown must stop all activity
     function pipeLoop() {
-      return CreatePromise((resolveLoop, rejectLoop) => {
+      return newPromise((resolveLoop, rejectLoop) => {
         function next(done) {
           if (done) {
             resolveLoop();
@@ -569,7 +569,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   let branch2;
 
   let resolveCancelPromise;
-  const cancelPromise = CreatePromise(resolve => {
+  const cancelPromise = newPromise(resolve => {
     resolveCancelPromise = resolve;
   });
 
@@ -662,7 +662,7 @@ function ReadableStreamAddReadIntoRequest(stream) {
   assert(IsReadableStreamBYOBReader(stream._reader) === true);
   assert(stream._state === 'readable' || stream._state === 'closed');
 
-  const promise = CreatePromise((resolve, reject) => {
+  const promise = newPromise((resolve, reject) => {
     const readIntoRequest = {
       _resolve: resolve,
       _reject: reject
@@ -678,7 +678,7 @@ function ReadableStreamAddReadRequest(stream) {
   assert(IsReadableStreamDefaultReader(stream._reader) === true);
   assert(stream._state === 'readable');
 
-  const promise = CreatePromise((resolve, reject) => {
+  const promise = newPromise((resolve, reject) => {
     const readRequest = {
       _resolve: resolve,
       _reject: reject
@@ -2184,7 +2184,7 @@ function defaultReaderBrandCheckException(name) {
 }
 
 function defaultReaderClosedPromiseInitialize(reader) {
-  reader._closedPromise = CreatePromise((resolve, reject) => {
+  reader._closedPromise = newPromise((resolve, reject) => {
     reader._closedPromise_resolve = resolve;
     reader._closedPromise_reject = reject;
   });

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -4,8 +4,8 @@
 const assert = require('assert');
 const { ArrayBufferCopy, CreateAlgorithmFromUnderlyingMethod, IsFiniteNonNegativeNumber, InvokeOrNoop,
         IsDetachedBuffer, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
-        MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject, WaitForAllPromise } =
-      require('./helpers.js');
+        MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject, WaitForAllPromise,
+        CreatePromise } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStream, IsWritableStreamLocked,
@@ -355,7 +355,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
   let currentWrite = Promise.resolve();
 
-  return new Promise((resolve, reject) => {
+  return CreatePromise((resolve, reject) => {
     let abortAlgorithm;
     if (signal !== undefined) {
       abortAlgorithm = () => {
@@ -392,7 +392,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     // - Backpressure must be enforced
     // - Shutdown must stop all activity
     function pipeLoop() {
-      return new Promise((resolveLoop, rejectLoop) => {
+      return CreatePromise((resolveLoop, rejectLoop) => {
         function next(done) {
           if (done) {
             resolveLoop();
@@ -549,7 +549,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   let branch2;
 
   let resolveCancelPromise;
-  const cancelPromise = new Promise(resolve => {
+  const cancelPromise = CreatePromise(resolve => {
     resolveCancelPromise = resolve;
   });
 
@@ -642,7 +642,7 @@ function ReadableStreamAddReadIntoRequest(stream) {
   assert(IsReadableStreamBYOBReader(stream._reader) === true);
   assert(stream._state === 'readable' || stream._state === 'closed');
 
-  const promise = new Promise((resolve, reject) => {
+  const promise = CreatePromise((resolve, reject) => {
     const readIntoRequest = {
       _resolve: resolve,
       _reject: reject
@@ -658,7 +658,7 @@ function ReadableStreamAddReadRequest(stream) {
   assert(IsReadableStreamDefaultReader(stream._reader) === true);
   assert(stream._state === 'readable');
 
-  const promise = new Promise((resolve, reject) => {
+  const promise = CreatePromise((resolve, reject) => {
     const readRequest = {
       _resolve: resolve,
       _reject: reject
@@ -2148,7 +2148,7 @@ function defaultReaderBrandCheckException(name) {
 }
 
 function defaultReaderClosedPromiseInitialize(reader) {
-  reader._closedPromise = new Promise((resolve, reject) => {
+  reader._closedPromise = CreatePromise((resolve, reject) => {
     reader._closedPromise_resolve = resolve;
     reader._closedPromise_reject = reject;
   });

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const { ArrayBufferCopy, CreateAlgorithmFromUnderlyingMethod, IsFiniteNonNegativeNumber, InvokeOrNoop,
         IsDetachedBuffer, TransferArrayBuffer, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, createArrayFromList, typeIsObject, WaitForAllPromise,
-        newPromise, promiseResolvedWith, promiseRejectedWith, PerformPromiseThen, PerformPromiseCatch,
+        newPromise, promiseResolvedWith, promiseRejectedWith, PerformPromiseThen,
         uponPromise, uponFulfillment, uponRejection, setPromiseIsHandledToTrue } = require('./helpers.js');
 const { DequeueValue, EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStream, IsWritableStreamLocked,
@@ -422,7 +422,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
             return true;
           }
 
-          currentWrite = PerformPromiseCatch(WritableStreamDefaultWriterWrite(writer, value), () => {});
+          currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, value), undefined, () => {});
           return false;
         });
       });

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber, MakeSizeAlgorithmFromSizeFunction, newPromise,
-        promiseResolvedWith, PromiseReject, PerformPromiseThen } = require('./helpers.js');
+        promiseResolvedWith, promiseRejectedWith, PerformPromiseThen } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -270,7 +270,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
       TransformStreamDefaultControllerEnqueue(controller, chunk);
       return promiseResolvedWith();
     } catch (transformResultE) {
-      return PromiseReject(transformResultE);
+      return promiseRejectedWith(transformResultE);
     }
   };
   const transformMethod = transformer.transform;

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -130,7 +130,7 @@ function InitializeTransformStream(stream, startPromise, writableHighWaterMark, 
 
   function cancelAlgorithm(reason) {
     TransformStreamErrorWritableAndUnblockWrite(stream, reason);
-    return promiseResolvedWith();
+    return promiseResolvedWith(undefined);
   }
 
   stream._readable = CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, readableHighWaterMark,
@@ -268,7 +268,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
   let transformAlgorithm = chunk => {
     try {
       TransformStreamDefaultControllerEnqueue(controller, chunk);
-      return promiseResolvedWith();
+      return promiseResolvedWith(undefined);
     } catch (transformResultE) {
       return promiseRejectedWith(transformResultE);
     }
@@ -375,7 +375,7 @@ function TransformStreamDefaultSinkAbortAlgorithm(stream, reason) {
   // abort() is not called synchronously, so it is possible for abort() to be called when the stream is already
   // errored.
   TransformStreamError(stream, reason);
-  return promiseResolvedWith();
+  return promiseResolvedWith(undefined);
 }
 
 function TransformStreamDefaultSinkCloseAlgorithm(stream) {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -7,7 +7,7 @@ const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction,
-        CreatePromise, PromiseResolve } = require('./helpers.js');
+        CreatePromise, PromiseResolve, PromiseReject } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -271,7 +271,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
       TransformStreamDefaultControllerEnqueue(controller, chunk);
       return PromiseResolve();
     } catch (transformResultE) {
-      return Promise.reject(transformResultE);
+      return PromiseReject(transformResultE);
     }
   };
   const transformMethod = transformer.transform;

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -7,7 +7,7 @@ const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction,
-        CreatePromise, PromiseResolve, PromiseReject } = require('./helpers.js');
+        CreatePromise, PromiseResolve, PromiseReject, PerformPromiseThen } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -358,7 +358,7 @@ function TransformStreamDefaultSinkWriteAlgorithm(stream, chunk) {
   if (stream._backpressure === true) {
     const backpressureChangePromise = stream._backpressureChangePromise;
     assert(backpressureChangePromise !== undefined);
-    return backpressureChangePromise.then(() => {
+    return PerformPromiseThen(backpressureChangePromise, () => {
       const writable = stream._writable;
       const state = writable._state;
       if (state === 'erroring') {
@@ -390,7 +390,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
   TransformStreamDefaultControllerClearAlgorithms(controller);
 
   // Return a promise that is fulfilled with undefined on success.
-  return flushPromise.then(() => {
+  return PerformPromiseThen(flushPromise, () => {
     if (readable._state === 'errored') {
       throw readable._storedError;
     }

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 // and do not appear in the standard text.
 const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
-        ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber, MakeSizeAlgorithmFromSizeFunction, CreatePromise,
+        ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber, MakeSizeAlgorithmFromSizeFunction, newPromise,
         PromiseResolve, PromiseReject, PerformPromiseThen } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
@@ -47,7 +47,7 @@ class TransformStream {
     readableHighWaterMark = ValidateAndNormalizeHighWaterMark(readableHighWaterMark);
 
     let startPromise_resolve;
-    const startPromise = CreatePromise(resolve => {
+    const startPromise = newPromise(resolve => {
       startPromise_resolve = resolve;
     });
 
@@ -87,7 +87,7 @@ function CreateTransformStream(startAlgorithm, transformAlgorithm, flushAlgorith
   const stream = Object.create(TransformStream.prototype);
 
   let startPromise_resolve;
-  const startPromise = CreatePromise(resolve => {
+  const startPromise = newPromise(resolve => {
     startPromise_resolve = resolve;
   });
 
@@ -187,7 +187,7 @@ function TransformStreamSetBackpressure(stream, backpressure) {
     stream._backpressureChangePromise_resolve();
   }
 
-  stream._backpressureChangePromise = CreatePromise(resolve => {
+  stream._backpressureChangePromise = newPromise(resolve => {
     stream._backpressureChangePromise_resolve = resolve;
   });
 

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber, MakeSizeAlgorithmFromSizeFunction, newPromise,
-        PromiseResolve, PromiseReject, PerformPromiseThen } = require('./helpers.js');
+        promiseResolvedWith, PromiseReject, PerformPromiseThen } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -130,7 +130,7 @@ function InitializeTransformStream(stream, startPromise, writableHighWaterMark, 
 
   function cancelAlgorithm(reason) {
     TransformStreamErrorWritableAndUnblockWrite(stream, reason);
-    return PromiseResolve();
+    return promiseResolvedWith();
   }
 
   stream._readable = CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, readableHighWaterMark,
@@ -268,7 +268,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
   let transformAlgorithm = chunk => {
     try {
       TransformStreamDefaultControllerEnqueue(controller, chunk);
-      return PromiseResolve();
+      return promiseResolvedWith();
     } catch (transformResultE) {
       return PromiseReject(transformResultE);
     }
@@ -375,7 +375,7 @@ function TransformStreamDefaultSinkAbortAlgorithm(stream, reason) {
   // abort() is not called synchronously, so it is possible for abort() to be called when the stream is already
   // errored.
   TransformStreamError(stream, reason);
-  return PromiseResolve();
+  return promiseResolvedWith();
 }
 
 function TransformStreamDefaultSinkCloseAlgorithm(stream) {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -389,7 +389,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
   TransformStreamDefaultControllerClearAlgorithms(controller);
 
   // Return a promise that is fulfilled with undefined on success.
-  return PerformPromiseCatch(PerformPromiseThen(flushPromise, () => {
+  return PerformPromiseThen(flushPromise, () => {
     if (readable._state === 'errored') {
       throw readable._storedError;
     }
@@ -400,7 +400,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
   }, r => {
     TransformStreamError(stream, r);
     throw readable._storedError;
-  }));
+  });
 }
 
 // TransformStreamDefaultSource Algorithms

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber, MakeSizeAlgorithmFromSizeFunction, CreatePromise,
-        PromiseResolve, PromiseReject, PerformPromiseThen, PerformPromiseCatch } = require('./helpers.js');
+        PromiseResolve, PromiseReject, PerformPromiseThen } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -325,7 +325,7 @@ function TransformStreamDefaultControllerError(controller, e) {
 
 function TransformStreamDefaultControllerPerformTransform(controller, chunk) {
   const transformPromise = controller._transformAlgorithm(chunk);
-  return PerformPromiseCatch(transformPromise, r => {
+  return PerformPromiseThen(transformPromise, undefined, r => {
     TransformStreamError(controller._controlledTransformStream, r);
     throw r;
   });

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -7,7 +7,7 @@ const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction,
-        CreatePromise } = require('./helpers.js');
+        CreatePromise, PromiseResolve } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -131,7 +131,7 @@ function InitializeTransformStream(stream, startPromise, writableHighWaterMark, 
 
   function cancelAlgorithm(reason) {
     TransformStreamErrorWritableAndUnblockWrite(stream, reason);
-    return Promise.resolve();
+    return PromiseResolve();
   }
 
   stream._readable = CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, readableHighWaterMark,
@@ -269,7 +269,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
   let transformAlgorithm = chunk => {
     try {
       TransformStreamDefaultControllerEnqueue(controller, chunk);
-      return Promise.resolve();
+      return PromiseResolve();
     } catch (transformResultE) {
       return Promise.reject(transformResultE);
     }
@@ -376,7 +376,7 @@ function TransformStreamDefaultSinkAbortAlgorithm(stream, reason) {
   // abort() is not called synchronously, so it is possible for abort() to be called when the stream is already
   // errored.
   TransformStreamError(stream, reason);
-  return Promise.resolve();
+  return PromiseResolve();
 }
 
 function TransformStreamDefaultSinkCloseAlgorithm(stream) {

--- a/reference-implementation/lib/transform-stream.js
+++ b/reference-implementation/lib/transform-stream.js
@@ -6,7 +6,8 @@ const assert = require('assert');
 const verbose = require('debug')('streams:transform-stream:verbose');
 const { InvokeOrNoop, CreateAlgorithmFromUnderlyingMethod, PromiseCall, typeIsObject,
         ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
-        MakeSizeAlgorithmFromSizeFunction } = require('./helpers.js');
+        MakeSizeAlgorithmFromSizeFunction,
+        CreatePromise } = require('./helpers.js');
 const { CreateReadableStream, ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue,
         ReadableStreamDefaultControllerError, ReadableStreamDefaultControllerGetDesiredSize,
         ReadableStreamDefaultControllerHasBackpressure,
@@ -47,7 +48,7 @@ class TransformStream {
     readableHighWaterMark = ValidateAndNormalizeHighWaterMark(readableHighWaterMark);
 
     let startPromise_resolve;
-    const startPromise = new Promise(resolve => {
+    const startPromise = CreatePromise(resolve => {
       startPromise_resolve = resolve;
     });
 
@@ -87,7 +88,7 @@ function CreateTransformStream(startAlgorithm, transformAlgorithm, flushAlgorith
   const stream = Object.create(TransformStream.prototype);
 
   let startPromise_resolve;
-  const startPromise = new Promise(resolve => {
+  const startPromise = CreatePromise(resolve => {
     startPromise_resolve = resolve;
   });
 
@@ -187,7 +188,7 @@ function TransformStreamSetBackpressure(stream, backpressure) {
     stream._backpressureChangePromise_resolve();
   }
 
-  stream._backpressureChangePromise = new Promise(resolve => {
+  stream._backpressureChangePromise = CreatePromise(resolve => {
     stream._backpressureChangePromise_resolve = resolve;
   });
 

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const verbose = require('debug')('streams:writable-stream:verbose');
 
 const { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
-        MakeSizeAlgorithmFromSizeFunction, typeIsObject } = require('./helpers.js');
+        MakeSizeAlgorithmFromSizeFunction, typeIsObject, CreatePromise } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
@@ -175,7 +175,7 @@ function WritableStreamAbort(stream, reason) {
     reason = undefined;
   }
 
-  const promise = new Promise((resolve, reject) => {
+  const promise = CreatePromise((resolve, reject) => {
     stream._pendingAbortRequest = {
       _resolve: resolve,
       _reject: reject,
@@ -198,7 +198,7 @@ function WritableStreamAddWriteRequest(stream) {
   assert(IsWritableStreamLocked(stream) === true);
   assert(stream._state === 'writable');
 
-  const promise = new Promise((resolve, reject) => {
+  const promise = CreatePromise((resolve, reject) => {
     const writeRequest = {
       _resolve: resolve,
       _reject: reject
@@ -573,7 +573,7 @@ function WritableStreamDefaultWriterClose(writer) {
   assert(state === 'writable' || state === 'erroring');
   assert(WritableStreamCloseQueuedOrInFlight(stream) === false);
 
-  const promise = new Promise((resolve, reject) => {
+  const promise = CreatePromise((resolve, reject) => {
     const closeRequest = {
       _resolve: resolve,
       _reject: reject
@@ -968,7 +968,7 @@ function defaultWriterLockException(name) {
 }
 
 function defaultWriterClosedPromiseInitialize(writer) {
-  writer._closedPromise = new Promise((resolve, reject) => {
+  writer._closedPromise = CreatePromise((resolve, reject) => {
     writer._closedPromise_resolve = resolve;
     writer._closedPromise_reject = reject;
     writer._closedPromiseState = 'pending';
@@ -1022,7 +1022,7 @@ function defaultWriterClosedPromiseResolve(writer) {
 
 function defaultWriterReadyPromiseInitialize(writer) {
   verbose('defaultWriterReadyPromiseInitialize()');
-  writer._readyPromise = new Promise((resolve, reject) => {
+  writer._readyPromise = CreatePromise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
     writer._readyPromise_reject = reject;
   });
@@ -1061,7 +1061,7 @@ function defaultWriterReadyPromiseReset(writer) {
   assert(writer._readyPromise_resolve === undefined);
   assert(writer._readyPromise_reject === undefined);
 
-  writer._readyPromise = new Promise((resolve, reject) => {
+  writer._readyPromise = CreatePromise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
     writer._readyPromise_reject = reject;
   });

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const verbose = require('debug')('streams:writable-stream:verbose');
 
 const { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
-        MakeSizeAlgorithmFromSizeFunction, typeIsObject, CreatePromise } = require('./helpers.js');
+        MakeSizeAlgorithmFromSizeFunction, typeIsObject, CreatePromise, PromiseResolve } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
@@ -160,7 +160,7 @@ function IsWritableStreamLocked(stream) {
 function WritableStreamAbort(stream, reason) {
   const state = stream._state;
   if (state === 'closed' || state === 'errored') {
-    return Promise.resolve(undefined);
+    return PromiseResolve(undefined);
   }
   if (stream._pendingAbortRequest !== undefined) {
     return stream._pendingAbortRequest._promise;
@@ -599,7 +599,7 @@ function WritableStreamDefaultWriterCloseWithErrorPropagation(writer) {
 
   const state = stream._state;
   if (WritableStreamCloseQueuedOrInFlight(stream) === true || state === 'closed') {
-    return Promise.resolve();
+    return PromiseResolve();
   }
 
   if (state === 'errored') {
@@ -767,7 +767,7 @@ function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm
   WritableStreamUpdateBackpressure(stream, backpressure);
 
   const startResult = startAlgorithm();
-  const startPromise = Promise.resolve(startResult);
+  const startPromise = PromiseResolve(startResult);
   startPromise.then(
     () => {
       assert(stream._state === 'writable' || stream._state === 'erroring');
@@ -983,7 +983,7 @@ function defaultWriterClosedPromiseInitializeAsRejected(writer, reason) {
 }
 
 function defaultWriterClosedPromiseInitializeAsResolved(writer) {
-  writer._closedPromise = Promise.resolve(undefined);
+  writer._closedPromise = PromiseResolve(undefined);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
   writer._closedPromiseState = 'resolved';
@@ -1039,7 +1039,7 @@ function defaultWriterReadyPromiseInitializeAsRejected(writer, reason) {
 
 function defaultWriterReadyPromiseInitializeAsResolved(writer) {
   verbose('defaultWriterReadyPromiseInitializeAsResolved()');
-  writer._readyPromise = Promise.resolve(undefined);
+  writer._readyPromise = PromiseResolve(undefined);
   writer._readyPromise_resolve = undefined;
   writer._readyPromise_reject = undefined;
   writer._readyPromiseState = 'fulfilled';

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -7,7 +7,7 @@ const verbose = require('debug')('streams:writable-stream:verbose');
 
 const { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
         MakeSizeAlgorithmFromSizeFunction, typeIsObject, newPromise, promiseResolvedWith, promiseRejectedWith,
-        uponPromise, PerformPromiseCatch } = require('./helpers.js');
+        uponPromise, setPromiseIsHandledToTrue } = require('./helpers.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
 const AbortSteps = Symbol('[[AbortSteps]]');
@@ -387,7 +387,7 @@ function WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
   const writer = stream._writer;
   if (writer !== undefined) {
     defaultWriterClosedPromiseReject(writer, stream._storedError);
-    PerformPromiseCatch(writer._closedPromise, () => {});
+    setPromiseIsHandledToTrue(writer._closedPromise);
   }
 }
 
@@ -433,7 +433,7 @@ class WritableStreamDefaultWriter {
       defaultWriterClosedPromiseInitialize(this);
     } else if (state === 'erroring') {
       defaultWriterReadyPromiseInitializeAsRejected(this, stream._storedError);
-      PerformPromiseCatch(this._readyPromise, () => {});
+      setPromiseIsHandledToTrue(this._readyPromise);
       defaultWriterClosedPromiseInitialize(this);
     } else if (state === 'closed') {
       defaultWriterReadyPromiseInitializeAsResolved(this);
@@ -443,9 +443,9 @@ class WritableStreamDefaultWriter {
 
       const storedError = stream._storedError;
       defaultWriterReadyPromiseInitializeAsRejected(this, storedError);
-      PerformPromiseCatch(this._readyPromise, () => {});
+      setPromiseIsHandledToTrue(this._readyPromise);
       defaultWriterClosedPromiseInitializeAsRejected(this, storedError);
-      PerformPromiseCatch(this._closedPromise, () => {});
+      setPromiseIsHandledToTrue(this._closedPromise);
     }
   }
 
@@ -618,7 +618,7 @@ function WritableStreamDefaultWriterEnsureClosedPromiseRejected(writer, error) {
   } else {
     defaultWriterClosedPromiseResetToRejected(writer, error);
   }
-  PerformPromiseCatch(writer._closedPromise, () => {});
+  setPromiseIsHandledToTrue(writer._closedPromise);
 }
 
 function WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error) {
@@ -628,7 +628,7 @@ function WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error) {
   } else {
     defaultWriterReadyPromiseResetToRejected(writer, error);
   }
-  PerformPromiseCatch(writer._readyPromise, () => {});
+  setPromiseIsHandledToTrue(writer._readyPromise);
 }
 
 function WritableStreamDefaultWriterGetDesiredSize(writer) {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -6,8 +6,8 @@ const assert = require('assert');
 const verbose = require('debug')('streams:writable-stream:verbose');
 
 const { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
-        MakeSizeAlgorithmFromSizeFunction, typeIsObject, CreatePromise, PromiseResolve, PromiseReject } =
-        require('./helpers.js');
+        MakeSizeAlgorithmFromSizeFunction, typeIsObject, CreatePromise, PromiseResolve, PromiseReject,
+        PerformPromiseThen } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
 
@@ -272,7 +272,8 @@ function WritableStreamFinishErroring(stream) {
   }
 
   const promise = stream._writableStreamController[AbortSteps](abortRequest._reason);
-  promise.then(
+  PerformPromiseThen(
+    promise,
     () => {
       abortRequest._resolve();
       WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
@@ -769,7 +770,8 @@ function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm
 
   const startResult = startAlgorithm();
   const startPromise = PromiseResolve(startResult);
-  startPromise.then(
+  PerformPromiseThen(
+    startPromise,
     () => {
       assert(stream._state === 'writable' || stream._state === 'erroring');
       controller._started = true;
@@ -894,7 +896,8 @@ function WritableStreamDefaultControllerProcessClose(controller) {
 
   const sinkClosePromise = controller._closeAlgorithm();
   WritableStreamDefaultControllerClearAlgorithms(controller);
-  sinkClosePromise.then(
+  PerformPromiseThen(
+    sinkClosePromise,
     () => {
       WritableStreamFinishInFlightClose(stream);
     },
@@ -910,7 +913,8 @@ function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
   WritableStreamMarkFirstWriteRequestInFlight(stream);
 
   const sinkWritePromise = controller._writeAlgorithm(chunk);
-  sinkWritePromise.then(
+  PerformPromiseThen(
+    sinkWritePromise,
     () => {
       WritableStreamFinishInFlightWrite(stream);
 

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const verbose = require('debug')('streams:writable-stream:verbose');
 
 const { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
-        MakeSizeAlgorithmFromSizeFunction, typeIsObject, CreatePromise, PromiseResolve, PromiseReject,
+        MakeSizeAlgorithmFromSizeFunction, typeIsObject, newPromise, PromiseResolve, PromiseReject,
         PerformPromiseThen, PerformPromiseCatch } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
@@ -176,7 +176,7 @@ function WritableStreamAbort(stream, reason) {
     reason = undefined;
   }
 
-  const promise = CreatePromise((resolve, reject) => {
+  const promise = newPromise((resolve, reject) => {
     stream._pendingAbortRequest = {
       _resolve: resolve,
       _reject: reject,
@@ -199,7 +199,7 @@ function WritableStreamAddWriteRequest(stream) {
   assert(IsWritableStreamLocked(stream) === true);
   assert(stream._state === 'writable');
 
-  const promise = CreatePromise((resolve, reject) => {
+  const promise = newPromise((resolve, reject) => {
     const writeRequest = {
       _resolve: resolve,
       _reject: reject
@@ -575,7 +575,7 @@ function WritableStreamDefaultWriterClose(writer) {
   assert(state === 'writable' || state === 'erroring');
   assert(WritableStreamCloseQueuedOrInFlight(stream) === false);
 
-  const promise = CreatePromise((resolve, reject) => {
+  const promise = newPromise((resolve, reject) => {
     const closeRequest = {
       _resolve: resolve,
       _reject: reject
@@ -982,7 +982,7 @@ function defaultWriterLockException(name) {
 }
 
 function defaultWriterClosedPromiseInitialize(writer) {
-  writer._closedPromise = CreatePromise((resolve, reject) => {
+  writer._closedPromise = newPromise((resolve, reject) => {
     writer._closedPromise_resolve = resolve;
     writer._closedPromise_reject = reject;
     writer._closedPromiseState = 'pending';
@@ -1036,7 +1036,7 @@ function defaultWriterClosedPromiseResolve(writer) {
 
 function defaultWriterReadyPromiseInitialize(writer) {
   verbose('defaultWriterReadyPromiseInitialize()');
-  writer._readyPromise = CreatePromise((resolve, reject) => {
+  writer._readyPromise = newPromise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
     writer._readyPromise_reject = reject;
   });
@@ -1075,7 +1075,7 @@ function defaultWriterReadyPromiseReset(writer) {
   assert(writer._readyPromise_resolve === undefined);
   assert(writer._readyPromise_reject === undefined);
 
-  writer._readyPromise = CreatePromise((resolve, reject) => {
+  writer._readyPromise = newPromise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
     writer._readyPromise_reject = reject;
   });

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -600,7 +600,7 @@ function WritableStreamDefaultWriterCloseWithErrorPropagation(writer) {
 
   const state = stream._state;
   if (WritableStreamCloseQueuedOrInFlight(stream) === true || state === 'closed') {
-    return promiseResolvedWith();
+    return promiseResolvedWith(undefined);
   }
 
   if (state === 'errored') {

--- a/reference-implementation/lib/writable-stream.js
+++ b/reference-implementation/lib/writable-stream.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const verbose = require('debug')('streams:writable-stream:verbose');
 
 const { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, ValidateAndNormalizeHighWaterMark, IsNonNegativeNumber,
-        MakeSizeAlgorithmFromSizeFunction, typeIsObject, newPromise, PromiseResolve, PromiseReject,
+        MakeSizeAlgorithmFromSizeFunction, typeIsObject, newPromise, promiseResolvedWith, PromiseReject,
         PerformPromiseThen, PerformPromiseCatch } = require('./helpers.js');
 const { rethrowAssertionErrorRejection } = require('./utils.js');
 const { DequeueValue, EnqueueValueWithSize, PeekQueueValue, ResetQueue } = require('./queue-with-sizes.js');
@@ -161,7 +161,7 @@ function IsWritableStreamLocked(stream) {
 function WritableStreamAbort(stream, reason) {
   const state = stream._state;
   if (state === 'closed' || state === 'errored') {
-    return PromiseResolve(undefined);
+    return promiseResolvedWith(undefined);
   }
   if (stream._pendingAbortRequest !== undefined) {
     return stream._pendingAbortRequest._promise;
@@ -601,7 +601,7 @@ function WritableStreamDefaultWriterCloseWithErrorPropagation(writer) {
 
   const state = stream._state;
   if (WritableStreamCloseQueuedOrInFlight(stream) === true || state === 'closed') {
-    return PromiseResolve();
+    return promiseResolvedWith();
   }
 
   if (state === 'errored') {
@@ -769,7 +769,7 @@ function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm
   WritableStreamUpdateBackpressure(stream, backpressure);
 
   const startResult = startAlgorithm();
-  const startPromise = PromiseResolve(startResult);
+  const startPromise = promiseResolvedWith(startResult);
   PerformPromiseCatch(
     PerformPromiseThen(
       startPromise,
@@ -997,7 +997,7 @@ function defaultWriterClosedPromiseInitializeAsRejected(writer, reason) {
 }
 
 function defaultWriterClosedPromiseInitializeAsResolved(writer) {
-  writer._closedPromise = PromiseResolve(undefined);
+  writer._closedPromise = promiseResolvedWith(undefined);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
   writer._closedPromiseState = 'resolved';
@@ -1053,7 +1053,7 @@ function defaultWriterReadyPromiseInitializeAsRejected(writer, reason) {
 
 function defaultWriterReadyPromiseInitializeAsResolved(writer) {
   verbose('defaultWriterReadyPromiseInitializeAsResolved()');
-  writer._readyPromise = PromiseResolve(undefined);
+  writer._readyPromise = promiseResolvedWith(undefined);
   writer._readyPromise_resolve = undefined;
   writer._readyPromise_reject = undefined;
   writer._readyPromiseState = 'fulfilled';


### PR DESCRIPTION
Currently, the reference implementation does not use the initial value of the `Promise` constructor and its methods to implement phrases such as ["upon fulfillment of _p_ with value _v_"](https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment), although this is required by the promise guide. This causes the reference implementation to fail on the new tests introduced in web-platform-tests/wpt#18452.

This PR adds helper functions to call the original versions of the promise constructor and its methods. Assuming they haven't been monkey-patched before the reference implementation was loaded, these should be the initial values expected by the spec.

It also replaces all direct calls to the promise constructos and its methods with calls to the respective helper functions. This is a purely mechanical change, but it does make for quite a big diff! 😅

With this change, the reference implementation once again passes all tests. 🎉

See also:
* [Original report](https://github.com/web-platform-tests/wpt/pull/18452#issuecomment-522364285)