### PR TITLE
Run idlharness tests on reference implementation

### DIFF
--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -19,7 +19,7 @@
     "nyc": "^15.0.1",
     "opener": "^1.5.1",
     "webidl2js": "^16.2.0",
-    "wpt-runner": "^3.0.1"
+    "wpt-runner": "^3.1.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
This enables the idlharness tests to run on the reference implementation, as details in [my comment on #1044](https://github.com/whatwg/streams/issues/1044#issuecomment-647189179).

Fixes #1044