### PR TITLE
Change promises-guide references to Web IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11,7 +11,7 @@ Opaque Elements: emu-alg
 </pre>
 
 <pre class=link-defaults>
-spec:promises-guide; type:dfn;
+spec:webidl; type:dfn;
     text:resolve
 </pre>
 
@@ -863,7 +863,7 @@ prototype, are created with the internal slots described in the following table:
   1. If ! IsReadableStreamAsyncIterator(*this*) is *false*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. Let _reader_ be *this*.[[asyncIteratorReader]].
   1. If _reader_.[[ownerReadableStream]] is *undefined*, return <a>a promise rejected with</a> a *TypeError* exception.
-  1. Return the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
+  1. Return the result of <a>reacting</a> to ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
      which takes the argument _result_ and performs the following steps:
     1. Assert: Type(_result_) is Object.
     1. Let _done_ be ! Get(_result_, `"done"`).
@@ -884,7 +884,7 @@ for="ReadableStreamAsyncIteratorPrototype">return( <var>value</var> )</h4>
   1. If *this*.[[preventCancel]] is *false*, then:
     1. Let _result_ be ! ReadableStreamReaderGenericCancel(_reader_, _value_).
     1. Perform ! ReadableStreamReaderGenericRelease(_reader_).
-    1. Return the result of <a>transforming</a> _result_ by a fulfillment handler that returns !
+    1. Return the result of <a>reacting</a> to _result_ with a fulfillment handler that returns !
     ReadableStreamCreateReadResult(_value_, *true*, *true*).
   1. Perform ! ReadableStreamReaderGenericRelease(_reader_).
   1. Return <a>a promise resolved with</a> ! ReadableStreamCreateReadResult(_value_, *true*, *true*).
@@ -1058,7 +1058,7 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Let _pullAlgorithm_ be the following steps:
     1. If _reading_ is *true*, return <a>a promise resolved with</a> *undefined*.
     1. Set _reading_ to *true*.
-    1. Let _readPromise_ be the result of <a>transforming</a> ! ReadableStreamDefaultReaderRead(_reader_) with a
+    1. Let _readPromise_ be the result of <a>reacting</a> to ! ReadableStreamDefaultReaderRead(_reader_) with a
        fulfillment handler which takes the argument _result_ and performs the following steps:
       1. Set _reading_ to *false*.
       1. Assert: Type(_result_) is Object.
@@ -1281,7 +1281,7 @@ nothrow>ReadableStreamAddReadIntoRequest ( <var>stream</var> )</h4>
   1. If _stream_.[[state]] is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
   1. Perform ! ReadableStreamClose(_stream_).
   1. Let _sourceCancelPromise_ be ! _stream_.[[readableStreamController]].<a abstract-op>[[CancelSteps]]</a>(_reason_).
-  1. Return the result of <a>transforming</a> _sourceCancelPromise_ with a fulfillment handler that returns *undefined*.
+  1. Return the result of <a>reacting</a> to _sourceCancelPromise_ with a fulfillment handler that returns *undefined*.
 </emu-alg>
 
 <h4 id="readable-stream-close" aoid="ReadableStreamClose" nothrow>ReadableStreamClose ( <var>stream</var> )</h4>
