### PR TITLE
Always resolve tee's cancel promise after stream closes or errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2196,6 +2196,7 @@ create them does not matter.
        [$ReadableStreamDefaultControllerClose$](|branch1|.\[[controller]]).
     1. If |canceled2| is false, perform !
        [$ReadableStreamDefaultControllerClose$](|branch2|.\[[controller]]).
+    1. [=Resolve=] |cancelPromise| with undefined.
 
    : [=read request/error steps=]
    ::

--- a/index.bs
+++ b/index.bs
@@ -2227,6 +2227,7 @@ create them does not matter.
  1. [=Upon rejection=] of |reader|.\[[closedPromise]] with reason |r|,
   1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.\[[controller]], |r|).
   1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.\[[controller]], |r|).
+  1. [=Resolve=] |cancelPromise| with undefined.
  1. Return « |branch1|, |branch2| ».
 </div>
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -331,10 +331,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   let branch1;
   let branch2;
 
-  let resolveCancelPromise;
-  const cancelPromise = new Promise(resolve => {
-    resolveCancelPromise = resolve;
-  });
+  const cancelPromise = newPromise();
 
   function pullAlgorithm() {
     if (reading === true) {
@@ -376,7 +373,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
         if (canceled2 === false) {
           ReadableStreamDefaultControllerClose(branch2._controller);
         }
-        resolveCancelPromise(undefined);
+        resolvePromise(cancelPromise, undefined);
       },
       errorSteps: () => {
         reading = false;
@@ -393,7 +390,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
     if (canceled2 === true) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);
-      resolveCancelPromise(cancelResult);
+      resolvePromise(cancelPromise, cancelResult);
     }
     return cancelPromise;
   }
@@ -404,7 +401,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
     if (canceled1 === true) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);
-      resolveCancelPromise(cancelResult);
+      resolvePromise(cancelPromise, cancelResult);
     }
     return cancelPromise;
   }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -414,6 +414,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   uponRejection(reader._closedPromise, r => {
     ReadableStreamDefaultControllerError(branch1._controller, r);
     ReadableStreamDefaultControllerError(branch2._controller, r);
+    resolvePromise(cancelPromise, undefined);
   });
 
   return [branch1, branch2];

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -376,6 +376,7 @@ function ReadableStreamTee(stream, cloneForBranch2) {
         if (canceled2 === false) {
           ReadableStreamDefaultControllerClose(branch2._controller);
         }
+        resolveCancelPromise(undefined);
       },
       errorSteps: () => {
         reading = false;


### PR DESCRIPTION
Fixes #1038.

- [x] At least two implementers are interested (and none opposed):
   * [Chromium](https://github.com/whatwg/streams/pull/1039#issuecomment-664739091)
   * In a private email, @youennf said this sounds good
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * web-platform-tests/wpt#24124
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1039.html" title="Last updated on Aug 5, 2020, 10:21 PM UTC (5c7ec3a)">Preview</a> | <a href="https://whatpr.org/streams/1039/d6ea924...5c7ec3a.html" title="Last updated on Aug 5, 2020, 10:21 PM UTC (5c7ec3a)">Diff</a>