### PR TITLE
Add checks before Close and Enqueue in tee()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1065,9 +1065,11 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
       1. Let _done_ be ! Get(_result_, `"done"`).
       1. Assert: Type(_done_) is Boolean.
       1. If _done_ is *true*,
-        1. If _canceled1_ is *false*,
+        1. If _canceled1_ is *false* and !
+           ReadableStreamDefaultControllerCanCloseOrEnqueue(_branch1_.[[readableStreamController]) is *true*,
           1. Perform ! ReadableStreamDefaultControllerClose(_branch1_.[[readableStreamController]]).
-        1. If _canceled2_ is *false*,
+        1. If _canceled2_ is *false* and !
+           ReadableStreamDefaultControllerCanCloseOrEnqueue(_branch2_.[[readableStreamController]) is *true*,
           1. Perform ! ReadableStreamDefaultControllerClose(_branch2_.[[readableStreamController]]).
         1. Return.
       1. Let _value_ be ! Get(_result_, `"value"`).
@@ -1075,9 +1077,11 @@ noticeable asymmetry between the two branches, and limits the possible <a>chunks
       1. If _canceled2_ is *false* and _cloneForBranch2_ is *true*, set _value2_ to ? <a
          abstract-op>StructuredDeserialize</a>(? <a abstract-op>StructuredSerialize</a>(_value2_), the current Realm
          Record).
-      1. If _canceled1_ is *false*, perform ?
+      1. If _canceled1_ is *false* and !
+         ReadableStreamDefaultControllerCanCloseOrEnqueue(_branch1_.[[readableStreamController]) is *true*, perform ?
          ReadableStreamDefaultControllerEnqueue(_branch1_.[[readableStreamController]], _value1_).
-      1. If _canceled2_ is *false*, perform ?
+      1. If _canceled2_ is *false* and !
+         ReadableStreamDefaultControllerCanCloseOrEnqueue(_branch2_.[[readableStreamController]) is *true*, perform ?
          ReadableStreamDefaultControllerEnqueue(_branch2_.[[readableStreamController]], _value2_).
     1. Set _readPromise_.[[PromiseIsHandled]] to *true*.
     1. Return <a>a promise resolved with</a> *undefined*.

--- a/reference-implementation/lib/readable-stream.js
+++ b/reference-implementation/lib/readable-stream.js
@@ -580,10 +580,12 @@ function ReadableStreamTee(stream, cloneForBranch2) {
       assert(typeof done === 'boolean');
 
       if (done === true) {
-        if (canceled1 === false) {
+        if (canceled1 === false &&
+            ReadableStreamDefaultControllerCanCloseOrEnqueue(branch1._readableStreamController) === true) {
           ReadableStreamDefaultControllerClose(branch1._readableStreamController);
         }
-        if (canceled2 === false) {
+        if (canceled2 === false &&
+            ReadableStreamDefaultControllerCanCloseOrEnqueue(branch2._readableStreamController) === true) {
           ReadableStreamDefaultControllerClose(branch2._readableStreamController);
         }
         return;
@@ -599,11 +601,13 @@ function ReadableStreamTee(stream, cloneForBranch2) {
       //   value2 = StructuredDeserialize(StructuredSerialize(value2));
       // }
 
-      if (canceled1 === false) {
+      if (canceled1 === false &&
+          ReadableStreamDefaultControllerCanCloseOrEnqueue(branch1._readableStreamController) === true) {
         ReadableStreamDefaultControllerEnqueue(branch1._readableStreamController, value1);
       }
 
-      if (canceled2 === false) {
+      if (canceled2 === false &&
+          ReadableStreamDefaultControllerCanCloseOrEnqueue(branch2._readableStreamController) === true) {
         ReadableStreamDefaultControllerEnqueue(branch2._readableStreamController, value2);
       }
     });


### PR DESCRIPTION
ReadableStream.prototype.tee didn't check CanCloseOrEnqueue() before
calling Close() or Enqueue(), violating the interface contract. Add
checks of CanCloseOrEnqueue() to fix it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1027.html" title="Last updated on Feb 3, 2020, 10:38 AM UTC (627adbf)">Preview</a> | <a href="https://whatpr.org/streams/1027/08b115d...627adbf.html" title="Last updated on Feb 3, 2020, 10:38 AM UTC (627adbf)">Diff</a>