@@ -4954,7 +4954,7 @@ nothrow>TransformStreamDefaultControllerPerformTransform ( <var>controller</var>
 
 <emu-alg>
   1. Let _transformPromise_ be the result of performing _controller_.[[transformAlgorithm]], passing _chunk_.
-  1. Return the result of <a>transforming</a> _transformPromise_ with a rejection handler that, when called with
+  1. Return the result of <a>reacting</a> to _transformPromise_ with a rejection handler that, when called with
      argument _r_, performs the following steps:
     1. Perform ! TransformStreamError(_controller_.[[controlledTransformStream]], _r_).
     1. Throw _r_.
@@ -4987,7 +4987,7 @@ nothrow>TransformStreamDefaultSinkWriteAlgorithm ( <var>stream</var>, <var>chunk
   1. If _stream_.[[backpressure]] is *true*,
     1. Let _backpressureChangePromise_ be _stream_.[[backpressureChangePromise]].
     1. Assert: _backpressureChangePromise_ is not *undefined*.
-    1. Return the result of <a>transforming</a> _backpressureChangePromise_ with a fulfillment handler which performs
+    1. Return the result of <a>reacting</a> to _backpressureChangePromise_ with a fulfillment handler which performs
        the following steps:
       1. Let _writable_ be _stream_.[[writable]].
       1. Let _state_ be _writable_.[[state]].
@@ -5013,7 +5013,7 @@ nothrow>TransformStreamDefaultSinkCloseAlgorithm( <var>stream</var> )</h4>
   1. Let _controller_ be _stream_.[[transformStreamController]].
   1. Let _flushPromise_ be the result of performing _controller_.[[flushAlgorithm]].
   1. Perform ! TransformStreamDefaultControllerClearAlgorithms(_controller_).
-  1. Return the result of <a>transforming</a> _flushPromise_ with:
+  1. Return the result of <a>reacting</a> to _flushPromise_ with:
     1. A fulfillment handler that performs the following steps:
       1. If _readable_.[[state]] is `"errored"`, throw _readable_.[[storedError]].
       1. Let _readableController_ be _readable_.[[readableStreamController]].
@@ -5365,7 +5365,7 @@ throws>CreateAlgorithmFromUnderlyingMethod ( <var ignore>underlyingObject</var>,
 <var>args</var> )</h4>
 
 <div class="note">
-  PromiseCall is a variant of <a>promise-calling</a> that works on methods.
+  PromiseCall is a variant of <a lt="call a user object's operation">promise-calling</a> that works on methods.
 </div>
 
 <emu-alg>
@@ -6091,8 +6091,6 @@ planned) that the conventions of ECMAScript itself will evolve in these ways.
   <li> We use destructuring notation in function and method declarations, and assume that <a
     abstract-op>DestructuringAssignmentEvaluation</a> was performed appropriately before the algorithm starts.
   <li> We use "<emu-val>this</emu-val>" instead of "<emu-val>this</emu-val> value".
-  <li> We use the shorthand phrases from the [[!PROMISES-GUIDE]] to operate on promises at a higher level than the
-    ECMAScript spec does.
 </ul>
 
 It's also worth noting that, as in [[!ECMASCRIPT]], all numbers are represented as double-precision floating point

--- a/index.bs
+++ b/index.bs
@@ -5364,7 +5364,8 @@ throws>CreateAlgorithmFromUnderlyingMethod ( <var ignore>underlyingObject</var>,
 <var>args</var> )</h4>
 
 <div class="note">
-  PromiseCall is a variant of <a lt="call a user object's operation">promise-calling</a> that works on methods.
+  This encapsulates the relevant promise-related parts of the Web IDL <a>call a user object's operation</a> algorithm
+  for use while we work on <a href="https://github.com/whatwg/streams/issues/963">moving to Web IDL</a>.
 </div>
 
 <emu-alg>

--- a/index.bs
+++ b/index.bs
@@ -1134,8 +1134,8 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
       1. If _preventCancel_ is *false*, <a for="set">append</a> the following action action to _actions_:
         1. If _source_.[[_state_]] is `"readable"`, return ! ReadableStreamCancel(_source_, _error_).
         1. Otherwise, return <a>a promise resolved with</a> *undefined*.
-      1. <a href="#rs-pipeTo-shutdown-with-action">Shutdown with an action</a> consisting of <a>waiting for all</a>
-         of the actions in _actions_, and with _error_.
+      1. <a href="#rs-pipeTo-shutdown-with-action">Shutdown with an action</a> consisting of
+         <a>getting a promise to wait for all</a> of the actions in _actions_, and with _error_.
     1. If _signal_'s <a for=AbortSignal>aborted flag</a> is set, perform _abortAlgorithm_ and return _promise_.
     1. <a for="AbortSignal">Add</a> _abortAlgorithm_ to _signal_.
   1. <a>In parallel</a> <span class="XXX">but not really; see <a

--- a/index.bs
+++ b/index.bs
@@ -863,8 +863,8 @@ prototype, are created with the internal slots described in the following table:
   1. If ! IsReadableStreamAsyncIterator(*this*) is *false*, return <a>a promise rejected with</a> a *TypeError* exception.
   1. Let _reader_ be *this*.[[asyncIteratorReader]].
   1. If _reader_.[[ownerReadableStream]] is *undefined*, return <a>a promise rejected with</a> a *TypeError* exception.
-  1. Return the result of <a>reacting</a> to ! ReadableStreamDefaultReaderRead(_reader_) with a fulfillment handler
-     which takes the argument _result_ and performs the following steps:
+  1. Return the result of <a>reacting</a> to ! ReadableStreamDefaultReaderRead(_reader_) with the following fulfillment
+     steps given the argument _result_:
     1. Assert: Type(_result_) is Object.
     1. Let _done_ be ! Get(_result_, `"done"`).
     1. Assert: Type(_done_) is Boolean.
@@ -884,7 +884,7 @@ for="ReadableStreamAsyncIteratorPrototype">return( <var>value</var> )</h4>
   1. If *this*.[[preventCancel]] is *false*, then:
     1. Let _result_ be ! ReadableStreamReaderGenericCancel(_reader_, _value_).
     1. Perform ! ReadableStreamReaderGenericRelease(_reader_).
-    1. Return the result of <a>reacting</a> to _result_ with a fulfillment handler that returns !
+    1. Return the result of <a>reacting</a> to _result_ with a fulfillment step that returns !
     ReadableStreamCreateReadResult(_value_, *true*, *true*).
   1. Perform ! ReadableStreamReaderGenericRelease(_reader_).
   1. Return <a>a promise resolved with</a> ! ReadableStreamCreateReadResult(_value_, *true*, *true*).
@@ -1058,8 +1058,8 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
   1. Let _pullAlgorithm_ be the following steps:
     1. If _reading_ is *true*, return <a>a promise resolved with</a> *undefined*.
     1. Set _reading_ to *true*.
-    1. Let _readPromise_ be the result of <a>reacting</a> to ! ReadableStreamDefaultReaderRead(_reader_) with a
-       fulfillment handler which takes the argument _result_ and performs the following steps:
+    1. Let _readPromise_ be the result of <a>reacting</a> to ! ReadableStreamDefaultReaderRead(_reader_) with the
+       following fulfillment steps given the argument _result_:
       1. Set _reading_ to *false*.
       1. Assert: Type(_result_) is Object.
       1. Let _done_ be ! Get(_result_, `"done"`).
@@ -1281,7 +1281,7 @@ nothrow>ReadableStreamAddReadIntoRequest ( <var>stream</var> )</h4>
   1. If _stream_.[[state]] is `"errored"`, return <a>a promise rejected with</a> _stream_.[[storedError]].
   1. Perform ! ReadableStreamClose(_stream_).
   1. Let _sourceCancelPromise_ be ! _stream_.[[readableStreamController]].<a abstract-op>[[CancelSteps]]</a>(_reason_).
-  1. Return the result of <a>reacting</a> to _sourceCancelPromise_ with a fulfillment handler that returns *undefined*.
+  1. Return the result of <a>reacting</a> to _sourceCancelPromise_ with a fulfillment step that returns *undefined*.
 </emu-alg>
 
 <h4 id="readable-stream-close" aoid="ReadableStreamClose" nothrow>ReadableStreamClose ( <var>stream</var> )</h4>
@@ -4954,8 +4954,8 @@ nothrow>TransformStreamDefaultControllerPerformTransform ( <var>controller</var>
 
 <emu-alg>
   1. Let _transformPromise_ be the result of performing _controller_.[[transformAlgorithm]], passing _chunk_.
-  1. Return the result of <a>reacting</a> to _transformPromise_ with a rejection handler that, when called with
-     argument _r_, performs the following steps:
+  1. Return the result of <a>reacting</a> to _transformPromise_ with the following rejection steps given the
+     argument _r_:
     1. Perform ! TransformStreamError(_controller_.[[controlledTransformStream]], _r_).
     1. Throw _r_.
 </emu-alg>
@@ -4987,8 +4987,7 @@ nothrow>TransformStreamDefaultSinkWriteAlgorithm ( <var>stream</var>, <var>chunk
   1. If _stream_.[[backpressure]] is *true*,
     1. Let _backpressureChangePromise_ be _stream_.[[backpressureChangePromise]].
     1. Assert: _backpressureChangePromise_ is not *undefined*.
-    1. Return the result of <a>reacting</a> to _backpressureChangePromise_ with a fulfillment handler which performs
-       the following steps:
+    1. Return the result of <a>reacting</a> to _backpressureChangePromise_ with the following fulfillment steps:
       1. Let _writable_ be _stream_.[[writable]].
       1. Let _state_ be _writable_.[[state]].
       1. If _state_ is `"erroring"`, throw _writable_.[[storedError]].
@@ -5013,13 +5012,13 @@ nothrow>TransformStreamDefaultSinkCloseAlgorithm( <var>stream</var> )</h4>
   1. Let _controller_ be _stream_.[[transformStreamController]].
   1. Let _flushPromise_ be the result of performing _controller_.[[flushAlgorithm]].
   1. Perform ! TransformStreamDefaultControllerClearAlgorithms(_controller_).
-  1. Return the result of <a>reacting</a> to _flushPromise_ with:
-    1. A fulfillment handler that performs the following steps:
+  1. Return the result of <a>reacting</a> to _flushPromise_:
+    1. If _flushPromise_ was fulfilled, then:
       1. If _readable_.[[state]] is `"errored"`, throw _readable_.[[storedError]].
       1. Let _readableController_ be _readable_.[[readableStreamController]].
       1. If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(_readableController_) is *true*, perform !
          ReadableStreamDefaultControllerClose(_readableController_).
-    1. A rejection handler that, when called with argument _r_, performs the following steps:
+    1. If _flushPromise_ was rejected with reason _r_, then:
       1. Perform ! TransformStreamError(_stream_, _r_).
       1. Throw _readable_.[[storedError]].
 </emu-alg>


### PR DESCRIPTION
The spec text has broken links to the old [promises guide](https://www.w3.org/2001/tag/doc/promises-guide/). This is inconvenient for readers, but it also causes builds for spec PRs to fail (see [my comment on #1011](https://github.com/whatwg/streams/pull/1011#issuecomment-549029385)).

This PR fixes the links by pointing to their new Web IDL counterparts.

Todo list (non-exhaustive, feel free to suggest other changes):
* [x] Get spec to build again.
* [ ] Figure out what to do with "promise-calling".
* [x] Change usages of "react to promise" to explicitly pass one or two sets of steps (as in [this example](https://heycam.github.io/webidl/#promise-example-addDelay)), instead of passing a "fulfillment handler" and a "rejection handler".
* [ ] ~Change pairs of "upon fulfillment / upon rejection" to a single "react to promise".~ (Not that important right now.)

Fixes #1020


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1021.html" title="Last updated on Nov 3, 2019, 9:31 PM UTC (66b04bf)">Preview</a> | <a href="https://whatpr.org/streams/1021/ae5e0cb...66b04bf.html" title="Last updated on Nov 3, 2019, 9:31 PM UTC (66b04bf)">Diff</a>