### PR TITLE
Set [[disturbed]] synchronously in ReadableStreamPipeTo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1122,6 +1122,7 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
      discretion.
   1. Otherwise, let _reader_ be ! AcquireReadableStreamDefaultReader(_source_).
   1. Let _writer_ be ! AcquireWritableStreamDefaultWriter(_dest_).
+  1. Set _source_.[[disturbed]] to *true*.
   1. Let _shuttingDown_ be *false*.
   1. Let _promise_ be <a>a new promise</a>.
   1. If _signal_ is not *undefined*,
@@ -1129,10 +1130,10 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
       1. Let _error_ be a new "`<a idl>AbortError</a>`" `<a idl>DOMException</a>`.
       1. Let _actions_ be an empty <a>ordered set</a>.
       1. If _preventAbort_ is *false*, <a for="set">append</a> the following action to _actions_:
-        1. If _dest_.[[_state_]] is `"writable"`, return ! WritableStreamAbort(_dest_, _error_).
+        1. If _dest_.[[state]] is `"writable"`, return ! WritableStreamAbort(_dest_, _error_).
         1. Otherwise, return <a>a promise resolved with</a> *undefined*.
       1. If _preventCancel_ is *false*, <a for="set">append</a> the following action action to _actions_:
-        1. If _source_.[[_state_]] is `"readable"`, return ! ReadableStreamCancel(_source_, _error_).
+        1. If _source_.[[state]] is `"readable"`, return ! ReadableStreamCancel(_source_, _error_).
         1. Otherwise, return <a>a promise resolved with</a> *undefined*.
       1. <a href="#rs-pipeTo-shutdown-with-action">Shutdown with an action</a> consisting of
          <a>getting a promise to wait for all</a> of the actions in _actions_, and with _error_.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -356,6 +356,8 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
   const reader = AcquireReadableStreamDefaultReader(source);
   const writer = AcquireWritableStreamDefaultWriter(dest);
 
+  source._disturbed = true;
+
   let shuttingDown = false;
 
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.


### PR DESCRIPTION
Set the [[disturbed]] internal slot to true in ReadableStreamPipeTo.
This is useful for the Fetch Standard. It is not visible to user code.

See https://github.com/whatwg/fetch/pull/959 for the Fetch Standard
change that requires this.

Also fix two places where the name of the `state` internal slot was
mistakenly italicised.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1022.html" title="Last updated on Nov 7, 2019, 7:01 AM UTC (9e94c6b)">Preview</a> | <a href="https://whatpr.org/streams/1022/547428b...9e94c6b.html" title="Last updated on Nov 7, 2019, 7:01 AM UTC (9e94c6b)">Diff</a>