### PR TITLE
Editorial: add cross-links to internal slots

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2547,7 +2547,7 @@ The following abstract operations support the implementation of the
 
  1. Let |stream| be |controller|.\[[stream]].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return false.
- 1. If |controller|.\[[started]] is false, return false.
+ 1. If |controller|.[=ReadableStreamDefaultController/[[started]]=] is false, return false.
  1. If ! [$IsReadableStreamLocked$](|stream|) is true and !
     [$ReadableStreamGetNumReadRequests$](|stream|) > 0, return true.
  1. Let |desiredSize| be ! [$ReadableStreamDefaultControllerGetDesiredSize$](|controller|).
@@ -2691,7 +2691,7 @@ The following abstract operations support the implementation of the
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. Set |controller|.\[[stream]] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.\[[started]], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
     |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.\[[strategyHWM]]
     to |highWaterMark|.
@@ -2701,7 +2701,7 @@ The following abstract operations support the implementation of the
  1. Let |startResult| be the result of performing |startAlgorithm|. (This might throw an exception.)
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=]  of |startPromise|,
-  1. Set |controller|.\[[started]] to true.
+  1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=] to true.
   1. Assert: |controller|.[=ReadableStreamDefaultController/[[pulling]]=] is false.
   1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
   1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
@@ -3162,7 +3162,7 @@ The following abstract operations support the implementation of the
  1. Let |stream| be |controller|.\[[stream]].
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return false.
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true, return false.
- 1. If |controller|.\[[started]] is false, return false.
+ 1. If |controller|.[=ReadableByteStreamController/[[started]]=] is false, return false.
  1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true and !
     [$ReadableStreamGetNumReadRequests$](|stream|) > 0, return true.
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true and !
@@ -3187,7 +3187,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
  1. Set |controller|.\[[byobRequest]] to null.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.\[[started]] to false.
+ 1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.[=ReadableByteStreamController/[[started]]=] to false.
  1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
@@ -3197,7 +3197,7 @@ The following abstract operations support the implementation of the
  1. Let |startResult| be the result of performing |startAlgorithm|.
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=]  of |startPromise|,
-   1. Set |controller|.\[[started]] to true.
+   1. Set |controller|.[=ReadableByteStreamController/[[started]]=] to true.
    1. Assert: |controller|.[=ReadableByteStreamController/[[pulling]]=] is false.
    1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
    1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -5647,14 +5647,14 @@ value given in the constructor.
  The <dfn id="cqs-constructor" constructor for="CountQueuingStrategy"
  lt="CountQueuingStrategy(init)">new CountQueuingStrategy(|init|)</dfn> constructor steps are:
 
- 1. Set [=this=].\[[highWaterMark]] to |init|["{{QueuingStrategyInit/highWaterMark}}"].
+ 1. Set [=this=].[=CountQueuingStrategy/[[highWaterMark]]=] to |init|["{{QueuingStrategyInit/highWaterMark}}"].
 </div>
 
 <div algorithm>
  The <dfn id="cqs-high-water-mark" attribute for="CountQueuingStrategy">highWaterMark</dfn>
  getter steps are:
 
- 1. Return [=this=].\[[highWaterMark]].
+ 1. Return [=this=].[=CountQueuingStrategy/[[highWaterMark]]=].
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -4480,7 +4480,7 @@ The following abstract operations support the implementation of the
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
- 1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm|.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to |sizeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategyHWM]]=] to |highWaterMark|.
  1. Set |controller|.\[[writeAlgorithm]] to |writeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to |closeAlgorithm|.
@@ -4568,7 +4568,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[writeAlgorithm]] to undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to undefined.
- 1. Set |controller|.\[[strategySizeAlgorithm]] to undefined.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to undefined.
 
  <p class="note">This algorithm will be performed multiple times in some edge cases. After the first
  time it will do nothing.
@@ -4617,7 +4617,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-get-chunk-size">WritableStreamDefaultControllerGetChunkSize(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Let |returnValue| be the result of performing |controller|.\[[strategySizeAlgorithm]], passing
+ 1. Let |returnValue| be the result of performing |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=], passing
     in |chunk|, and interpreting the result as a [=completion record=].
  1. If |returnValue| is an abrupt completion,
   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|,

--- a/index.bs
+++ b/index.bs
@@ -4793,7 +4793,7 @@ table:
   <tr>
    <td><dfn>\[[backpressureChangePromise]]</dfn>
    <td class="non-normative">A promise which is fulfilled and replaced every time the value of
-   \[[backpressure]] changes
+   [=TransformStream/[[backpressure]]=] changes
   <tr>
    <td><dfn>\[[controller]]</dfn>
    <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to
@@ -5132,10 +5132,10 @@ are even meant to be generally useful by other specifications.
   1. Return [=a promise resolved with=] undefined.
  1. Set |stream|.\[[readable]] to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancelAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
- 1. Set |stream|.\[[backpressure]] and |stream|.\[[backpressureChangePromise]] to undefined.
-    <p class="note">The \[[backpressure]] slot is set to undefined so that it can be initialized by
+ 1. Set |stream|.[=TransformStream/[[backpressure]]=] and |stream|.\[[backpressureChangePromise]] to undefined.
+    <p class="note">The [=TransformStream/[[backpressure]]=] slot is set to undefined so that it can be initialized by
     [$TransformStreamSetBackpressure$]. Alternatively, implementations can use a strictly boolean
-    value for \[[backpressure]] and change the way it is initialized. This will not be visible to
+    value for [=TransformStream/[[backpressure]]=] and change the way it is initialized. This will not be visible to
     user code so long as the initialization is correctly completed before the transformer's
     {{Transformer/start|start()}} method is called.
  1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
@@ -5162,7 +5162,7 @@ are even meant to be generally useful by other specifications.
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.\[[controller]]).
  1. Perform !
     [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].[=WritableStream/[[controller]]=], |e|).
- 1. If |stream|.\[[backpressure]] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
+ 1. If |stream|.[=TransformStream/[[backpressure]]=] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
     false).
 
  <p class="note">The [$TransformStreamDefaultSinkWriteAlgorithm$] abstract operation could be
@@ -5175,11 +5175,11 @@ are even meant to be generally useful by other specifications.
  id="transform-stream-set-backpressure">TransformStreamSetBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[backpressure]] is not |backpressure|.
+ 1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is not |backpressure|.
  1. If |stream|.\[[backpressureChangePromise]] is not undefined, [=resolve=]
     stream.\[[backpressureChangePromise]] with undefined.
  1. Set |stream|.\[[backpressureChangePromise]] to [=a new promise=].
- 1. Set |stream|.\[[backpressure]] to |backpressure|.
+ 1. Set |stream|.[=TransformStream/[[backpressure]]=] to |backpressure|.
 </div>
 
 <h4 id="ts-default-controller-abstract-ops">Default controllers</h4>
@@ -5262,7 +5262,7 @@ The following abstract operations support the implementaiton of the
    1. Throw |stream|.\[[readable]].[=ReadableStream/[[storedError]]=].
  1. Let |backpressure| be !
     [$ReadableStreamDefaultControllerHasBackpressure$](|readableController|).
- 1. If |backpressure| is not |stream|.\[[backpressure]],
+ 1. If |backpressure| is not |stream|.[=TransformStream/[[backpressure]]=],
    1. Assert: |backpressure| is true.
    1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
 </div>
@@ -5321,7 +5321,7 @@ side=] of [=transform streams=].
 
  1. Assert: |stream|.\[[writable]].[=WritableStream/[[state]]=] is "`writable`".
  1. Let |controller| be |stream|.\[[controller]].
- 1. If |stream|.\[[backpressure]] is true,
+ 1. If |stream|.[=TransformStream/[[backpressure]]=] is true,
   1. Let |backpressureChangePromise| be |stream|.\[[backpressureChangePromise]].
   1. Assert: |backpressureChangePromise| is not undefined.
   1. Return the result of [=reacting=] to |backpressureChangePromise| with the following fulfillment
@@ -5371,7 +5371,7 @@ side=] of [=transform streams=].
  id="transform-stream-default-source-pull">TransformStreamDefaultSourcePullAlgorithm(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[backpressure]] is true.
+ 1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is true.
  1. Assert: |stream|.\[[backpressureChangePromise]] is not undefined.
  1. Perform ! [$TransformStreamSetBackpressure$](|stream|, false).
  1. Return |stream|.\[[backpressureChangePromise]].

--- a/index.bs
+++ b/index.bs
@@ -4023,7 +4023,7 @@ are even meant to be generally useful by other specifications.
     |stream|.\[[inFlightWriteRequest]], |stream|.\[[closeRequest]],
     |stream|.\[[inFlightCloseRequest]] and |stream|.\[[pendingAbortRequest]] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
- 1. Set |stream|.\[[backpressure]] to false.
+ 1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
 </div>
 
 <div algorithm>
@@ -4046,7 +4046,7 @@ are even meant to be generally useful by other specifications.
  1. Set |stream|.\[[writer]] to |writer|.
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`writable`",
-  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.\[[backpressure]]
+  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[backpressure]]=]
      is true, set |writer|.\[[readyPromise]] to [=a new promise=].
   1. Otherwise, set |writer|.\[[readyPromise]] to [=a promise resolved with=] undefined.
   1. Set |writer|.\[[closedPromise]] to [=a new promise=].
@@ -4100,7 +4100,7 @@ are even meant to be generally useful by other specifications.
  1. Let |promise| be [=a new promise=].
  1. Set |stream|.\[[closeRequest]] to |promise|.
  1. Let |writer| be |stream|.\[[writer]].
- 1. If |writer| is not undefined, and |stream|.\[[backpressure]] is true, and |state| is
+ 1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and |state| is
     "`writable`", [=resolve=] |writer|.\[[readyPromise]] with undefined.
  1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.\[[controller]]).
  1. Return |promise|.
@@ -4339,12 +4339,12 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.\[[state]] is "`writable`".
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
  1. Let |writer| be |stream|.\[[writer]].
- 1. If |writer| is not undefined and |backpressure| is not |stream|.\[[backpressure]],
+ 1. If |writer| is not undefined and |backpressure| is not |stream|.[=WritableStream/[[backpressure]]=],
   1. If |backpressure| is true, set |writer|.\[[readyPromise]] to [=a new promise=].
   1. Otherwise,
    1. Assert: |backpressure| is false.
    1. [=Resolve=] |writer|.\[[readyPromise]] with undefined.
- 1. Set |stream|.\[[backpressure]] to |backpressure|.
+ 1. Set |stream|.[=WritableStream/[[backpressure]]=] to |backpressure|.
 </div>
 
 <h4 id="ws-writer-abstract-ops">Writers</h4>

--- a/index.bs
+++ b/index.bs
@@ -2093,8 +2093,8 @@ are even meant to be generally useful by other specifications.
    1. <strong>Errors must be propagated backward:</strong> if |dest|.[=WritableStream/[[state]]=] is or becomes
       "`errored`", then
     1. If |preventCancel| is false, [=shutdown with an action=] of !
-       [$ReadableStreamCancel$](|source|, |dest|.\[[storedError]]) and with |dest|.\[[storedError]].
-    1. Otherwise, [=shutdown=] with |dest|.\[[storedError]].
+       [$ReadableStreamCancel$](|source|, |dest|.[=WritableStream/[[storedError]]=]) and with |dest|.[=WritableStream/[[storedError]]=].
+    1. Otherwise, [=shutdown=] with |dest|.[=WritableStream/[[storedError]]=].
    1. <strong>Closing must be propagated forward:</strong> if |source|.[=ReadableStream/[[state]]=] is or becomes
       "`closed`", then
     1. If |preventClose| is false, [=shutdown with an action=] of !
@@ -4019,7 +4019,7 @@ are even meant to be generally useful by other specifications.
  steps:
 
  1. Set |stream|.[=WritableStream/[[state]]=] to "`writable`".
- 1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
+ 1. Set |stream|.[=WritableStream/[[storedError]]=], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
     |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
     |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
@@ -4051,7 +4051,7 @@ are even meant to be generally useful by other specifications.
   1. Otherwise, set |writer|.\[[readyPromise]] to [=a promise resolved with=] undefined.
   1. Set |writer|.\[[closedPromise]] to [=a new promise=].
  1. Otherwise, if |state| is "`erroring`",
-  1. Set |writer|.\[[readyPromise]] to [=a promise rejected with=] |stream|.\[[storedError]].
+  1. Set |writer|.\[[readyPromise]] to [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.\[[readyPromise]].\[[PromiseIsHandled]] to true.
   1. Set |writer|.\[[closedPromise]] to [=a new promise=].
  1. Otherwise, if |state| is "`closed`",
@@ -4059,7 +4059,7 @@ are even meant to be generally useful by other specifications.
   1. Set |writer|.\[[closedPromise]] to [=a promise resolved with=] undefined.
  1. Otherwise,
   1. Assert: |state| is "`errored`".
-  1. Let |storedError| be |stream|.\[[storedError]].
+  1. Let |storedError| be |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.\[[readyPromise]] to [=a promise rejected with=] |storedError|.
   1. Set |writer|.\[[readyPromise]].\[[PromiseIsHandled]] to true.
   1. Set |writer|.\[[closedPromise]] to [=a promise rejected with=] |storedError|.
@@ -4181,7 +4181,7 @@ the {{WritableStream}}'s public API.
  1. Assert: ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`errored`".
  1. Perform ! |stream|.[=WritableStream/[[controller]]=].\[[ErrorSteps]]().
- 1. Let |storedError| be |stream|.\[[storedError]].
+ 1. Let |storedError| be |stream|.[=WritableStream/[[storedError]]=].
  1. [=list/For each=] |writeRequest| of |stream|.\[[writeRequests]]:
   1. [=Reject=] |writeRequest| with |storedError|.
  1. Set |stream|.\[[writeRequests]] to an empty [=list=].
@@ -4215,7 +4215,7 @@ the {{WritableStream}}'s public API.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
  1. If |state| is "`erroring`",
-  1. Set |stream|.\[[storedError]] to undefined.
+  1. Set |stream|.[=WritableStream/[[storedError]]=] to undefined.
   1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
    1. [=Resolve=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=] with
       undefined.
@@ -4224,7 +4224,7 @@ the {{WritableStream}}'s public API.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, [=resolve=] |writer|.\[[closedPromise]] with undefined.
  1. Assert: |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined.
- 1. Assert: |stream|.\[[storedError]] is undefined.
+ 1. Assert: |stream|.[=WritableStream/[[storedError]]=] is undefined.
 </div>
 
 <div algorithm>
@@ -4305,11 +4305,11 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`errored`".
  1. If |stream|.[=WritableStream/[[closeRequest]]=] is not undefined,
   1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined.
-  1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with |stream|.\[[storedError]].
+  1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with |stream|.[=WritableStream/[[storedError]]=].
   1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined,
-  1. [=Reject=] |writer|.\[[closedPromise]] with |stream|.\[[storedError]].
+  1. [=Reject=] |writer|.\[[closedPromise]] with |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.\[[closedPromise]].\[[PromiseIsHandled]] to true.
 </div>
 
@@ -4318,12 +4318,12 @@ the {{WritableStream}}'s public API.
  id="writable-stream-start-erroring">WritableStreamStartErroring(|stream|, |reason|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[storedError]] is undefined.
+ 1. Assert: |stream|.[=WritableStream/[[storedError]]=] is undefined.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Let |controller| be |stream|.[=WritableStream/[[controller]]=].
  1. Assert: |controller| is not undefined.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`erroring`".
- 1. Set |stream|.\[[storedError]] to |reason|.
+ 1. Set |stream|.[=WritableStream/[[storedError]]=] to |reason|.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, perform !
     [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |reason|).
@@ -4382,7 +4382,7 @@ The following abstract operations support the implementation and manipulation of
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
     [=a promise resolved with=] undefined.
- 1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.\[[storedError]].
+ 1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
  1. Assert: |state| is "`writable`" or "`erroring`".
  1. Return ! [$WritableStreamDefaultWriterClose$](|writer|).
 
@@ -4451,11 +4451,11 @@ The following abstract operations support the implementation and manipulation of
  1. If |stream| is not equal to |writer|.\[[stream]], return [=a promise rejected with=] a
     {{TypeError}} exception.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
- 1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.\[[storedError]].
+ 1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
     [=a promise rejected with=] a {{TypeError}} exception indicating that the stream is closing or
     closed.
- 1. If |state| is "`erroring`", return [=a promise rejected with=] |stream|.\[[storedError]].
+ 1. If |state| is "`erroring`", return [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
  1. Assert: |state| is "`writable`".
  1. Let |promise| be ! [$WritableStreamAddWriteRequest$](|stream|).
  1. Perform ! [$WritableStreamDefaultControllerWrite$](|controller|, |chunk|, |chunkSize|).
@@ -5328,7 +5328,7 @@ side=] of [=transform streams=].
      steps:
    1. Let |writable| be |stream|.\[[writable]].
    1. Let |state| be |writable|.[=WritableStream/[[state]]=].
-   1. If |state| is "`erroring`", throw |writable|.\[[storedError]].
+   1. If |state| is "`erroring`", throw |writable|.[=WritableStream/[[storedError]]=].
    1. Assert: |state| is "`writable`".
    1. Return ! [$TransformStreamDefaultControllerPerformTransform$](|controller|, |chunk|).
  1. Return ! [$TransformStreamDefaultControllerPerformTransform$](|controller|, |chunk|).

--- a/index.bs
+++ b/index.bs
@@ -5132,7 +5132,7 @@ are even meant to be generally useful by other specifications.
   1. Return [=a promise resolved with=] undefined.
  1. Set |stream|.\[[readable]] to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancelAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
- 1. Set |stream|.[=TransformStream/[[backpressure]]=] and |stream|.\[[backpressureChangePromise]] to undefined.
+ 1. Set |stream|.[=TransformStream/[[backpressure]]=] and |stream|.[=TransformStream/[[backpressureChangePromise]]=] to undefined.
     <p class="note">The [=TransformStream/[[backpressure]]=] slot is set to undefined so that it can be initialized by
     [$TransformStreamSetBackpressure$]. Alternatively, implementations can use a strictly boolean
     value for [=TransformStream/[[backpressure]]=] and change the way it is initialized. This will not be visible to
@@ -5166,7 +5166,7 @@ are even meant to be generally useful by other specifications.
     false).
 
  <p class="note">The [$TransformStreamDefaultSinkWriteAlgorithm$] abstract operation could be
- waiting for the promise stored in the \[[backpressureChangePromise]] slot to resolve. The call to
+ waiting for the promise stored in the [=TransformStream/[[backpressureChangePromise]]=] slot to resolve. The call to
  [$TransformStreamSetBackpressure$] ensures that the promise always resolves.
 </div>
 
@@ -5176,9 +5176,9 @@ are even meant to be generally useful by other specifications.
  |backpressure|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is not |backpressure|.
- 1. If |stream|.\[[backpressureChangePromise]] is not undefined, [=resolve=]
-    stream.\[[backpressureChangePromise]] with undefined.
- 1. Set |stream|.\[[backpressureChangePromise]] to [=a new promise=].
+ 1. If |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined, [=resolve=]
+    stream.[=TransformStream/[[backpressureChangePromise]]=] with undefined.
+ 1. Set |stream|.[=TransformStream/[[backpressureChangePromise]]=] to [=a new promise=].
  1. Set |stream|.[=TransformStream/[[backpressure]]=] to |backpressure|.
 </div>
 
@@ -5322,7 +5322,7 @@ side=] of [=transform streams=].
  1. Assert: |stream|.\[[writable]].[=WritableStream/[[state]]=] is "`writable`".
  1. Let |controller| be |stream|.\[[controller]].
  1. If |stream|.[=TransformStream/[[backpressure]]=] is true,
-  1. Let |backpressureChangePromise| be |stream|.\[[backpressureChangePromise]].
+  1. Let |backpressureChangePromise| be |stream|.[=TransformStream/[[backpressureChangePromise]]=].
   1. Assert: |backpressureChangePromise| is not undefined.
   1. Return the result of [=reacting=] to |backpressureChangePromise| with the following fulfillment
      steps:
@@ -5372,9 +5372,9 @@ side=] of [=transform streams=].
  performs the following steps:
 
  1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is true.
- 1. Assert: |stream|.\[[backpressureChangePromise]] is not undefined.
+ 1. Assert: |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined.
  1. Perform ! [$TransformStreamSetBackpressure$](|stream|, false).
- 1. Return |stream|.\[[backpressureChangePromise]].
+ 1. Return |stream|.[=TransformStream/[[backpressureChangePromise]]=].
 </div>
 
 <h2 id="qs">Queuing strategies</h2>

--- a/index.bs
+++ b/index.bs
@@ -5599,7 +5599,7 @@ interface CountQueuingStrategy {
 
 <h4 id="cqs-internal-slots">Internal slots</h4>
 
-Instances of {{CountQueuingStrategy}} have a \[[highWaterMark]] internal slot, storing the
+Instances of {{CountQueuingStrategy}} have a <dfn for="CountQueuingStrategy">\[[highWaterMark]]</dfn> internal slot, storing the
 value given in the constructor.
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -3434,7 +3434,7 @@ table:
   requests not yet processed by the [=underlying sink=]
 </table>
 
-<p class="note">The \[[inFlightCloseRequest]] slot and [=WritableStream/[[closeRequest]]=] slot are mutually
+<p class="note">The [=WritableStream/[[inFlightCloseRequest]]=] slot and [=WritableStream/[[closeRequest]]=] slot are mutually
 exclusive. Similarly, no element will be removed from \[[writeRequests]] while
 [=WritableStream/[[inFlightWriteRequest]]=] is not undefined. Implementations can optimize storage for these slots
 based on these invariants.
@@ -4021,7 +4021,7 @@ are even meant to be generally useful by other specifications.
  1. Set |stream|.\[[state]] to "`writable`".
  1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
     |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
-    |stream|.\[[inFlightCloseRequest]] and |stream|.\[[pendingAbortRequest]] to undefined.
+    |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.\[[pendingAbortRequest]] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
 </div>
@@ -4154,7 +4154,7 @@ the {{WritableStream}}'s public API.
  id="writable-stream-close-queued-or-in-flight">WritableStreamCloseQueuedOrInFlight(|stream|)</dfn>
  performs the following steps:
 
- 1. If |stream|.[=WritableStream/[[closeRequest]]=] is undefined and |stream|.\[[inFlightCloseRequest]] is undefined,
+ 1. If |stream|.[=WritableStream/[[closeRequest]]=] is undefined and |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined,
     return false.
  1. Return true.
 </div>
@@ -4209,9 +4209,9 @@ the {{WritableStream}}'s public API.
  id="writable-stream-finish-in-flight-close">WritableStreamFinishInFlightClose(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[inFlightCloseRequest]] is not undefined.
- 1. [=Resolve=] |stream|.\[[inFlightCloseRequest]] with undefined.
- 1. Set |stream|.\[[inFlightCloseRequest]] to undefined.
+ 1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is not undefined.
+ 1. [=Resolve=] |stream|.[=WritableStream/[[inFlightCloseRequest]]=] with undefined.
+ 1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
  1. Let |state| be |stream|.\[[state]].
  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
  1. If |state| is "`erroring`",
@@ -4232,9 +4232,9 @@ the {{WritableStream}}'s public API.
  id="writable-stream-finish-in-flight-close-with-error">WritableStreamFinishInFlightCloseWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[inFlightCloseRequest]] is not undefined.
- 1. [=Reject=] |stream|.\[[inFlightCloseRequest]] with |error|.
- 1. Set |stream|.\[[inFlightCloseRequest]] to undefined.
+ 1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is not undefined.
+ 1. [=Reject=] |stream|.[=WritableStream/[[inFlightCloseRequest]]=] with |error|.
+ 1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
  1. If |stream|.\[[pendingAbortRequest]] is not undefined,
   1. [=Reject=] |stream|.\[[pendingAbortRequest]]'s [=pending abort request/promise=] with |error|.
@@ -4270,7 +4270,7 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. If |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is undefined and
-    |stream|.[=WritableStream/[[controller]]=].\[[inFlightCloseRequest]] is undefined, return false.
+    |stream|.[=WritableStream/[[controller]]=].[=WritableStream/[[inFlightCloseRequest]]=] is undefined, return false.
  1. Return true.
 </div>
 
@@ -4279,9 +4279,9 @@ the {{WritableStream}}'s public API.
  id="writable-stream-mark-close-request-in-flight">WritableStreamMarkCloseRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[inFlightCloseRequest]] is undefined.
+ 1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined.
  1. Assert: |stream|.[=WritableStream/[[closeRequest]]=] is not undefined.
- 1. Set |stream|.\[[inFlightCloseRequest]] to |stream|.[=WritableStream/[[closeRequest]]=].
+ 1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to |stream|.[=WritableStream/[[closeRequest]]=].
  1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
 </div>
 
@@ -4304,7 +4304,7 @@ the {{WritableStream}}'s public API.
 
  1. Assert: |stream|.\[[state]] is "`errored`".
  1. If |stream|.[=WritableStream/[[closeRequest]]=] is not undefined,
-  1. Assert: |stream|.\[[inFlightCloseRequest]] is undefined.
+  1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined.
   1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with |stream|.\[[storedError]].
   1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
  1. Let |writer| be |stream|.\[[writer]].

--- a/index.bs
+++ b/index.bs
@@ -1720,7 +1720,7 @@ has the following [=struct/items=]:
      |firstDescriptor|'s [=pull-into descriptor/bytes filled=], |firstDescriptor|'s [=pull-into
      descriptor/byte length=] − |firstDescriptor|'s [=pull-into descriptor/bytes filled=] »).
   1. Let |byobRequest| be a [=new=] {{ReadableStreamBYOBRequest}}.
-  1. Set |byobRequest|.\[[controller]] to [=this=].
+  1. Set |byobRequest|.[=ReadableStreamBYOBRequest/[[controller]]=] to [=this=].
   1. Set |byobRequest|.\[[view]] to |view|.
   1. Set [=this=].[=ReadableByteStreamController/[[byobRequest]]=] to |byobRequest|.
  1. Return [=this=].[=ReadableByteStreamController/[[byobRequest]]=].
@@ -1892,12 +1892,12 @@ following table:
  The <dfn id="rs-byob-request-respond" method
  for="ReadableStreamBYOBRequest">respond(|bytesWritten|)</dfn> method steps are:
 
- 1. If [=this=].\[[controller]] is undefined, throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}} exception.
  1. If [$IsDetachedBuffer$]([=this=].\[[view]].\[[ArrayBuffer]]) is true, throw a {{TypeError}}
     exception.
  1. Assert: [=this=].\[[view]].\[[ByteLength]] &gt; 0.
  1. Assert: [=this=].\[[view]].\[[ViewedArrayBuffer]].\[[ByeLength]] &gt; 0.
- 1. Perform ? [$ReadableByteStreamControllerRespond$]([=this=].\[[controller]], |bytesWritten|).
+ 1. Perform ? [$ReadableByteStreamControllerRespond$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=], |bytesWritten|).
 </div>
 
 <div algorithm>
@@ -1907,8 +1907,8 @@ following table:
  1. If |view|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
- 1. If [=this=].\[[controller]] is undefined, throw a {{TypeError}} exception.
- 1. Return ? [$ReadableByteStreamControllerRespondWithNewView$]([=this=].\[[controller]], |view|).
+ 1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}} exception.
+ 1. Return ? [$ReadableByteStreamControllerRespondWithNewView$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=], |view|).
 </div>
 
 <h3 id="rs-all-abstract-ops">Abstract operations</h3>
@@ -2985,7 +2985,7 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. If |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null, return.
- 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].\[[controller]] to undefined.
+ 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].[=ReadableStreamBYOBRequest/[[controller]]=] to undefined.
  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].\[[view]] to null.
  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to null.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2530,7 +2530,7 @@ The following abstract operations support the implementation of the
   1. Return.
  1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
  1. Set |controller|.\[[pulling]] to true.
- 1. Let |pullPromise| be the result of performing |controller|.\[[pullAlgorithm]].
+ 1. Let |pullPromise| be the result of performing |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=].
  1. [=Upon fulfillment=] of |pullPromise|,
   1. Set |controller|.\[[pulling]] to false.
   1. If |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is true,
@@ -2570,7 +2570,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Set |controller|.\[[pullAlgorithm]] to undefined.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=] to undefined.
  1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to undefined.
  1. Set |controller|.\[[strategySizeAlgorithm]] to undefined.
 </div>
@@ -2695,7 +2695,7 @@ The following abstract operations support the implementation of the
     |controller|.\[[pulling]] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.\[[strategyHWM]]
     to |highWaterMark|.
- 1. Set |controller|.\[[pullAlgorithm]] to |pullAlgorithm|.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
  1. Set |stream|.[=ReadableStream/[[controller]]=] to |controller|.
  1. Let |startResult| be the result of performing |startAlgorithm|. (This might throw an exception.)
@@ -2749,7 +2749,7 @@ The following abstract operations support the implementation of the
   1. Return.
  1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
  1. Set |controller|.\[[pulling]] to true.
- 1. Let |pullPromise| be the result of performing |controller|.\[[pullAlgorithm]].
+ 1. Let |pullPromise| be the result of performing |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=].
  1. [=Upon fulfillment=] of |pullPromise|,
   1. Set |controller|.\[[pulling]] to false.
   1. If |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is true,
@@ -2773,7 +2773,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Set |controller|.\[[pullAlgorithm]] to undefined.
+ 1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to undefined.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to undefined.
 </div>
 
@@ -3189,7 +3189,7 @@ The following abstract operations support the implementation of the
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.\[[started]] to false.
  1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
- 1. Set |controller|.\[[pullAlgorithm]] to |pullAlgorithm|.
+ 1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
  1. Set |controller|.\[[autoAllocateChunkSize]] to |autoAllocateChunkSize|.
  1. Set |controller|.\[[pendingPullIntos]] to a new empty [=list=].

--- a/index.bs
+++ b/index.bs
@@ -4019,7 +4019,7 @@ are even meant to be generally useful by other specifications.
  steps:
 
  1. Set |stream|.\[[state]] to "`writable`".
- 1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.\[[controller]],
+ 1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
     |stream|.\[[inFlightWriteRequest]], |stream|.[=WritableStream/[[closeRequest]]=],
     |stream|.\[[inFlightCloseRequest]] and |stream|.\[[pendingAbortRequest]] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
@@ -4102,7 +4102,7 @@ are even meant to be generally useful by other specifications.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and |state| is
     "`writable`", [=resolve=] |writer|.\[[readyPromise]] with undefined.
- 1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.\[[controller]]).
+ 1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.[=WritableStream/[[controller]]=]).
  1. Return |promise|.
 </div>
 
@@ -4180,7 +4180,7 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.\[[state]] is "`erroring`".
  1. Assert: ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false.
  1. Set |stream|.\[[state]] to "`errored`".
- 1. Perform ! |stream|.\[[controller]].\[[ErrorSteps]]().
+ 1. Perform ! |stream|.[=WritableStream/[[controller]]=].\[[ErrorSteps]]().
  1. Let |storedError| be |stream|.\[[storedError]].
  1. [=list/For each=] |writeRequest| of |stream|.\[[writeRequests]]:
   1. [=Reject=] |writeRequest| with |storedError|.
@@ -4194,7 +4194,7 @@ the {{WritableStream}}'s public API.
   1. [=Reject=] |abortRequest|'s [=pending abort request/promise=] with |storedError|.
   1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
   1. Return.
- 1. Let |promise| be ! stream.\[[controller]].\[[AbortSteps]](|abortRequest|'s [=pending abort
+ 1. Let |promise| be ! stream.[=WritableStream/[[controller]]=].\[[AbortSteps]](|abortRequest|'s [=pending abort
     request/reason=]).
  1. [=Upon fulfillment=] of |promise|,
   1. [=Resolve=] |abortRequest|'s [=pending abort request/promise=] with undefined.
@@ -4270,7 +4270,7 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. If |stream|.\[[inFlightWriteRequest]] is undefined and
-    |stream|.\[[controller]].\[[inFlightCloseRequest]] is undefined, return false.
+    |stream|.[=WritableStream/[[controller]]=].\[[inFlightCloseRequest]] is undefined, return false.
  1. Return true.
 </div>
 
@@ -4320,7 +4320,7 @@ the {{WritableStream}}'s public API.
 
  1. Assert: |stream|.\[[storedError]] is undefined.
  1. Assert: |stream|.\[[state]] is "`writable`".
- 1. Let |controller| be |stream|.\[[controller]].
+ 1. Let |controller| be |stream|.[=WritableStream/[[controller]]=].
  1. Assert: |controller| is not undefined.
  1. Set |stream|.\[[state]] to "`erroring`".
  1. Set |stream|.\[[storedError]] to |reason|.
@@ -4421,7 +4421,7 @@ The following abstract operations support the implementation and manipulation of
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`errored`" or "`erroring`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return ! [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.\[[controller]]).
+ 1. Return ! [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.[=WritableStream/[[controller]]=]).
 </div>
 
 <div algorithm>
@@ -4446,7 +4446,7 @@ The following abstract operations support the implementation and manipulation of
 
  1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
- 1. Let |controller| be |stream|.\[[controller]].
+ 1. Let |controller| be |stream|.[=WritableStream/[[controller]]=].
  1. Let |chunkSize| be ! [$WritableStreamDefaultControllerGetChunkSize$](|controller|, |chunk|).
  1. If |stream| is not equal to |writer|.\[[stream]], return [=a promise rejected with=] a
     {{TypeError}} exception.
@@ -4475,9 +4475,9 @@ The following abstract operations support the implementation of the
  |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{WritableStream}}.
- 1. Assert: |stream|.\[[controller]] is undefined.
+ 1. Assert: |stream|.[=WritableStream/[[controller]]=] is undefined.
  1. Set |controller|.\[[stream]] to |stream|.
- 1. Set |stream|.\[[controller]] to |controller|.
+ 1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.\[[started]] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm|.
@@ -5161,7 +5161,7 @@ are even meant to be generally useful by other specifications.
 
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.\[[controller]]).
  1. Perform !
-    [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].\[[controller]], |e|).
+    [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].[=WritableStream/[[controller]]=], |e|).
  1. If |stream|.\[[backpressure]] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
     false).
 

--- a/index.bs
+++ b/index.bs
@@ -2319,12 +2319,6 @@ the {{ReadableStream}}'s public API.
    1. Perform |readRequest|'s [=read request/close steps=].
   1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to an empty [=list=].
  1. [=Resolve=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with undefined.
-
- <p class="note">The case where |stream|.[=ReadableStream/[[state]]=] is "`closed`", but |stream|.[=ReadableStream/[[controller]]=].\[[closeRequested]]
- is false, will happen if the stream was closed without its controller's close method ever being
- called: i.e., if the stream was closed by a call to {{ReadableStream/cancel(reason)}}. In this
- case we allow the controller's <code>close()</code> method to be called and silently do nothing,
- since the cancelation was outside the control of the underlying source.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -5196,7 +5196,7 @@ The following abstract operations support the implementaiton of the
  1. Assert: |stream|.[=TransformStream/[[controller]]=] is undefined.
  1. Set |controller|.[=TransformStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=TransformStream/[[controller]]=] to |controller|.
- 1. Set |controller|.\[[transformAlgorithm]] to |transformAlgorithm|.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to |transformAlgorithm|.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to |flushAlgorithm|.
 </div>
 
@@ -5236,7 +5236,7 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Set |controller|.\[[transformAlgorithm]] to undefined.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to undefined.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to undefined.
 </div>
 
@@ -5285,7 +5285,7 @@ The following abstract operations support the implementaiton of the
  performs the following steps:
 
  1. Let |transformPromise| be the result of performing
-    |controller|.\[[transformAlgorithm]], passing |chunk|.
+    |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=], passing |chunk|.
  1. Return the result of [=reacting=] to |transformPromise| with the following
     rejection steps given the argument |r|:
    1. Perform ! [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=], |r|).

--- a/index.bs
+++ b/index.bs
@@ -1391,57 +1391,57 @@ interface ReadableStreamDefaultController {
 Instances of {{ReadableStreamDefaultController}} are created with the internal slots described in
 the following table:
 
-<table>
+<table dfn-for="ReadableStreamDefaultController">
  <thead>
   <tr>
    <th>Internal Slot</th>
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
   <tr>
-   <td>\[[cancelAlgorithm]]
+   <td><dfn>\[[cancelAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm, taking one argument (the cancel reason),
    which communicates a requested cancelation to the [=underlying source=]
   <tr>
-   <td>\[[closeRequested]]
+   <td><dfn>\[[closeRequested]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the stream has been closed by its
    [=underlying source=], but still has [=chunks=] in its internal queue that have not yet been
    read
   <tr>
-   <td>\[[pullAgain]]
+   <td><dfn>\[[pullAgain]]</dfn>
    <td class="non-normative">A boolean flag set to true if the stream's mechanisms requested a call
    to the [=underlying source=]'s pull algorithm to pull more data, but the pull could not yet be
    done since a previous call is still executing
   <tr>
-   <td>\[[pullAlgorithm]]
+   <td><dfn>\[[pullAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm that pulls data from the [=underlying
    source=]
   <tr>
-   <td>\[[pulling]]
+   <td><dfn>\[[pulling]]</dfn>
    <td class="non-normative">A boolean flag set to true while the [=underlying source=]'s pull
    algorithm is executing and the returned promise has not yet fulfilled, used to prevent reentrant
    calls
   <tr>
-   <td>\[[queue]]
+   <td><dfn>\[[queue]]</dfn>
    <td class="non-normative">A [=list=] representing the stream's internal queue of [=chunks=]
   <tr>
-   <td>\[[queueTotalSize]]
+   <td><dfn>\[[queueTotalSize]]</dfn>
    <td class="non-normative">The total size of all the chunks stored in \[[queue]] (see
    [[#queue-with-sizes]])
   <tr>
-   <td>\[[started]]
+   <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying source=] has
    finished starting
   <tr>
-   <td>\[[strategyHWM]]
+   <td><dfn>\[[strategyHWM]]</dfn>
    <td class="non-normative">A number supplied to the constructor as part of the stream's [=queuing
    strategy=], indicating the point at which the stream will apply [=backpressure=] to its
    [=underlying source=]
   <tr>
-   <td>\[[strategySizeAlgorithm]]
+   <td><dfn>\[[strategySizeAlgorithm]]</dfn>
    <td class="non-normative">An algorithm to calculate the size of enqueued [=chunks=], as part of
    the stream's [=queuing strategy=]
   <tr>
-   <td>\[[stream]]
+   <td><dfn>\[[stream]]</dfn>
    <td class="non-normative">The {{ReadableStream}} instance controlled
 </table>
 
@@ -1566,66 +1566,66 @@ interface ReadableByteStreamController {
 Instances of {{ReadableByteStreamController}} are created with the internal slots described in the
 following table:
 
-<table>
+<table dfn-for="ReadableByteStreamController">
  <thead>
   <tr>
    <th>Internal Slot</th>
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
   <tr>
-   <td>\[[autoAllocateChunkSize]]
+   <td><dfn>\[[autoAllocateChunkSize]]</dfn>
    <td class="non-normative">A positive integer, when the automatic buffer allocation feature is
    enabled. In that case, this value specifies the size of buffer to allocate. It is undefined
    otherwise.
   <tr>
-   <td>\[[byobRequest]]
+   <td><dfn>\[[byobRequest]]</dfn>
    <td class="non-normative">A {{ReadableStreamBYOBRequest}} instance representing the current BYOB
    pull request, or null if there are no pending requests
   <tr>
-   <td>\[[cancelAlgorithm]]
+   <td><dfn>\[[cancelAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm, taking one argument (the cancel reason),
    which communicates a requested cancelation to the [=underlying byte source=]
   <tr>
-   <td>\[[closeRequested]]
+   <td><dfn>\[[closeRequested]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the stream has been closed by its
    [=underlying byte source=], but still has [=chunks=] in its internal queue that have not yet been
    read
   <tr>
-   <td>\[[pullAgain]]
+   <td><dfn>\[[pullAgain]]</dfn>
    <td class="non-normative">A boolean flag set to true if the stream's mechanisms requested a call
    to the [=underlying byte source=]'s pull algorithm to pull more data, but the pull could not yet
    be done since a previous call is still executing
   <tr>
-   <td>\[[pullAlgorithm]]
+   <td><dfn>\[[pullAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm that pulls data from the [=underlying
    byte source=]
   <tr>
-   <td>\[[pulling]]
+   <td><dfn>\[[pulling]]</dfn>
    <td class="non-normative">A boolean flag set to true while the [=underlying byte source=]'s pull
    algorithm is executing and the returned promise has not yet fulfilled, used to prevent reentrant
    calls
   <tr>
-   <td>\[[pendingPullIntos]]
+   <td><dfn>\[[pendingPullIntos]]</dfn>
    <td class="non-normative">A [=list=] of [=pull-into descriptors=]
   <tr>
-   <td>\[[queue]]
+   <td><dfn>\[[queue]]</dfn>
    <td class="non-normative">A [=list=] of [=readable byte stream queue entry|readable byte stream
    queue entries=] representing the stream's internal queue of [=chunks=]
   <tr>
-   <td>\[[queueTotalSize]]
+   <td><dfn>\[[queueTotalSize]]</dfn>
    <td class="non-normative">The total size, in bytes, of all the chunks stored in \[[queue]] (see
    [[#queue-with-sizes]])
   <tr>
-   <td>\[[started]]
+   <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying byte source=] has
    finished starting
   <tr>
-   <td>\[[strategyHWM]]
+   <td><dfn>\[[strategyHWM]]</dfn>
    <td class="non-normative">A number supplied to the constructor as part of the stream's [=queuing
    strategy=], indicating the point at which the stream will apply [=backpressure=] to its
    [=underlying byte source=]
   <tr>
-   <td>\[[stream]]
+   <td><dfn>\[[stream]]</dfn>
    <td class="non-normative">The {{ReadableStream}} instance controlled
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -4951,7 +4951,7 @@ side=], or to terminate or error the stream.
  1. Let |startPromise| be [=a new promise=].
  1. If |transformerDict|["{{Transformer/start}}"] [=map/exists=], then [=resolve=] |startPromise|
     with the result of [=invoking=] |transformerDict|["{{Transformer/start}}"] with argument list
-    «&nbsp;[=this=].\[[controller]]&nbsp;» and [=callback this value=] |transformer|.
+    «&nbsp;[=this=].[=TransformStream/[[controller]]=]&nbsp;» and [=callback this value=] |transformer|.
  1. Otherwise, [=resolve=] |startPromise| with undefined.
 </div>
 
@@ -5139,7 +5139,7 @@ are even meant to be generally useful by other specifications.
     user code so long as the initialization is correctly completed before the transformer's
     {{Transformer/start|start()}} method is called.
  1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
- 1. Set |stream|.\[[controller]] to undefined.
+ 1. Set |stream|.[=TransformStream/[[controller]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -5159,7 +5159,7 @@ are even meant to be generally useful by other specifications.
  id="transform-stream-error-writable-and-unblock-write">TransformStreamErrorWritableAndUnblockWrite(|stream|,
  |e|)</dfn> performs the following steps:
 
- 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.\[[controller]]).
+ 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.[=TransformStream/[[controller]]=]).
  1. Perform !
     [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].[=WritableStream/[[controller]]=], |e|).
  1. If |stream|.[=TransformStream/[[backpressure]]=] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
@@ -5193,9 +5193,9 @@ The following abstract operations support the implementaiton of the
  |controller|, |transformAlgorithm|, |flushAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{TransformStream}}.
- 1. Assert: |stream|.\[[controller]] is undefined.
+ 1. Assert: |stream|.[=TransformStream/[[controller]]=] is undefined.
  1. Set |controller|.\[[stream]] to |stream|.
- 1. Set |stream|.\[[controller]] to |controller|.
+ 1. Set |stream|.[=TransformStream/[[controller]]=] to |controller|.
  1. Set |controller|.\[[transformAlgorithm]] to |transformAlgorithm|.
  1. Set |controller|.\[[flushAlgorithm]] to |flushAlgorithm|.
 </div>
@@ -5320,7 +5320,7 @@ side=] of [=transform streams=].
  |chunk|)</dfn> performs the following steps:
 
  1. Assert: |stream|.\[[writable]].[=WritableStream/[[state]]=] is "`writable`".
- 1. Let |controller| be |stream|.\[[controller]].
+ 1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
  1. If |stream|.[=TransformStream/[[backpressure]]=] is true,
   1. Let |backpressureChangePromise| be |stream|.[=TransformStream/[[backpressureChangePromise]]=].
   1. Assert: |backpressureChangePromise| is not undefined.
@@ -5349,7 +5349,7 @@ side=] of [=transform streams=].
  performs the following steps:
 
  1. Let |readable| be |stream|.\[[readable]].
- 1. Let |controller| be |stream|.\[[controller]].
+ 1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
  1. Let |flushPromise| be the result of performing |controller|.\[[flushAlgorithm]].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Return the result of [=reacting=] to |flushPromise|:

--- a/index.bs
+++ b/index.bs
@@ -2525,14 +2525,14 @@ The following abstract operations support the implementation of the
 
  1. Let |shouldPull| be ! [$ReadableStreamDefaultControllerShouldCallPull$](|controller|).
  1. If |shouldPull| is false, return.
- 1. If |controller|.\[[pulling]] is true,
+ 1. If |controller|.[=ReadableStreamDefaultController/[[pulling]]=] is true,
   1. Set |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] to true.
   1. Return.
  1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
- 1. Set |controller|.\[[pulling]] to true.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to true.
  1. Let |pullPromise| be the result of performing |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=].
  1. [=Upon fulfillment=] of |pullPromise|,
-  1. Set |controller|.\[[pulling]] to false.
+  1. Set |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
   1. If |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is true,
    1. Set |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] to false.
    1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
@@ -2692,7 +2692,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[stream]] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.\[[started]], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
-    |controller|.\[[pulling]] to false.
+    |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.\[[strategyHWM]]
     to |highWaterMark|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=] to |pullAlgorithm|.
@@ -2702,7 +2702,7 @@ The following abstract operations support the implementation of the
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=]  of |startPromise|,
   1. Set |controller|.\[[started]] to true.
-  1. Assert: |controller|.\[[pulling]] is false.
+  1. Assert: |controller|.[=ReadableStreamDefaultController/[[pulling]]=] is false.
   1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
   1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
@@ -2744,14 +2744,14 @@ The following abstract operations support the implementation of the
 
  1. Let |shouldPull| be ! [$ReadableByteStreamControllerShouldCallPull$](|controller|).
  1. If |shouldPull| is false, return.
- 1. If |controller|.\[[pulling]] is true,
+ 1. If |controller|.[=ReadableByteStreamController/[[pulling]]=] is true,
   1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] to true.
   1. Return.
  1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
- 1. Set |controller|.\[[pulling]] to true.
+ 1. Set |controller|.[=ReadableByteStreamController/[[pulling]]=] to true.
  1. Let |pullPromise| be the result of performing |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=].
  1. [=Upon fulfillment=] of |pullPromise|,
-  1. Set |controller|.\[[pulling]] to false.
+  1. Set |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
   1. If |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is true,
    1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] to false.
    1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
@@ -3184,7 +3184,7 @@ The following abstract operations support the implementation of the
   1. Assert: ! IsInteger(|autoAllocateChunkSize|) is true.
   1. Assert: |autoAllocateChunkSize| is positive.
  1. Set |controller|.\[[stream]] to |stream|.
- 1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and |controller|.\[[pulling]] to false.
+ 1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
  1. Set |controller|.\[[byobRequest]] to null.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.\[[started]] to false.
@@ -3198,7 +3198,7 @@ The following abstract operations support the implementation of the
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=]  of |startPromise|,
    1. Set |controller|.\[[started]] to true.
-   1. Assert: |controller|.\[[pulling]] is false.
+   1. Assert: |controller|.[=ReadableByteStreamController/[[pulling]]=] is false.
    1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
    1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,

--- a/index.bs
+++ b/index.bs
@@ -3434,7 +3434,7 @@ table:
   requests not yet processed by the [=underlying sink=]
 </table>
 
-<p class="note">The \[[inFlightCloseRequest]] slot and \[[closeRequest]] slot are mutually
+<p class="note">The \[[inFlightCloseRequest]] slot and [=WritableStream/[[closeRequest]]=] slot are mutually
 exclusive. Similarly, no element will be removed from \[[writeRequests]] while
 \[[inFlightWriteRequest]] is not undefined. Implementations can optimize storage for these slots
 based on these invariants.
@@ -4020,7 +4020,7 @@ are even meant to be generally useful by other specifications.
 
  1. Set |stream|.\[[state]] to "`writable`".
  1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.\[[controller]],
-    |stream|.\[[inFlightWriteRequest]], |stream|.\[[closeRequest]],
+    |stream|.\[[inFlightWriteRequest]], |stream|.[=WritableStream/[[closeRequest]]=],
     |stream|.\[[inFlightCloseRequest]] and |stream|.\[[pendingAbortRequest]] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
@@ -4098,7 +4098,7 @@ are even meant to be generally useful by other specifications.
  1. Assert: |state| is "`writable`" or "`erroring`".
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
  1. Let |promise| be [=a new promise=].
- 1. Set |stream|.\[[closeRequest]] to |promise|.
+ 1. Set |stream|.[=WritableStream/[[closeRequest]]=] to |promise|.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and |state| is
     "`writable`", [=resolve=] |writer|.\[[readyPromise]] with undefined.
@@ -4154,7 +4154,7 @@ the {{WritableStream}}'s public API.
  id="writable-stream-close-queued-or-in-flight">WritableStreamCloseQueuedOrInFlight(|stream|)</dfn>
  performs the following steps:
 
- 1. If |stream|.\[[closeRequest]] is undefined and |stream|.\[[inFlightCloseRequest]] is undefined,
+ 1. If |stream|.[=WritableStream/[[closeRequest]]=] is undefined and |stream|.\[[inFlightCloseRequest]] is undefined,
     return false.
  1. Return true.
 </div>
@@ -4280,9 +4280,9 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. Assert: |stream|.\[[inFlightCloseRequest]] is undefined.
- 1. Assert: |stream|.\[[closeRequest]] is not undefined.
- 1. Set |stream|.\[[inFlightCloseRequest]] to |stream|.\[[closeRequest]].
- 1. Set |stream|.\[[closeRequest]] to undefined.
+ 1. Assert: |stream|.[=WritableStream/[[closeRequest]]=] is not undefined.
+ 1. Set |stream|.\[[inFlightCloseRequest]] to |stream|.[=WritableStream/[[closeRequest]]=].
+ 1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -4303,10 +4303,10 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. Assert: |stream|.\[[state]] is "`errored`".
- 1. If |stream|.\[[closeRequest]] is not undefined,
+ 1. If |stream|.[=WritableStream/[[closeRequest]]=] is not undefined,
   1. Assert: |stream|.\[[inFlightCloseRequest]] is undefined.
-  1. [=Reject=] |stream|.\[[closeRequest]] with |stream|.\[[storedError]].
-  1. Set |stream|.\[[closeRequest]] to undefined.
+  1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with |stream|.\[[storedError]].
+  1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined,
   1. [=Reject=] |writer|.\[[closedPromise]] with |stream|.\[[storedError]].

--- a/index.bs
+++ b/index.bs
@@ -5045,7 +5045,7 @@ the following table:
  The <dfn id="ts-default-controller-desired-size" attribute
  for="TransformStreamDefaultController">desiredSize</dfn> getter steps are:
 
- 1. Let |readableController| be [=this=].\[[stream]].[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
+ 1. Let |readableController| be [=this=].[=TransformStreamDefaultController/[[stream]]=].[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. Return ! [$ReadableStreamDefaultControllerGetDesiredSize$](|readableController|).
 </div>
 
@@ -5194,7 +5194,7 @@ The following abstract operations support the implementaiton of the
 
  1. Assert: |stream| [=implements=] {{TransformStream}}.
  1. Assert: |stream|.[=TransformStream/[[controller]]=] is undefined.
- 1. Set |controller|.\[[stream]] to |stream|.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=TransformStream/[[controller]]=] to |controller|.
  1. Set |controller|.\[[transformAlgorithm]] to |transformAlgorithm|.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to |flushAlgorithm|.
@@ -5250,7 +5250,7 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=TransformStreamDefaultController/[[stream]]=].
  1. Let |readableController| be |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|readableController|) is false, throw
     a {{TypeError}} exception.
@@ -5276,7 +5276,7 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Perform ! [$TransformStreamError$](|controller|.\[[stream]], |e|).
+ 1. Perform ! [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=], |e|).
 </div>
 
 <div algorithm>
@@ -5288,7 +5288,7 @@ The following abstract operations support the implementaiton of the
     |controller|.\[[transformAlgorithm]], passing |chunk|.
  1. Return the result of [=reacting=] to |transformPromise| with the following
     rejection steps given the argument |r|:
-   1. Perform ! [$TransformStreamError$](|controller|.\[[stream]], |r|).
+   1. Perform ! [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=], |r|).
    1. Throw |r|.
 </div>
 
@@ -5302,7 +5302,7 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=TransformStreamDefaultController/[[stream]]=].
  1. Let |readableController| be |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. Perform ! [$ReadableStreamDefaultControllerClose$](|readableController|).
  1. Let |error| be a {{TypeError}} exception indicating that the stream has been terminated.

--- a/index.bs
+++ b/index.bs
@@ -2653,7 +2653,7 @@ The following abstract operations support the implementation of the
  1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return |controller|.\[[strategyHWM]] − |controller|.[=ReadableStreamDefaultController/[[queueTotalSize]]=].
+ 1. Return |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=] − |controller|.[=ReadableStreamDefaultController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>
@@ -2693,7 +2693,7 @@ The following abstract operations support the implementation of the
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
     |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
- 1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.\[[strategyHWM]]
+ 1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=]
     to |highWaterMark|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
@@ -2963,7 +2963,7 @@ The following abstract operations support the implementation of the
  1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return |controller|.\[[strategyHWM]] − |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=].
+ 1. Return |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] − |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>
@@ -3188,7 +3188,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[byobRequest]] to null.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.[=ReadableByteStreamController/[[started]]=] to false.
- 1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
+ 1. Set |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] to |highWaterMark|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
  1. Set |controller|.\[[autoAllocateChunkSize]] to |autoAllocateChunkSize|.

--- a/index.bs
+++ b/index.bs
@@ -3688,22 +3688,22 @@ interface WritableStreamDefaultWriter {
 Instances of {{WritableStreamDefaultWriter}} are created with the internal slots described in the
 following table:
 
-<table>
+<table dfn-for="WritableStreamDefaultWriter">
  <thead>
   <tr>
    <th>Internal Slot
    <th>Description (<em>non-normative</em>)
  <tbody>
   <tr>
-   <td>\[[closedPromise]]
+   <td><dfn>\[[closedPromise]]</dfn>
    <td class="non-normative">A promise returned by the writer's
    {{WritableStreamDefaultWriter/closed}} getter
   <tr>
-   <td>\[[readyPromise]]
+   <td><dfn>\[[readyPromise]]</dfn>
    <td class="non-normative">A promise returned by the writer's
    {{WritableStreamDefaultWriter/ready}} getter
   <tr>
-   <td>\[[stream]]
+   <td><dfn>\[[stream]]</dfn>
    <td class="non-normative">A {{WritableStream}} instance that owns this reader
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -1788,11 +1788,11 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
 
  1. Let |stream| be [=this=].\[[stream]].
  1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
- 1. If [=this=].\[[queueTotalSize]] > 0,
+ 1. If [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. Assert: ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0.
   1. Let |entry| be [=this=].[=ReadableByteStreamController/[[queue]]=][0].
   1. [=list/Remove=] |entry| from [=this=].[=ReadableByteStreamController/[[queue]]=].
-  1. Set [=this=].\[[queueTotalSize]] to [=this=].\[[queueTotalSize]] − |entry|'s [=readable byte
+  1. Set [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] to [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] − |entry|'s [=readable byte
      stream queue entry/byte length=].
   1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$]([=this=]).
   1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |entry|'s [=readable byte stream queue
@@ -2653,7 +2653,7 @@ The following abstract operations support the implementation of the
  1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return |controller|.\[[strategyHWM]] − |controller|.\[[queueTotalSize]].
+ 1. Return |controller|.\[[strategyHWM]] − |controller|.[=ReadableStreamDefaultController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>
@@ -2793,7 +2793,7 @@ The following abstract operations support the implementation of the
 
  1. Let |stream| be |controller|.\[[stream]].
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
- 1. If |controller|.\[[queueTotalSize]] > 0,
+ 1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] to true.
   1. Return.
  1. If |controller|.\[[pendingPullIntos]] is not empty,
@@ -2878,7 +2878,7 @@ The following abstract operations support the implementation of the
  1. [=list/Append=] a new [=readable byte stream queue entry=] with [=readable byte stream queue
     entry/buffer=] |buffer|, [=readable byte stream queue entry/byte offset=] |byteOffset|, and
     [=readable byte stream queue entry/byte length=] |byteLength| to |controller|.[=ReadableByteStreamController/[[queue]]=].
- 1. Set |controller|.\[[queueTotalSize]] to |controller|.\[[queueTotalSize]] + |byteLength|.
+ 1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] + |byteLength|.
 </div>
 
 <div algorithm>
@@ -2914,7 +2914,7 @@ The following abstract operations support the implementation of the
  1. Let |elementSize| be |pullIntoDescriptor|.\[[elementSize]].
  1. Let |currentAlignedBytes| be |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] −
     (|pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] mod |elementSize|).
- 1. Let |maxBytesToCopy| be min(|controller|.\[[queueTotalSize]], |pullIntoDescriptor|'s [=pull-into
+ 1. Let |maxBytesToCopy| be min(|controller|.[=ReadableByteStreamController/[[queueTotalSize]]=], |pullIntoDescriptor|'s [=pull-into
     descriptor/byte length=] − |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=]).
  1. Let |maxBytesFilled| be |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] +
     |maxBytesToCopy|.
@@ -2943,12 +2943,12 @@ The following abstract operations support the implementation of the
       [=readable byte stream queue entry/byte offset=] + |bytesToCopy|.
    1. Set |headOfQueue|'s [=readable byte stream queue entry/byte length=] to |headOfQueue|'s
       [=readable byte stream queue entry/byte length=] − |bytesToCopy|.
-  1. Set |controller|.\[[queueTotalSize]] to |controller|.\[[queueTotalSize]] − |bytesToCopy|.
+  1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] − |bytesToCopy|.
   1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
      |bytesToCopy|, |pullIntoDescriptor|).
   1. Set |totalBytesToCopyRemaining| to |totalBytesToCopyRemaining| − |bytesToCopy|.
  1. If |ready| is false,
-  1. Assert: |controller|.\[[queueTotalSize]] is 0.
+  1. Assert: |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0.
   1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] > 0.
   1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] &lt;
      |pullIntoDescriptor|'s [=pull-into descriptor/element size=].
@@ -2963,7 +2963,7 @@ The following abstract operations support the implementation of the
  1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return |controller|.\[[strategyHWM]] − |controller|.\[[queueTotalSize]].
+ 1. Return |controller|.\[[strategyHWM]] − |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>
@@ -2972,7 +2972,7 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Assert: |controller|.\[[stream]].[=ReadableStream/[[state]]=] is "`readable`".
- 1. If |controller|.\[[queueTotalSize]] is 0 and |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
+ 1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0 and |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
   1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
   1. Perform ! [$ReadableStreamClose$](|controller|.\[[stream]]).
  1. Otherwise,
@@ -2997,7 +2997,7 @@ The following abstract operations support the implementation of the
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is false.
  1. [=While=] |controller|.\[[pendingPullIntos]] is not [=list/is empty|empty=],
-  1. If |controller|.\[[queueTotalSize]] is 0, return.
+  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, return.
   1. Let |pullIntoDescriptor| be |controller|.\[[pendingPullIntos]][0].
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
      |pullIntoDescriptor|) is true,
@@ -3036,7 +3036,7 @@ The following abstract operations support the implementation of the
      descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=], 0 »).
   1. Perform |readIntoRequest|'s [=read-into request/close steps=], given |emptyView|.
   1. Return.
- 1. If |controller|.\[[queueTotalSize]] > 0,
+ 1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
      |pullIntoDescriptor|) is true,
    1. Let |filledView| be !

--- a/index.bs
+++ b/index.bs
@@ -3933,7 +3933,7 @@ developers.
  The <dfn id="ws-default-controller-error" method
  for="WritableStreamDefaultController">error(|e|)</dfn> method steps are:
 
- 1. Let |state| be [=this=].\[[stream]].[=WritableStream/[[state]]=].
+ 1. Let |state| be [=this=].[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=].
  1. If |state| is not "`writable`", return.
  1. Perform ! [$WritableStreamDefaultControllerError$]([=this=], |e|).
 </div>
@@ -4476,7 +4476,7 @@ The following abstract operations support the implementation of the
 
  1. Assert: |stream| [=implements=] {{WritableStream}}.
  1. Assert: |stream|.[=WritableStream/[[controller]]=] is undefined.
- 1. Set |controller|.\[[stream]] to |stream|.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
@@ -4535,7 +4535,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-advance-queue-if-needed">WritableStreamDefaultControllerAdvanceQueueIfNeeded(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. If |controller|.[=WritableStreamDefaultController/[[started]]=] is false, return.
  1. If |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is not undefined, return.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
@@ -4588,7 +4588,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-error">WritableStreamDefaultControllerError(|controller|,
  |error|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Perform ! [$WritableStreamStartErroring$](|stream|, |error|).
@@ -4599,7 +4599,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-error-if-needed">WritableStreamDefaultControllerErrorIfNeeded(|controller|,
  |error|)</dfn> performs the following steps:
 
- 1. If |controller|.\[[stream]].[=WritableStream/[[state]]=] is "`writable`", perform !
+ 1. If |controller|.[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=] is "`writable`", perform !
     [$WritableStreamDefaultControllerError$](|controller|, |error|).
 </div>
 
@@ -4639,7 +4639,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-process-close">WritableStreamDefaultControllerProcessClose(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. Perform ! [$WritableStreamMarkCloseRequestInFlight$](|stream|).
  1. Perform ! [$DequeueValue$](|controller|).
  1. Assert: |controller|.[=WritableStreamDefaultController/[[queue]]=] is empty.
@@ -4656,7 +4656,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-process-write">WritableStreamDefaultControllerProcessWrite(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. Perform ! [$WritableStreamMarkFirstWriteRequestInFlight$](|stream|).
  1. Let |sinkWritePromise| be the result of performing |controller|.\[[writeAlgorithm]], passing in
     |chunk|.
@@ -4685,7 +4685,7 @@ The following abstract operations support the implementation of the
   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|,
      |enqueueResult|.\[[Value]]).
   1. Return.
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[state]]=] is
     "`writable`",
   1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -3804,7 +3804,7 @@ following table:
  The <dfn id="default-writer-ready" attribute for="WritableStreamDefaultWriter">ready</dfn> getter
  steps are:
 
- 1. Return [=this=].\[[readyPromise]].
+ 1. Return [=this=].[=WritableStreamDefaultWriter/[[readyPromise]]=].
 </div>
 
 <div algorithm>
@@ -4047,21 +4047,21 @@ are even meant to be generally useful by other specifications.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
   1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[backpressure]]=]
-     is true, set |writer|.\[[readyPromise]] to [=a new promise=].
-  1. Otherwise, set |writer|.\[[readyPromise]] to [=a promise resolved with=] undefined.
+     is true, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a new promise=].
+  1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise resolved with=] undefined.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |state| is "`erroring`",
-  1. Set |writer|.\[[readyPromise]] to [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
-  1. Set |writer|.\[[readyPromise]].\[[PromiseIsHandled]] to true.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseIsHandled]] to true.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |state| is "`closed`",
-  1. Set |writer|.\[[readyPromise]] to [=a promise resolved with=] undefined.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise resolved with=] undefined.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise resolved with=] undefined.
  1. Otherwise,
   1. Assert: |state| is "`errored`".
   1. Let |storedError| be |stream|.[=WritableStream/[[storedError]]=].
-  1. Set |writer|.\[[readyPromise]] to [=a promise rejected with=] |storedError|.
-  1. Set |writer|.\[[readyPromise]].\[[PromiseIsHandled]] to true.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=] |storedError|.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseIsHandled]] to true.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected with=] |storedError|.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
@@ -4101,7 +4101,7 @@ are even meant to be generally useful by other specifications.
  1. Set |stream|.[=WritableStream/[[closeRequest]]=] to |promise|.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and |state| is
-    "`writable`", [=resolve=] |writer|.\[[readyPromise]] with undefined.
+    "`writable`", [=resolve=] |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] with undefined.
  1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.[=WritableStream/[[controller]]=]).
  1. Return |promise|.
 </div>
@@ -4340,10 +4340,10 @@ the {{WritableStream}}'s public API.
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined and |backpressure| is not |stream|.[=WritableStream/[[backpressure]]=],
-  1. If |backpressure| is true, set |writer|.\[[readyPromise]] to [=a new promise=].
+  1. If |backpressure| is true, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a new promise=].
   1. Otherwise,
    1. Assert: |backpressure| is false.
-   1. [=Resolve=] |writer|.\[[readyPromise]] with undefined.
+   1. [=Resolve=] |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] with undefined.
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to |backpressure|.
 </div>
 
@@ -4406,10 +4406,10 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-ensure-ready-promise-rejected">WritableStreamDefaultWriterEnsureReadyPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
- 1. If |writer|.\[[readyPromise]].\[[PromiseState]] is "`pending`", [=reject=]
-    |writer|.\[[readyPromise]] with |error|.
- 1. Otherwise, set |writer|.\[[readyPromise]] to [=a promise rejected with=] |error|.
- 1. Set |writer|.\[[readyPromise]].\[[PromiseIsHandled]] to true.
+ 1. If |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseState]] is "`pending`", [=reject=]
+    |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] with |error|.
+ 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=] |error|.
+ 1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -4996,21 +4996,21 @@ interface TransformStreamDefaultController {
 Instances of {{TransformStreamDefaultController}} are created with the internal slots described in
 the following table:
 
-<table>
+<table dfn-for="TransformStreamDefaultController">
  <thead>
   <tr>
    <th>Internal Slot</th>
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
   <tr>
-   <td>\[[flushAlgorithm]]
+   <td><dfn>\[[flushAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=transformer=]
   <tr>
-   <td>\[[stream]]
+   <td><dfn>\[[stream]]</dfn>
    <td class="non-normative">The {{TransformStream}} instance controlled
   <tr>
-   <td>\[[transformAlgorithm]]
+   <td><dfn>\[[transformAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm, taking one argument (the [=chunk=] to
    transform), which requests the [=transformer=] perform its transformation
 </table>

--- a/index.bs
+++ b/index.bs
@@ -4483,7 +4483,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm|.
  1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
  1. Set |controller|.\[[writeAlgorithm]] to |writeAlgorithm|.
- 1. Set |controller|.\[[closeAlgorithm]] to |closeAlgorithm|.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to |closeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to |abortAlgorithm|.
  1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
  1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
@@ -4566,7 +4566,7 @@ The following abstract operations support the implementation of the
  It performs the following steps:
 
  1. Set |controller|.\[[writeAlgorithm]] to undefined.
- 1. Set |controller|.\[[closeAlgorithm]] to undefined.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to undefined.
  1. Set |controller|.\[[strategySizeAlgorithm]] to undefined.
 
@@ -4643,7 +4643,7 @@ The following abstract operations support the implementation of the
  1. Perform ! [$WritableStreamMarkCloseRequestInFlight$](|stream|).
  1. Perform ! [$DequeueValue$](|controller|).
  1. Assert: |controller|.\[[queue]] is empty.
- 1. Let |sinkClosePromise| be the result of performing |controller|.\[[closeAlgorithm]].
+ 1. Let |sinkClosePromise| be the result of performing |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=].
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
  1. [=Upon fulfillment=] of |sinkClosePromise|,
   1. Perform ! [$WritableStreamFinishInFlightClose$](|stream|).

--- a/index.bs
+++ b/index.bs
@@ -1515,7 +1515,7 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
  1. Perform ! [$ResetQueue$]([=this=]).
- 1. Let |result| be the result of performing [=this=].\[[cancelAlgorithm]], passing |reason|.
+ 1. Let |result| be the result of performing [=this=].[=ReadableStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
  1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$]([=this=]).
  1. Return |result|.
 </div>
@@ -1776,7 +1776,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
   1. Let |firstDescriptor| be [=this=].\[[pendingPullIntos]][0].
   1. Set |firstDescriptor|'s [=pull-into descriptor/bytes filled=] to 0.
  1. Perform ! [$ResetQueue$]([=this=]).
- 1. Let |result| be the result of performing [=this=].\[[cancelAlgorithm]], passing in |reason|.
+ 1. Let |result| be the result of performing [=this=].[=ReadableByteStreamController/[[cancelAlgorithm]]=], passing in |reason|.
  1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$]([=this=]).
  1. Return |result|.
 </div>
@@ -2571,7 +2571,7 @@ The following abstract operations support the implementation of the
  It performs the following steps:
 
  1. Set |controller|.\[[pullAlgorithm]] to undefined.
- 1. Set |controller|.\[[cancelAlgorithm]] to undefined.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to undefined.
  1. Set |controller|.\[[strategySizeAlgorithm]] to undefined.
 </div>
 
@@ -2696,7 +2696,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.\[[strategyHWM]]
     to |highWaterMark|.
  1. Set |controller|.\[[pullAlgorithm]] to |pullAlgorithm|.
- 1. Set |controller|.\[[cancelAlgorithm]] to |cancelAlgorithm|.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
  1. Set |stream|.[=ReadableStream/[[controller]]=] to |controller|.
  1. Let |startResult| be the result of performing |startAlgorithm|. (This might throw an exception.)
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
@@ -2774,7 +2774,7 @@ The following abstract operations support the implementation of the
  It performs the following steps:
 
  1. Set |controller|.\[[pullAlgorithm]] to undefined.
- 1. Set |controller|.\[[cancelAlgorithm]] to undefined.
+ 1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -3190,7 +3190,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[closeRequested]] and |controller|.\[[started]] to false.
  1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
  1. Set |controller|.\[[pullAlgorithm]] to |pullAlgorithm|.
- 1. Set |controller|.\[[cancelAlgorithm]] to |cancelAlgorithm|.
+ 1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
  1. Set |controller|.\[[autoAllocateChunkSize]] to |autoAllocateChunkSize|.
  1. Set |controller|.\[[pendingPullIntos]] to a new empty [=list=].
  1. Set |stream|.[=ReadableStream/[[controller]]=] to |controller|.

--- a/index.bs
+++ b/index.bs
@@ -1721,7 +1721,7 @@ has the following [=struct/items=]:
      descriptor/byte length=] − |firstDescriptor|'s [=pull-into descriptor/bytes filled=] »).
   1. Let |byobRequest| be a [=new=] {{ReadableStreamBYOBRequest}}.
   1. Set |byobRequest|.[=ReadableStreamBYOBRequest/[[controller]]=] to [=this=].
-  1. Set |byobRequest|.\[[view]] to |view|.
+  1. Set |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] to |view|.
   1. Set [=this=].[=ReadableByteStreamController/[[byobRequest]]=] to |byobRequest|.
  1. Return [=this=].[=ReadableByteStreamController/[[byobRequest]]=].
 </div>
@@ -1885,7 +1885,7 @@ following table:
  The <dfn id="rs-byob-request-view" attribute for="ReadableStreamBYOBRequest">view</dfn>
  getter steps are:
 
- 1. Return [=this=].\[[view]].
+ 1. Return [=this=].[=ReadableStreamBYOBRequest/[[view]]=].
 </div>
 
 <div algorithm>
@@ -1893,10 +1893,10 @@ following table:
  for="ReadableStreamBYOBRequest">respond(|bytesWritten|)</dfn> method steps are:
 
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}} exception.
- 1. If [$IsDetachedBuffer$]([=this=].\[[view]].\[[ArrayBuffer]]) is true, throw a {{TypeError}}
+ 1. If [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]]) is true, throw a {{TypeError}}
     exception.
- 1. Assert: [=this=].\[[view]].\[[ByteLength]] &gt; 0.
- 1. Assert: [=this=].\[[view]].\[[ViewedArrayBuffer]].\[[ByeLength]] &gt; 0.
+ 1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ByteLength]] &gt; 0.
+ 1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByeLength]] &gt; 0.
  1. Perform ? [$ReadableByteStreamControllerRespond$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=], |bytesWritten|).
 </div>
 
@@ -2986,7 +2986,7 @@ The following abstract operations support the implementation of the
 
  1. If |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null, return.
  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].[=ReadableStreamBYOBRequest/[[controller]]=] to undefined.
- 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].\[[view]] to null.
+ 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].[=ReadableStreamBYOBRequest/[[view]]=] to null.
  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to null.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3435,7 +3435,7 @@ table:
 </table>
 
 <p class="note">The [=WritableStream/[[inFlightCloseRequest]]=] slot and [=WritableStream/[[closeRequest]]=] slot are mutually
-exclusive. Similarly, no element will be removed from \[[writeRequests]] while
+exclusive. Similarly, no element will be removed from [=WritableStream/[[writeRequests]]=] while
 [=WritableStream/[[inFlightWriteRequest]]=] is not undefined. Implementations can optimize storage for these slots
 based on these invariants.
 
@@ -4022,7 +4022,7 @@ are even meant to be generally useful by other specifications.
  1. Set |stream|.[=WritableStream/[[storedError]]=], |stream|.[=WritableStream/[[writer]]=], |stream|.[=WritableStream/[[controller]]=],
     |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
     |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
- 1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
+ 1. Set |stream|.[=WritableStream/[[writeRequests]]=] to a new empty [=list=].
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
 </div>
 
@@ -4145,7 +4145,7 @@ the {{WritableStream}}'s public API.
  1. Assert: ! [$IsWritableStreamLocked$](|stream|) is true.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Let |promise| be [=a new promise=].
- 1. [=list/Append=] |promise| to |stream|.\[[writeRequests]].
+ 1. [=list/Append=] |promise| to |stream|.[=WritableStream/[[writeRequests]]=].
  1. Return |promise|.
 </div>
 
@@ -4182,9 +4182,9 @@ the {{WritableStream}}'s public API.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`errored`".
  1. Perform ! |stream|.[=WritableStream/[[controller]]=].\[[ErrorSteps]]().
  1. Let |storedError| be |stream|.[=WritableStream/[[storedError]]=].
- 1. [=list/For each=] |writeRequest| of |stream|.\[[writeRequests]]:
+ 1. [=list/For each=] |writeRequest| of |stream|.[=WritableStream/[[writeRequests]]=]:
   1. [=Reject=] |writeRequest| with |storedError|.
- 1. Set |stream|.\[[writeRequests]] to an empty [=list=].
+ 1. Set |stream|.[=WritableStream/[[writeRequests]]=] to an empty [=list=].
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined,
   1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
   1. Return.
@@ -4291,9 +4291,9 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. Assert: |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is undefined.
- 1. Assert: |stream|.\[[writeRequests]] is not empty.
- 1. Let |writeRequest| be |stream|.\[[writeRequests]][0].
- 1. [=list/Remove=] |writeRequest| from |stream|.\[[writeRequests]].
+ 1. Assert: |stream|.[=WritableStream/[[writeRequests]]=] is not empty.
+ 1. Let |writeRequest| be |stream|.[=WritableStream/[[writeRequests]]=][0].
+ 1. [=list/Remove=] |writeRequest| from |stream|.[=WritableStream/[[writeRequests]]=].
  1. Set |stream|.[=WritableStream/[[inFlightWriteRequest]]=] to |writeRequest|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3386,50 +3386,50 @@ interface WritableStream {
 Instances of {{WritableStream}} are created with the internal slots described in the following
 table:
 
-<table>
+<table dfn-for="WritableStream">
  <thead>
   <tr>
    <th>Internal Slot
    <th>Description (<em>non-normative</em>)
  <tbody>
   <tr>
-  <td>\[[backpressure]]
+  <td><dfn>\[[backpressure]]</dfn>
   <td class="non-normative">A boolean indicating the backpressure signal set by the controller
  <tr>
-  <td>\[[closeRequest]]
+  <td><dfn>\[[closeRequest]]</dfn>
   <td class="non-normative">The promise returned from the writer's
   {{WritableStreamDefaultWriter/close()}} method
  <tr>
-  <td>\[[controller]]
+  <td><dfn>\[[controller]]</dfn>
   <td class="non-normative">A {{WritableStreamDefaultController}} created with the ability to
   control the state and queue of this stream
  <tr>
-  <td>\[[inFlightWriteRequest]]
+  <td><dfn>\[[inFlightWriteRequest]]</dfn>
   <td class="non-normative">A slot set to the promise for the current in-flight write operation
   while the [=underlying sink=]'s write algorithm is executing and has not yet fulfilled, used to
   prevent reentrant calls
  <tr>
-  <td>\[[inFlightCloseRequest]]
+  <td><dfn>\[[inFlightCloseRequest]]</dfn>
   <td class="non-normative">A slot set to the promise for the current in-flight close operation
   while the [=underlying sink=]'s close algorithm is executing and has not yet fulfilled, used to
   prevent the {{WritableStreamDefaultWriter/abort()}} method from interrupting close
  <tr>
-  <td>\[[pendingAbortRequest]]
+  <td><dfn>\[[pendingAbortRequest]]</dfn>
   <td class="non-normative">A [=pending abort request=]
  <tr>
-  <td>\[[state]]
+  <td><dfn>\[[state]]</dfn>
   <td class="non-normative">A string containing the stream's current state, used internally; one of
   "`writable`", "`closed`", "`erroring`", or "`errored`"
  <tr>
-  <td>\[[storedError]]
+  <td><dfn>\[[storedError]]</dfn>
   <td class="non-normative">A value indicating how the stream failed, to be given as a failure
   reason or exception when trying to operate on the stream while in the "`errored`" state
  <tr>
-  <td>\[[writer]]
+  <td><dfn>\[[writer]]</dfn>
   <td class="non-normative">A {{WritableStreamDefaultWriter}} instance, if the stream is [=locked to
   a writer=], or undefined if it is not
  <tr>
-  <td>\[[writeRequests]]
+  <td><dfn>\[[writeRequests]]</dfn>
   <td class="non-normative">A [=list=] of promises representing the stream's internal queue of write
   requests not yet processed by the [=underlying sink=]
 </table>

--- a/index.bs
+++ b/index.bs
@@ -3,8 +3,8 @@ Group: WHATWG
 H1: Streams
 Shortname: streams
 Text Macro: TWITTER streamsstandard
-Abstract: This specification provides APIs for creating, composing, and consuming streams of data that map efficiently
-Abstract: to low-level I/O primitives.
+Abstract: This specification provides APIs for creating, composing, and consuming streams of data
+Abstract: that map efficiently to low-level I/O primitives.
 Translation: ja https://triple-underscore.github.io/Streams-ja.html
 !Demos: <a href="https://streams.spec.whatwg.org/demos/">streams.spec.whatwg.org/demos</a>
 Indent: 1
@@ -655,8 +655,8 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
  <dt><code>await <var ignore>stream</var>.{{ReadableStream/cancel(reason)|cancel}}([ <var ignore>reason</var> ])</code>
  <dd>
   <p>[=cancel a readable stream|Cancels=] the stream, signaling a loss of interest in the stream by
-  a consumer. The supplied <var ignore>reason</var> argument will be given to the underlying source's
-  {{UnderlyingSource/cancel|cancel()}} method, which might or might not use it.
+  a consumer. The supplied <var ignore>reason</var> argument will be given to the underlying
+  source's {{UnderlyingSource/cancel|cancel()}} method, which might or might not use it.
 
   <p>The returned promise will fulfill if the stream shuts down successfully, or reject if the
   underlying source signaled that there was an error doing so. Additionally, it will reject with a
@@ -712,7 +712,8 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
 
   * An error in |destination| will [=cancel a readable stream|cancel=] this source [=readable
     stream=], unless {{StreamPipeOptions/preventCancel}} is truthy. The returned promise will be
-    rejected with the destination's error, or with any error that occurs during canceling the source.
+    rejected with the destination's error, or with any error that occurs during canceling the
+    source.
 
   * When this source [=readable stream=] closes, |destination| will be closed, unless
     {{StreamPipeOptions/preventClose}} is truthy. The returned promise will be fulfilled once this
@@ -1783,7 +1784,8 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  id="rbs-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
- 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
+ 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is
+    empty|empty=],
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. Set |firstDescriptor|'s [=pull-into descriptor/bytes filled=] to 0.
  1. Perform ! [$ResetQueue$]([=this=]).
@@ -1813,7 +1815,8 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
      [=readable byte stream queue entry/byte length=] »).
   1. Perform |readRequest|'s [=read request/chunk steps=], given |view|.
   1. Return.
- 1. Let |autoAllocateChunkSize| be [=this=].[=ReadableByteStreamController/[[autoAllocateChunkSize]]=].
+ 1. Let |autoAllocateChunkSize| be
+    [=this=].[=ReadableByteStreamController/[[autoAllocateChunkSize]]=].
  1. If |autoAllocateChunkSize| is not undefined,
   1. Let |buffer| be [$Construct$]({{%ArrayBuffer%}}, « |autoAllocateChunkSize| »).
   1. If |buffer| is an abrupt completion,
@@ -1824,7 +1827,8 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
      length=] |autoAllocateChunkSize|, [=pull-into descriptor/bytes filled=] 0, [=pull-into
      descriptor/element size=] 1, [=pull-into descriptor/view constructor=] {{%Uint8Array%}}, and
      [=pull-into descriptor/reader type=] "`default`".
-  1. [=list/Append=] |pullIntoDescriptor| to [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=].
+  1. [=list/Append=] |pullIntoDescriptor| to
+     [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=].
  1. Perform ! [$ReadableStreamAddReadRequest$](|stream|, |readRequest|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$]([=this=]).
 </div>
@@ -1912,7 +1916,9 @@ following table:
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ByteLength]] &gt; 0.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByeLength]]
     &gt; 0.
- 1. Perform ? [$ReadableByteStreamControllerRespond$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=], |bytesWritten|).
+ 1. Perform ?
+    [$ReadableByteStreamControllerRespond$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
+    |bytesWritten|).
 </div>
 
 <div algorithm>
@@ -1924,7 +1930,9 @@ following table:
     exception.
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
- 1. Return ? [$ReadableByteStreamControllerRespondWithNewView$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=], |view|).
+ 1. Return ?
+    [$ReadableByteStreamControllerRespondWithNewView$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
+    |view|).
 </div>
 
 <h3 id="rs-all-abstract-ops">Abstract operations</h3>
@@ -2107,7 +2115,8 @@ are even meant to be generally useful by other specifications.
    1. <strong>Errors must be propagated forward:</strong>  if |source|.[=ReadableStream/[[state]]=]
       is or becomes "`errored`", then
     1. If |preventAbort| is false, [=shutdown with an action=] of ! [$WritableStreamAbort$](|dest|,
-       |source|.[=ReadableStream/[[storedError]]=]) and with |source|.[=ReadableStream/[[storedError]]=].
+       |source|.[=ReadableStream/[[storedError]]=]) and with
+       |source|.[=ReadableStream/[[storedError]]=].
     1. Otherwise, [=shutdown=] with |source|.[=ReadableStream/[[storedError]]=].
    1. <strong>Errors must be propagated backward:</strong> if |dest|.[=WritableStream/[[state]]=]
       is or becomes "`errored`", then
@@ -2252,7 +2261,8 @@ create them does not matter.
     |cancel1Algorithm|).
  1. Set |branch2| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancel2Algorithm|).
- 1. [=Upon rejection=] of |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason |r|,
+ 1. [=Upon rejection=] of |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
+    |r|,
   1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
      |r|).
   1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
@@ -2363,7 +2373,8 @@ the {{ReadableStream}}'s public API.
   1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to a new empty [=list=].
  1. Otherwise,
    1. Assert: |reader| [=implements=] {{ReadableStreamBYOBReader}}.
-   1. [=list/For each=] |readIntoRequest| of |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=],
+   1. [=list/For each=] |readIntoRequest| of
+      |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=],
     1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
    1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
  1. [=Reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with |e|.
@@ -2376,9 +2387,11 @@ the {{ReadableStream}}'s public API.
  |chunk|, |done|)</dfn> performs the following steps:
 
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
- 1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is empty|empty=].
+ 1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is
+    empty|empty=].
  1. Let |readIntoRequest| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=][0].
- 1. [=list/Remove=] |readIntoRequest| from |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
+ 1. [=list/Remove=] |readIntoRequest| from
+    |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
  1. If |done| is true, perform |readIntoRequest|'s [=read-into request/close steps=], given |chunk|.
  1. Otherwise, perform |readIntoRequest|'s [=read-into request/chunk steps=], given |chunk|.
 </div>
@@ -2389,7 +2402,8 @@ the {{ReadableStream}}'s public API.
  |done|)</dfn> performs the following steps:
 
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
- 1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is empty|empty=].
+ 1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is
+    empty|empty=].
  1. Let |readRequest| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=][0].
  1. [=list/Remove=] |readRequest| from |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
  1. If |done| is true, perform |readRequest|'s [=read request/close steps=].
@@ -2401,7 +2415,8 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-get-num-read-into-requests">ReadableStreamGetNumReadIntoRequests(|stream|)</dfn>
  performs the following steps:
 
- 1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=]'s
+ 1. Return
+    |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=]'s
     [=list/size=].
 </div>
 
@@ -2481,10 +2496,11 @@ The following abstract operations support the implementation and manipulation of
  1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is
     "`readable`", [=reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with a
     {{TypeError}} exception.
- 1. Otherwise, set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise rejected
-    with=] a {{TypeError}} exception.
+ 1. Otherwise, set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise
+    rejected with=] a {{TypeError}} exception.
  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
- 1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[reader]]=] to undefined.
+ 1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[reader]]=] to
+    undefined.
  1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=] to undefined.
 </div>
 
@@ -2516,7 +2532,8 @@ The following abstract operations support the implementation and manipulation of
     [=read request/error steps=] given |stream|.[=ReadableStream/[[storedError]]=].
  1. Otherwise,
   1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
-  1. Perform ! |stream|.[=ReadableStream/[[controller]]=].[$ReadableStreamController/[[PullSteps]]$](|readRequest|).
+  1. Perform !
+     |stream|.[=ReadableStream/[[controller]]=].[$ReadableStreamController/[[PullSteps]]$](|readRequest|).
 </div>
 
 <div algorithm>
@@ -2558,7 +2575,8 @@ The following abstract operations support the implementation of the
   1. Return.
  1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
  1. Set |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to true.
- 1. Let |pullPromise| be the result of performing |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=].
+ 1. Let |pullPromise| be the result of performing
+    |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=].
  1. [=Upon fulfillment=] of |pullPromise|,
   1. Set |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
   1. If |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is true,
@@ -2679,7 +2697,8 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Let |state| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].[=ReadableStream/[[state]]=].
+ 1. Let |state| be
+    |controller|.[=ReadableStreamDefaultController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=] −
@@ -3016,7 +3035,8 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-handle-queue-drain">ReadableByteStreamControllerHandleQueueDrain(|controller|)</dfn>
  performs the following steps:
 
- 1. Assert: |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is "`readable`".
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is
+    "`readable`".
  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0 and
     |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
   1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
@@ -3031,8 +3051,12 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. If |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null, return.
- 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].[=ReadableStreamBYOBRequest/[[controller]]=] to undefined.
- 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].[=ReadableStreamBYOBRequest/[[view]]=] to null.
+ 1. Set
+    |controller|.[=ReadableByteStreamController/[[byobRequest]]=].[=ReadableStreamBYOBRequest/[[controller]]=]
+    to undefined.
+ 1. Set
+    |controller|.[=ReadableByteStreamController/[[byobRequest]]=].[=ReadableStreamBYOBRequest/[[view]]=]
+    to null.
  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to null.
 </div>
 
@@ -3045,11 +3069,13 @@ The following abstract operations support the implementation of the
  1. [=While=] |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
     [=list/is empty|empty=],
   1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, return.
-  1. Let |pullIntoDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. Let |pullIntoDescriptor| be
+     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
      |pullIntoDescriptor|) is true,
    1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
-   1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+   1. Perform !
+      [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
       |pullIntoDescriptor|).
 </div>
 
@@ -3154,7 +3180,8 @@ The following abstract operations support the implementation of the
     [$TransferArrayBuffer$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] − |remainderSize|.
- 1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+ 1. Perform !
+    [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
     |pullIntoDescriptor|).
  1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
 </div>
@@ -3165,7 +3192,8 @@ The following abstract operations support the implementation of the
  |bytesWritten|)</dfn> performs the following steps:
 
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
- 1. Let |state| be |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
+ 1. Let |state| be
+    |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`closed`",
   1. If |bytesWritten| is not 0, throw a {{TypeError}} exception.
   1. Perform ! [$ReadableByteStreamControllerRespondInClosedState$](|controller|,
@@ -3182,7 +3210,8 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-respond-with-new-view">ReadableByteStreamControllerRespondWithNewView(|controller|,
  |view|)</dfn> performs the following steps:
 
- 1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=].
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is
+    empty|empty=].
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. If |firstDescriptor|'s [=pull-into descriptor/byte offset=] + |firstDescriptor|' [=pull-into
     descriptor/bytes filled=] is not |view|.\[[ByteOffset]], throw a {{RangeError}} exception.
@@ -3198,7 +3227,8 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Let |descriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
- 1. [=list/Remove=] |descriptor| from |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
+ 1. [=list/Remove=] |descriptor| from
+    |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. Return |descriptor|.
 </div>
@@ -3242,7 +3272,8 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] to |highWaterMark|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
- 1. Set |controller|.[=ReadableByteStreamController/[[autoAllocateChunkSize]]=] to |autoAllocateChunkSize|.
+ 1. Set |controller|.[=ReadableByteStreamController/[[autoAllocateChunkSize]]=] to
+    |autoAllocateChunkSize|.
  1. Set |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] to a new empty [=list=].
  1. Set |stream|.[=ReadableStream/[[controller]]=] to |controller|.
  1. Let |startResult| be the result of performing |startAlgorithm|.
@@ -3853,7 +3884,8 @@ following table:
  The <dfn id="default-writer-desired-size" attribute
  for="WritableStreamDefaultWriter">desiredSize</dfn> getter steps are:
 
- 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, throw a {{TypeError}} exception.
+ 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, throw a {{TypeError}}
+    exception.
  1. Return ! [$WritableStreamDefaultWriterGetDesiredSize$]([=this=]).
 </div>
 
@@ -4078,9 +4110,11 @@ are even meant to be generally useful by other specifications.
 
  1. Set |stream|.[=WritableStream/[[state]]=] to "`writable`".
  1. Set |stream|.[=WritableStream/[[storedError]]=], |stream|.[=WritableStream/[[writer]]=],
-    |stream|.[=WritableStream/[[controller]]=], |stream|.[=WritableStream/[[inFlightWriteRequest]]=],
-    |stream|.[=WritableStream/[[closeRequest]]=], |stream|.[=WritableStream/[[inFlightCloseRequest]]=]
-    and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
+    |stream|.[=WritableStream/[[controller]]=],
+    |stream|.[=WritableStream/[[inFlightWriteRequest]]=],
+    |stream|.[=WritableStream/[[closeRequest]]=],
+    |stream|.[=WritableStream/[[inFlightCloseRequest]]=], and
+    |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.[=WritableStream/[[writeRequests]]=] to a new empty [=list=].
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
 </div>
@@ -4108,8 +4142,8 @@ are even meant to be generally useful by other specifications.
   1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and
      |stream|.[=WritableStream/[[backpressure]]=] is true, set
      |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a new promise=].
-  1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise resolved
-     with=] undefined.
+  1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise
+     resolved with=] undefined.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |state| is "`erroring`",
   1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=]
@@ -4474,8 +4508,8 @@ The following abstract operations support the implementation and manipulation of
 
  1. If |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseState]] is "`pending`",
     [=reject=] |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with |error|.
- 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected
-    with=] |error|.
+ 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise
+    rejected with=] |error|.
  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
@@ -4500,7 +4534,8 @@ The following abstract operations support the implementation and manipulation of
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`errored`" or "`erroring`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return ! [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.[=WritableStream/[[controller]]=]).
+ 1. Return !
+    [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.[=WritableStream/[[controller]]=]).
 </div>
 
 <div algorithm>
@@ -4561,7 +4596,8 @@ The following abstract operations support the implementation of the
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
- 1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to |sizeAlgorithm|.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to
+    |sizeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategyHWM]]=] to |highWaterMark|.
  1. Set |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=] to |writeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to |closeAlgorithm|.
@@ -5035,7 +5071,8 @@ side=], or to terminate or error the stream.
  1. Let |startPromise| be [=a new promise=].
  1. If |transformerDict|["{{Transformer/start}}"] [=map/exists=], then [=resolve=] |startPromise|
     with the result of [=invoking=] |transformerDict|["{{Transformer/start}}"] with argument list
-    «&nbsp;[=this=].[=TransformStream/[[controller]]=]&nbsp;» and [=callback this value=] |transformer|.
+    «&nbsp;[=this=].[=TransformStream/[[controller]]=]&nbsp;» and [=callback this value=]
+    |transformer|.
  1. Otherwise, [=resolve=] |startPromise| with undefined.
 </div>
 
@@ -5364,7 +5401,8 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Perform ! [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=], |e|).
+ 1. Perform ! [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=],
+    |e|).
 </div>
 
 <div algorithm>
@@ -5376,7 +5414,8 @@ The following abstract operations support the implementaiton of the
     |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=], passing |chunk|.
  1. Return the result of [=reacting=] to |transformPromise| with the following
     rejection steps given the argument |r|:
-   1. Perform ! [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=], |r|).
+   1. Perform !
+      [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=], |r|).
    1. Throw |r|.
 </div>
 
@@ -5391,7 +5430,8 @@ The following abstract operations support the implementaiton of the
  It performs the following steps:
 
  1. Let |stream| be |controller|.[=TransformStreamDefaultController/[[stream]]=].
- 1. Let |readableController| be |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
+ 1. Let |readableController| be
+    |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. Perform ! [$ReadableStreamDefaultControllerClose$](|readableController|).
  1. Let |error| be a {{TypeError}} exception indicating that the stream has been terminated.
  1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |error|).
@@ -5445,7 +5485,8 @@ side=] of [=transform streams=].
   1. If |flushPromise| was fulfilled, then:
    1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", throw
       |readable|.[=ReadableStream/[[storedError]]=].
-   1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
+   1. Perform !
+      [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
   1. If |flushPromise| was rejected with reason |r|, then:
    1. Perform ! [$TransformStreamError$](|stream|, |r|).
    1. Throw |readable|.[=ReadableStream/[[storedError]]=].
@@ -6591,10 +6632,12 @@ Youenn Fablet,
 平野裕 (Yutaka Hirano),
 and
 Xabier Rodríguez
-for their contributions to this specification. Community involvement in this specification has been above and beyond; we
-couldn't have done it without you.
+for their contributions to this specification. Community involvement in this specification has been
+above and beyond; we couldn't have done it without you.
 
 This standard is written by Adam Rice (<a href="https://google.com">Google</a>, <a
-href="mailto:ricea@chromium.org">ricea@chromium.org</a>), <a href="https://domenic.me/">Domenic Denicola</a> (<a
-href="https://google.com">Google</a>, <a href="mailto:d@domenic.me">d@domenic.me</a>), and 吉野剛史 (Takeshi Yoshino, <a
-href="https://google.com">Google</a>, <a href="mailto:tyoshino@chromium.org">tyoshino@chromium.org</a>).
+href="mailto:ricea@chromium.org">ricea@chromium.org</a>), <a href="https://domenic.me/">Domenic
+Denicola</a> (<a href="https://google.com">Google</a>, <a
+href="mailto:d@domenic.me">d@domenic.me</a>), and 吉野剛史 (Takeshi Yoshino, <a
+href="https://google.com">Google</a>, <a
+href="mailto:tyoshino@chromium.org">tyoshino@chromium.org</a>).

--- a/index.bs
+++ b/index.bs
@@ -1712,7 +1712,7 @@ has the following [=struct/items=]:
  The <dfn id="rbs-controller-byob-request" attribute
  for="ReadableByteStreamController">byobRequest</dfn> getter steps are:
 
- 1. If [=this=].\[[byobRequest]] is null and [=this=].\[[pendingPullIntos]] is not [=list/is
+ 1. If [=this=].[=ReadableByteStreamController/[[byobRequest]]=] is null and [=this=].\[[pendingPullIntos]] is not [=list/is
     empty|empty=],
   1. Let |firstDescriptor| be [=this=].\[[pendingPullIntos]][0].
   1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |firstDescriptor|'s [=pull-into
@@ -1722,8 +1722,8 @@ has the following [=struct/items=]:
   1. Let |byobRequest| be a [=new=] {{ReadableStreamBYOBRequest}}.
   1. Set |byobRequest|.\[[controller]] to [=this=].
   1. Set |byobRequest|.\[[view]] to |view|.
-  1. Set [=this=].\[[byobRequest]] to |byobRequest|.
- 1. Return [=this=].\[[byobRequest]].
+  1. Set [=this=].[=ReadableByteStreamController/[[byobRequest]]=] to |byobRequest|.
+ 1. Return [=this=].[=ReadableByteStreamController/[[byobRequest]]=].
 </div>
 
 <div algorithm>
@@ -2984,10 +2984,10 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-invalidate-byob-request">ReadableByteStreamControllerInvalidateBYOBRequest(|controller|)</dfn>
  performs the following steps:
 
- 1. If |controller|.\[[byobRequest]] is null, return.
- 1. Set |controller|.\[[byobRequest]].\[[controller]] to undefined.
- 1. Set |controller|.\[[byobRequest]].\[[view]] to null.
- 1. Set |controller|.\[[byobRequest]] to null.
+ 1. If |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null, return.
+ 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].\[[controller]] to undefined.
+ 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=].\[[view]] to null.
+ 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to null.
 </div>
 
 <div algorithm>
@@ -3185,7 +3185,7 @@ The following abstract operations support the implementation of the
   1. Assert: |autoAllocateChunkSize| is positive.
  1. Set |controller|.[=ReadableByteStreamController/[[stream]]=] to |stream|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
- 1. Set |controller|.\[[byobRequest]] to null.
+ 1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to null.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.[=ReadableByteStreamController/[[started]]=] to false.
  1. Set |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] to |highWaterMark|.

--- a/index.bs
+++ b/index.bs
@@ -3887,7 +3887,7 @@ the following table:
    <td class="non-normative">A [=list=] representing the stream's internal queue of [=chunks=]
   <tr>
    <td><dfn>\[[queueTotalSize]]</dfn>
-   <td class="non-normative">The total size of all the chunks stored in \[[queue]] (see
+   <td class="non-normative">The total size of all the chunks stored in [=WritableStreamDefaultController/[[queue]]=] (see
    [[#queue-with-sizes]])
   <tr>
    <td><dfn>\[[started]]</dfn>
@@ -3911,7 +3911,7 @@ the following table:
    write), which writes data to the [=underlying sink=]
 </table>
 
-The <dfn>close sentinel</dfn> is a unique value enqueued into \[[queue]], in lieu of a [=chunk=], to
+The <dfn>close sentinel</dfn> is a unique value enqueued into [=WritableStreamDefaultController/[[queue]]=], in lieu of a [=chunk=], to
 signal that the stream is closed. It is only used internally, and is never exposed to web
 developers.
 
@@ -4543,7 +4543,7 @@ The following abstract operations support the implementation of the
  1. If |state| is "`erroring`",
   1. Perform ! [$WritableStreamFinishErroring$](|stream|).
   1. Return.
- 1. If |controller|.\[[queue]] is empty, return.
+ 1. If |controller|.[=WritableStreamDefaultController/[[queue]]=] is empty, return.
  1. Let |value| be ! [$PeekQueueValue$](|controller|).
  1. If |value| is the [=close sentinel=], perform !
     [$WritableStreamDefaultControllerProcessClose$](|controller|).
@@ -4642,7 +4642,7 @@ The following abstract operations support the implementation of the
  1. Let |stream| be |controller|.\[[stream]].
  1. Perform ! [$WritableStreamMarkCloseRequestInFlight$](|stream|).
  1. Perform ! [$DequeueValue$](|controller|).
- 1. Assert: |controller|.\[[queue]] is empty.
+ 1. Assert: |controller|.[=WritableStreamDefaultController/[[queue]]=] is empty.
  1. Let |sinkClosePromise| be the result of performing |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=].
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
  1. [=Upon fulfillment=] of |sinkClosePromise|,

--- a/index.bs
+++ b/index.bs
@@ -4631,7 +4631,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-get-desired-size">WritableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
- 1. Return |controller|.\[[strategyHWM]] − |controller|.\[[queueTotalSize]].
+ 1. Return |controller|.\[[strategyHWM]] − |controller|.[=WritableStreamDefaultController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -1914,7 +1914,7 @@ following table:
  1. If [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]]) is
     true, throw a {{TypeError}} exception.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ByteLength]] &gt; 0.
- 1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByeLength]]
+ 1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByteLength]]
     &gt; 0.
  1. Perform ?
     [$ReadableByteStreamControllerRespond$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
@@ -2112,7 +2112,7 @@ are even meant to be generally useful by other specifications.
     before performing any reads or writes, since they might lead to immediate shutdown.
   * <strong>Error and close states must be propagated:</strong> the following conditions must be
     applied in order.
-   1. <strong>Errors must be propagated forward:</strong>  if |source|.[=ReadableStream/[[state]]=]
+   1. <strong>Errors must be propagated forward:</strong> if |source|.[=ReadableStream/[[state]]=]
       is or becomes "`errored`", then
     1. If |preventAbort| is false, [=shutdown with an action=] of ! [$WritableStreamAbort$](|dest|,
        |source|.[=ReadableStream/[[storedError]]=]) and with

--- a/index.bs
+++ b/index.bs
@@ -1528,7 +1528,7 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  1. Let |stream| be [=this=].[=ReadableStreamGenericReader/[[stream]]=].
  1. If [=this=].\[[queue]] is not [=list/is empty|empty=],
   1. Let |chunk| be ! [$DequeueValue$]([=this=]).
-  1. If [=this=].\[[closeRequested]] is true and [=this=].\[[queue]] [=list/is empty=],
+  1. If [=this=].[=ReadableStreamDefaultController/[[closeRequested]]=] is true and [=this=].\[[queue]] [=list/is empty=],
    1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$]([=this=]).
    1. Perform ! [$ReadableStreamClose$](|stream|).
   1. Otherwise, perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$]([=this=]).
@@ -1737,7 +1737,7 @@ has the following [=struct/items=]:
  The <dfn id="rbs-controller-close" method for="ReadableByteStreamController">close()</dfn> method
  steps are:
 
- 1. If [=this=].\[[closeRequested]] is true, throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not "`readable`", throw a {{TypeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
 </div>
@@ -1749,7 +1749,7 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
  1. If |chunk|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |chunk|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
- 1. If [=this=].\[[closeRequested]] is true, throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not "`readable`", throw a {{TypeError}} exception.
  1. Return ! [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
 </div>
@@ -2587,7 +2587,7 @@ The following abstract operations support the implementation of the
 
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
  1. Let |stream| be |controller|.\[[stream]].
- 1. Set |controller|.\[[closeRequested]] to true.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] to true.
  1. If |controller|.\[[queue]] [=list/is empty=],
   1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
   1. Perform ! [$ReadableStreamClose$](|stream|).
@@ -2671,10 +2671,10 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
- 1. If |controller|.\[[closeRequested]] is false and |state| is "`readable`", return true.
+ 1. If |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] is false and |state| is "`readable`", return true.
  1. Otherwise, return false.
 
- <p class="note">The case where |controller|.\[[closeRequested]] is false, but |state| is not
+ <p class="note">The case where |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] is false, but |state| is not
  "`readable`", happens when the stream is errored via
  {{ReadableStreamDefaultController/error(e)|controller.error()}}, or when it is closed without its
  controller's {{ReadableStreamDefaultController/close()|controller.close()}} method ever being
@@ -2691,7 +2691,7 @@ The following abstract operations support the implementation of the
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. Set |controller|.\[[stream]] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.\[[started]], |controller|.\[[closeRequested]], |controller|.\[[pullAgain]], and
+ 1. Set |controller|.\[[started]], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.\[[pullAgain]], and
     |controller|.\[[pulling]] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.\[[strategyHWM]]
     to |highWaterMark|.
@@ -2792,9 +2792,9 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Let |stream| be |controller|.\[[stream]].
- 1. If |controller|.\[[closeRequested]] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
+ 1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. If |controller|.\[[queueTotalSize]] > 0,
-  1. Set |controller|.\[[closeRequested]] to true.
+  1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] to true.
   1. Return.
  1. If |controller|.\[[pendingPullIntos]] is not empty,
   1. Let |firstPendingPullInto| be |controller|.\[[pendingPullIntos]][0].
@@ -2845,7 +2845,7 @@ The following abstract operations support the implementation of the
  |chunk|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.\[[stream]].
- 1. If |controller|.\[[closeRequested]] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
+ 1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
  1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
  1. Let |byteLength| be |chunk|.\[[ByteLength]].
@@ -2972,7 +2972,7 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Assert: |controller|.\[[stream]].[=ReadableStream/[[state]]=] is "`readable`".
- 1. If |controller|.\[[queueTotalSize]] is 0 and |controller|.\[[closeRequested]] is true,
+ 1. If |controller|.\[[queueTotalSize]] is 0 and |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
   1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
   1. Perform ! [$ReadableStreamClose$](|controller|.\[[stream]]).
  1. Otherwise,
@@ -2995,7 +2995,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-process-pull-into-descriptors-using-queue">ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
- 1. Assert: |controller|.\[[closeRequested]] is false.
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is false.
  1. [=While=] |controller|.\[[pendingPullIntos]] is not [=list/is empty|empty=],
   1. If |controller|.\[[queueTotalSize]] is 0, return.
   1. Let |pullIntoDescriptor| be |controller|.\[[pendingPullIntos]][0].
@@ -3044,7 +3044,7 @@ The following abstract operations support the implementation of the
    1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$](|controller|).
    1. Perform |readIntoRequest|'s [=read-into request/chunk steps=], given |filledView|.
    1. Return.
-  1. If |controller|.\[[closeRequested]] is true,
+  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
    1. Let |e| be a {{TypeError}} exception.
    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
    1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
@@ -3161,7 +3161,7 @@ The following abstract operations support the implementation of the
 
  1. Let |stream| be |controller|.\[[stream]].
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return false.
- 1. If |controller|.\[[closeRequested]] is true, return false.
+ 1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true, return false.
  1. If |controller|.\[[started]] is false, return false.
  1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true and !
     [$ReadableStreamGetNumReadRequests$](|stream|) > 0, return true.
@@ -3187,7 +3187,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[pullAgain]] and |controller|.\[[pulling]] to false.
  1. Set |controller|.\[[byobRequest]] to null.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.\[[closeRequested]] and |controller|.\[[started]] to false.
+ 1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.\[[started]] to false.
  1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
  1. Set |controller|.\[[pullAlgorithm]] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.

--- a/index.bs
+++ b/index.bs
@@ -4328,7 +4328,7 @@ the {{WritableStream}}'s public API.
  1. If |writer| is not undefined, perform !
     [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |reason|).
  1. If ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false and
-    |controller|.\[[started]] is true, perform ! [$WritableStreamFinishErroring$](|stream|).
+    |controller|.[=WritableStreamDefaultController/[[started]]=] is true, perform ! [$WritableStreamFinishErroring$](|stream|).
 </div>
 
 <div algorithm>
@@ -4479,7 +4479,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[stream]] to |stream|.
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.\[[started]] to false.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm|.
  1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
  1. Set |controller|.\[[writeAlgorithm]] to |writeAlgorithm|.
@@ -4491,11 +4491,11 @@ The following abstract operations support the implementation of the
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=] of |startPromise|,
   1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
-  1. Set |controller|.\[[started]] to true.
+  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to true.
   1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
   1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
-  1. Set |controller|.\[[started]] to true.
+  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to true.
   1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |r|).
 </div>
 
@@ -4536,7 +4536,7 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Let |stream| be |controller|.\[[stream]].
- 1. If |controller|.\[[started]] is false, return.
+ 1. If |controller|.[=WritableStreamDefaultController/[[started]]=] is false, return.
  1. If |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is not undefined, return.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. Assert: |state| is not "`closed`" or "`errored`".

--- a/index.bs
+++ b/index.bs
@@ -2526,15 +2526,15 @@ The following abstract operations support the implementation of the
  1. Let |shouldPull| be ! [$ReadableStreamDefaultControllerShouldCallPull$](|controller|).
  1. If |shouldPull| is false, return.
  1. If |controller|.\[[pulling]] is true,
-  1. Set |controller|.\[[pullAgain]] to true.
+  1. Set |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] to true.
   1. Return.
- 1. Assert: |controller|.\[[pullAgain]] is false.
+ 1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
  1. Set |controller|.\[[pulling]] to true.
  1. Let |pullPromise| be the result of performing |controller|.\[[pullAlgorithm]].
  1. [=Upon fulfillment=] of |pullPromise|,
   1. Set |controller|.\[[pulling]] to false.
-  1. If |controller|.\[[pullAgain]] is true,
-   1. Set |controller|.\[[pullAgain]] to false.
+  1. If |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is true,
+   1. Set |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] to false.
    1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
  1. [=Upon rejection=] of |pullPromise| with reason |e|,
   1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |e|).
@@ -2691,7 +2691,7 @@ The following abstract operations support the implementation of the
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. Set |controller|.\[[stream]] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.\[[started]], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.\[[pullAgain]], and
+ 1. Set |controller|.\[[started]], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
     |controller|.\[[pulling]] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.\[[strategyHWM]]
     to |highWaterMark|.
@@ -2703,7 +2703,7 @@ The following abstract operations support the implementation of the
  1. [=Upon fulfillment=]  of |startPromise|,
   1. Set |controller|.\[[started]] to true.
   1. Assert: |controller|.\[[pulling]] is false.
-  1. Assert: |controller|.\[[pullAgain]] is false.
+  1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
   1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
   1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |r|).
@@ -2745,15 +2745,15 @@ The following abstract operations support the implementation of the
  1. Let |shouldPull| be ! [$ReadableByteStreamControllerShouldCallPull$](|controller|).
  1. If |shouldPull| is false, return.
  1. If |controller|.\[[pulling]] is true,
-  1. Set |controller|.\[[pullAgain]] to true.
+  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] to true.
   1. Return.
- 1. Assert: |controller|.\[[pullAgain]] is false.
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
  1. Set |controller|.\[[pulling]] to true.
  1. Let |pullPromise| be the result of performing |controller|.\[[pullAlgorithm]].
  1. [=Upon fulfillment=] of |pullPromise|,
   1. Set |controller|.\[[pulling]] to false.
-  1. If |controller|.\[[pullAgain]] is true,
-   1. Set |controller|.\[[pullAgain]] to false.
+  1. If |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is true,
+   1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] to false.
    1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
  1. [=Upon rejection=] of |pullPromise| with reason |e|,
   1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
@@ -3184,7 +3184,7 @@ The following abstract operations support the implementation of the
   1. Assert: ! IsInteger(|autoAllocateChunkSize|) is true.
   1. Assert: |autoAllocateChunkSize| is positive.
  1. Set |controller|.\[[stream]] to |stream|.
- 1. Set |controller|.\[[pullAgain]] and |controller|.\[[pulling]] to false.
+ 1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and |controller|.\[[pulling]] to false.
  1. Set |controller|.\[[byobRequest]] to null.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.\[[started]] to false.
@@ -3199,7 +3199,7 @@ The following abstract operations support the implementation of the
  1. [=Upon fulfillment=]  of |startPromise|,
    1. Set |controller|.\[[started]] to true.
    1. Assert: |controller|.\[[pulling]] is false.
-   1. Assert: |controller|.\[[pullAgain]] is false.
+   1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
    1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |r|).

--- a/index.bs
+++ b/index.bs
@@ -3868,45 +3868,45 @@ interface WritableStreamDefaultController {
 Instances of {{WritableStreamDefaultController}} are created with the internal slots described in
 the following table:
 
-<table>
+<table dfn-for="WritableStreamDefaultController">
  <thead>
   <tr>
    <th>Internal Slot</th>
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
   <tr>
-   <td>\[[abortAlgorithm]]
+   <td><dfn>\[[abortAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm, taking one argument (the abort reason),
    which communicates a requested abort to the [=underlying sink=]
   <tr>
-   <td>\[[closeAlgorithm]]
+   <td><dfn>\[[closeAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=underlying sink=]
   <tr>
-   <td>\[[queue]]
+   <td><dfn>\[[queue]]</dfn>
    <td class="non-normative">A [=list=] representing the stream's internal queue of [=chunks=]
   <tr>
-   <td>\[[queueTotalSize]]
+   <td><dfn>\[[queueTotalSize]]</dfn>
    <td class="non-normative">The total size of all the chunks stored in \[[queue]] (see
    [[#queue-with-sizes]])
   <tr>
-   <td>\[[started]]
+   <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying sink=] has finished
    starting
   <tr>
-   <td>\[[strategyHWM]]
+   <td><dfn>\[[strategyHWM]]</dfn>
    <td class="non-normative">A number supplied by the creator of the stream as part of the stream's
    [=queuing strategy=], indicating the point at which the stream will apply [=backpressure=] to its
    [=underlying sink=]
   <tr>
-   <td>\[[strategySizeAlgorithm]]
+   <td><dfn>\[[strategySizeAlgorithm]]</dfn>
    <td class="non-normative">An algorithm to calculate the size of enqueued [=chunks=], as part of
     the stream's [=queuing strategy=]
   <tr>
-   <td>\[[stream]]
+   <td><dfn>\[[stream]]</dfn>
    <td class="non-normative">The {{WritableStream}} instance controlled
   <tr>
-   <td>\[[writeAlgorithm]]
+   <td><dfn>\[[writeAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm, taking one argument (the [=chunk=] to
    write), which writes data to the [=underlying sink=]
 </table>

--- a/index.bs
+++ b/index.bs
@@ -4482,7 +4482,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to |sizeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategyHWM]]=] to |highWaterMark|.
- 1. Set |controller|.\[[writeAlgorithm]] to |writeAlgorithm|.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=] to |writeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to |closeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to |abortAlgorithm|.
  1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
@@ -4565,7 +4565,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Set |controller|.\[[writeAlgorithm]] to undefined.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=] to undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to undefined.
@@ -4658,7 +4658,7 @@ The following abstract operations support the implementation of the
 
  1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. Perform ! [$WritableStreamMarkFirstWriteRequestInFlight$](|stream|).
- 1. Let |sinkWritePromise| be the result of performing |controller|.\[[writeAlgorithm]], passing in
+ 1. Let |sinkWritePromise| be the result of performing |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=], passing in
     |chunk|.
  1. [=Upon fulfillment=] of |sinkWritePromise|,
   1. Perform ! [$WritableStreamFinishInFlightWrite$](|stream|).

--- a/index.bs
+++ b/index.bs
@@ -1786,7 +1786,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  id="rbs-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
- 1. Let |stream| be [=this=].\[[stream]].
+ 1. Let |stream| be [=this=].[=ReadableByteStreamController/[[stream]]=].
  1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
  1. If [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. Assert: ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0.
@@ -2545,7 +2545,7 @@ The following abstract operations support the implementation of the
  id="readable-stream-default-controller-should-call-pull">ReadableStreamDefaultControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return false.
  1. If |controller|.[=ReadableStreamDefaultController/[[started]]=] is false, return false.
  1. If ! [$IsReadableStreamLocked$](|stream|) is true and !
@@ -2586,7 +2586,7 @@ The following abstract operations support the implementation of the
  It performs the following steps:
 
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
  1. Set |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] to true.
  1. If |controller|.[=ReadableStreamDefaultController/[[queue]]=] [=list/is empty=],
   1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
@@ -2604,7 +2604,7 @@ The following abstract operations support the implementation of the
  It performs the following steps:
 
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
  1. If ! [$IsReadableStreamLocked$](|stream|) is true and !
     [$ReadableStreamGetNumReadRequests$](|stream|) > 0, perform !
     [$ReadableStreamFulfillReadRequest$](|stream|, |chunk|, false).
@@ -2632,7 +2632,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
@@ -2650,7 +2650,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
+ 1. Let |state| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=] − |controller|.[=ReadableStreamDefaultController/[[queueTotalSize]]=].
@@ -2670,7 +2670,7 @@ The following abstract operations support the implementation of the
  id="readable-stream-default-controller-can-close-or-enqueue">ReadableStreamDefaultControllerCanCloseOrEnqueue(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
+ 1. Let |state| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] is false and |state| is "`readable`", return true.
  1. Otherwise, return false.
 
@@ -2689,7 +2689,7 @@ The following abstract operations support the implementation of the
  |sizeAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
- 1. Set |controller|.\[[stream]] to |stream|.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[stream]]=] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
     |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
@@ -2791,7 +2791,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-close">ReadableByteStreamControllerClose(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] to true.
@@ -2844,7 +2844,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-enqueue">ReadableByteStreamControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
  1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
@@ -2886,7 +2886,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-error">ReadableByteStreamControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. Perform ! [$ReadableByteStreamControllerClearPendingPullIntos$](|controller|).
  1. Perform ! [$ResetQueue$](|controller|).
@@ -2960,7 +2960,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-get-desired-size">ReadableByteStreamControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
+ 1. Let |state| be |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] − |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=].
@@ -2971,10 +2971,10 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-handle-queue-drain">ReadableByteStreamControllerHandleQueueDrain(|controller|)</dfn>
  performs the following steps:
 
- 1. Assert: |controller|.\[[stream]].[=ReadableStream/[[state]]=] is "`readable`".
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is "`readable`".
  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0 and |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
   1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
-  1. Perform ! [$ReadableStreamClose$](|controller|.\[[stream]]).
+  1. Perform ! [$ReadableStreamClose$](|controller|.[=ReadableByteStreamController/[[stream]]=]).
  1. Otherwise,
   1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
 </div>
@@ -3002,7 +3002,7 @@ The following abstract operations support the implementation of the
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
      |pullIntoDescriptor|) is true,
    1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
-   1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.\[[stream]],
+   1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
       |pullIntoDescriptor|).
 </div>
 
@@ -3011,7 +3011,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-pull-into">ReadableByteStreamControllerPullInto(|controller|,
  |view|, |readIntoRequest|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. Let |elementSize| be 1.
  1. Let |ctor| be {{%DataView%}}.
  1. If |view| has a \[[TypedArrayName]] internal slot (i.e., it is not a {{DataView}}),
@@ -3071,7 +3071,7 @@ The following abstract operations support the implementation of the
  1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to !
     [$TransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Assert: |firstDescriptor|'s [=pull-into descriptor/bytes filled=] is 0.
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
   1. [=While=] ! [$ReadableStreamGetNumReadIntoRequests$](|stream|) > 0,
    1. Let |pullIntoDescriptor| be !
@@ -3105,7 +3105,7 @@ The following abstract operations support the implementation of the
     [$TransferArrayBuffer$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] − |remainderSize|.
- 1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.\[[stream]],
+ 1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
     |pullIntoDescriptor|).
  1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
 </div>
@@ -3116,7 +3116,7 @@ The following abstract operations support the implementation of the
  |bytesWritten|)</dfn> performs the following steps:
 
  1. Let |firstDescriptor| be |controller|.\[[pendingPullIntos]][0].
- 1. Let |state| be |controller|.\[[stream]].[=ReadableStream/[[state]]=].
+ 1. Let |state| be |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`closed`",
   1. If |bytesWritten| is not 0, throw a {{TypeError}} exception.
   1. Perform ! [$ReadableByteStreamControllerRespondInClosedState$](|controller|,
@@ -3159,7 +3159,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-should-call-pull">ReadableByteStreamControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
+ 1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return false.
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true, return false.
  1. If |controller|.[=ReadableByteStreamController/[[started]]=] is false, return false.
@@ -3183,7 +3183,7 @@ The following abstract operations support the implementation of the
  1. If |autoAllocateChunkSize| is not undefined,
   1. Assert: ! IsInteger(|autoAllocateChunkSize|) is true.
   1. Assert: |autoAllocateChunkSize| is positive.
- 1. Set |controller|.\[[stream]] to |stream|.
+ 1. Set |controller|.[=ReadableByteStreamController/[[stream]]=] to |stream|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
  1. Set |controller|.\[[byobRequest]] to null.
  1. Perform ! [$ResetQueue$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -3796,7 +3796,7 @@ following table:
  The <dfn id="default-writer-desired-size" attribute
  for="WritableStreamDefaultWriter">desiredSize</dfn> getter steps are:
 
- 1. If [=this=].\[[stream]] is undefined, throw a {{TypeError}} exception.
+ 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, throw a {{TypeError}} exception.
  1. Return ! [$WritableStreamDefaultWriterGetDesiredSize$]([=this=]).
 </div>
 
@@ -3811,7 +3811,7 @@ following table:
  The <dfn id="default-writer-abort" method for="WritableStreamDefaultWriter">abort(|reason|)</dfn>
  method steps are:
 
- 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+ 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected with=] a {{TypeError}}
     exception.
  1. Return ! [$WritableStreamDefaultWriterAbort$]([=this=], |reason|).
 </div>
@@ -3820,7 +3820,7 @@ following table:
  The <dfn id="default-writer-close" method for="WritableStreamDefaultWriter">close()</dfn> method
  steps are:
 
- 1. Let |stream| be [=this=].\[[stream]].
+ 1. Let |stream| be [=this=].[=WritableStreamDefaultWriter/[[stream]]=].
  1. If |stream| is undefined, return [=a promise rejected with=] a {{TypeError}} exception.
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true, return [=a promise rejected
     with=] a {{TypeError}} exception.
@@ -3831,7 +3831,7 @@ following table:
  The <dfn id="default-writer-release-lock" method
  for="WritableStreamDefaultWriter">releaseLock()</dfn> method steps are:
 
- 1. Let |stream| be [=this=].\[[stream]].
+ 1. Let |stream| be [=this=].[=WritableStreamDefaultWriter/[[stream]]=].
  1. If |stream| is undefined, return.
  1. Assert: |stream|.[=WritableStream/[[writer]]=] is not undefined.
  1. Perform ! [$WritableStreamDefaultWriterRelease$]([=this=]).
@@ -3841,7 +3841,7 @@ following table:
  The <dfn id="default-writer-write" method for="WritableStreamDefaultWriter">write(|chunk|)</dfn>
  method steps are:
 
- 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+ 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected with=] a {{TypeError}}
     exception.
  1. Return ! [$WritableStreamDefaultWriterWrite$]([=this=], |chunk|).
 </div>
@@ -4042,7 +4042,7 @@ are even meant to be generally useful by other specifications.
  |stream|)</dfn> performs the following steps:
 
  1. If ! [$IsWritableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
- 1. Set |writer|.\[[stream]] to |stream|.
+ 1. Set |writer|.[=WritableStreamDefaultWriter/[[stream]]=] to |stream|.
  1. Set |stream|.[=WritableStream/[[writer]]=] to |writer|.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
@@ -4357,7 +4357,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-abort">WritableStreamDefaultWriterAbort(|writer|,
  |reason|)</dfn> performs the following steps:
 
- 1. Let |stream| be |writer|.\[[stream]].
+ 1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Return ! [$WritableStreamAbort$](|stream|, |reason|).
 </div>
@@ -4367,7 +4367,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-close">WritableStreamDefaultWriterClose(|writer|)</dfn> performs
  the following steps:
 
- 1. Let |stream| be |writer|.\[[stream]].
+ 1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Return ! [$WritableStreamClose$](|stream|).
 </div>
@@ -4377,7 +4377,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-close-with-error-propagation">WritableStreamDefaultWriterCloseWithErrorPropagation(|writer|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[stream]].
+ 1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
@@ -4417,7 +4417,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-get-desired-size">WritableStreamDefaultWriterGetDesiredSize(|writer|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[stream]].
+ 1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`errored`" or "`erroring`", return null.
  1. If |state| is "`closed`", return 0.
@@ -4429,14 +4429,14 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-release">WritableStreamDefaultWriterRelease(|writer|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[stream]].
+ 1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Assert: |stream|.[=WritableStream/[[writer]]=] is |writer|.
  1. Let |releasedError| be a new {{TypeError}}.
  1. Perform ! [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |releasedError|).
  1. Perform ! [$WritableStreamDefaultWriterEnsureClosedPromiseRejected$](|writer|, |releasedError|).
  1. Set |stream|.[=WritableStream/[[writer]]=] to undefined.
- 1. Set |writer|.\[[stream]] to undefined.
+ 1. Set |writer|.[=WritableStreamDefaultWriter/[[stream]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -4444,11 +4444,11 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-write">WritableStreamDefaultWriterWrite(|writer|, |chunk|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[stream]].
+ 1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Let |controller| be |stream|.[=WritableStream/[[controller]]=].
  1. Let |chunkSize| be ! [$WritableStreamDefaultControllerGetChunkSize$](|controller|, |chunk|).
- 1. If |stream| is not equal to |writer|.\[[stream]], return [=a promise rejected with=] a
+ 1. If |stream| is not equal to |writer|.[=WritableStreamDefaultWriter/[[stream]]=], return [=a promise rejected with=] a
     {{TypeError}} exception.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].

--- a/index.bs
+++ b/index.bs
@@ -4797,7 +4797,7 @@ table:
   <tr>
    <td><dfn>\[[controller]]</dfn>
    <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to
-   control [=TransformStream/[[readable]]=] and \[[writable]]
+   control [=TransformStream/[[readable]]=] and [=TransformStream/[[writable]]=]
   <tr>
    <td><dfn>\[[readable]]</dfn>
    <td class="non-normative">The {{ReadableStream}} instance controlled by this object
@@ -4966,7 +4966,7 @@ side=], or to terminate or error the stream.
  The <dfn id="ts-writable" attribute for="TransformStream">writable</dfn> getter steps
  are:
 
- 1. Return [=this=].\[[writable]].
+ 1. Return [=this=].[=TransformStream/[[writable]]=].
 </div>
 
 <h3 id="ts-default-controller-class">The {{TransformStreamDefaultController}} class</h3>
@@ -5123,7 +5123,7 @@ are even meant to be generally useful by other specifications.
   1. Return ! [$TransformStreamDefaultSinkAbortAlgorithm$](|stream|, |reason|).
  1. Let |closeAlgorithm| be the following steps:
   1. Return ! [$TransformStreamDefaultSinkCloseAlgorithm$](|stream|).
- 1. Set |stream|.\[[writable]] to ! [$CreateWritableStream$](|startAlgorithm|, |writeAlgorithm|,
+ 1. Set |stream|.[=TransformStream/[[writable]]=] to ! [$CreateWritableStream$](|startAlgorithm|, |writeAlgorithm|,
     |closeAlgorithm|, |abortAlgorithm|, |writableHighWaterMark|, |writableSizeAlgorithm|).
  1. Let |pullAlgorithm| be the following steps:
   1. Return ! [$TransformStreamDefaultSourcePullAlgorithm$](|stream|).
@@ -5161,7 +5161,7 @@ are even meant to be generally useful by other specifications.
 
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.[=TransformStream/[[controller]]=]).
  1. Perform !
-    [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].[=WritableStream/[[controller]]=], |e|).
+    [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=TransformStream/[[writable]]=].[=WritableStream/[[controller]]=], |e|).
  1. If |stream|.[=TransformStream/[[backpressure]]=] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
     false).
 
@@ -5319,14 +5319,14 @@ side=] of [=transform streams=].
  id="transform-stream-default-sink-write-algorithm">TransformStreamDefaultSinkWriteAlgorithm(|stream|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[writable]].[=WritableStream/[[state]]=] is "`writable`".
+ 1. Assert: |stream|.[=TransformStream/[[writable]]=].[=WritableStream/[[state]]=] is "`writable`".
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
  1. If |stream|.[=TransformStream/[[backpressure]]=] is true,
   1. Let |backpressureChangePromise| be |stream|.[=TransformStream/[[backpressureChangePromise]]=].
   1. Assert: |backpressureChangePromise| is not undefined.
   1. Return the result of [=reacting=] to |backpressureChangePromise| with the following fulfillment
      steps:
-   1. Let |writable| be |stream|.\[[writable]].
+   1. Let |writable| be |stream|.[=TransformStream/[[writable]]=].
    1. Let |state| be |writable|.[=WritableStream/[[state]]=].
    1. If |state| is "`erroring`", throw |writable|.[=WritableStream/[[storedError]]=].
    1. Assert: |state| is "`writable`".

--- a/index.bs
+++ b/index.bs
@@ -2572,7 +2572,7 @@ The following abstract operations support the implementation of the
 
  1. Set |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=] to undefined.
  1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to undefined.
- 1. Set |controller|.\[[strategySizeAlgorithm]] to undefined.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -2609,7 +2609,7 @@ The following abstract operations support the implementation of the
     [$ReadableStreamGetNumReadRequests$](|stream|) > 0, perform !
     [$ReadableStreamFulfillReadRequest$](|stream|, |chunk|, false).
  1. Otherwise,
-  1. Let |result| be the result of performing |controller|.\[[strategySizeAlgorithm]], passing in
+  1. Let |result| be the result of performing |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in
      |chunk|, and interpreting the result as a [=completion record=].
   1. If |result| is an abrupt completion,
    1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |result|.\[[Value]]).
@@ -2693,7 +2693,7 @@ The following abstract operations support the implementation of the
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
     |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
- 1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm| and |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=]
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=] to |sizeAlgorithm| and |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=]
     to |highWaterMark|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.

--- a/index.bs
+++ b/index.bs
@@ -2320,7 +2320,7 @@ the {{ReadableStream}}'s public API.
   1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to an empty [=list=].
  1. [=Resolve=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with undefined.
 
- <p class="note">The case where |stream|.[=ReadableStream/[[state]]=] is "`closed`", but |stream|.\[[closeRequested]]
+ <p class="note">The case where |stream|.[=ReadableStream/[[state]]=] is "`closed`", but |stream|.[=ReadableStream/[[controller]]=].\[[closeRequested]]
  is false, will happen if the stream was closed without its controller's close method ever being
  called: i.e., if the stream was closed by a call to {{ReadableStream/cancel(reason)}}. In this
  case we allow the controller's <code>close()</code> method to be called and silently do nothing,

--- a/index.bs
+++ b/index.bs
@@ -3956,7 +3956,7 @@ as such the counterpart internal methods are used polymorphically.
  oldids="writable-stream-default-controller-abort">\[[AbortSteps]](|reason|)</dfn> implements the
  [$WritableStreamController/[[AbortSteps]]$] contract. It performs the following steps:
 
- 1. Let |result| be the result of performing [=this=].\[[abortAlgorithm]], passing |reason|.
+ 1. Let |result| be the result of performing [=this=].[=WritableStreamDefaultController/[[abortAlgorithm]]=], passing |reason|.
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$]([=this=]).
  1. Return |result|.
 </div>
@@ -4484,7 +4484,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
  1. Set |controller|.\[[writeAlgorithm]] to |writeAlgorithm|.
  1. Set |controller|.\[[closeAlgorithm]] to |closeAlgorithm|.
- 1. Set |controller|.\[[abortAlgorithm]] to |abortAlgorithm|.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to |abortAlgorithm|.
  1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
  1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
  1. Let |startResult| be the result of performing |startAlgorithm|. (This may throw an exception.)
@@ -4567,7 +4567,7 @@ The following abstract operations support the implementation of the
 
  1. Set |controller|.\[[writeAlgorithm]] to undefined.
  1. Set |controller|.\[[closeAlgorithm]] to undefined.
- 1. Set |controller|.\[[abortAlgorithm]] to undefined.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to undefined.
  1. Set |controller|.\[[strategySizeAlgorithm]] to undefined.
 
  <p class="note">This algorithm will be performed multiple times in some edge cases. After the first

--- a/index.bs
+++ b/index.bs
@@ -5485,7 +5485,7 @@ interface ByteLengthQueuingStrategy {
 
 <h4 id="blqs-internal-slots">Internal slots</h4>
 
-Instances of {{ByteLengthQueuingStrategy}} have a \[[highWaterMark]] internal slot, storing the
+Instances of {{ByteLengthQueuingStrategy}} have a <dfn for="ByteLengthQueuingStrategy">\[[highWaterMark]]</dfn> internal slot, storing the
 value given in the constructor.
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -3789,7 +3789,7 @@ following table:
  The <dfn id="default-writer-closed" attribute for="WritableStreamDefaultWriter">closed</dfn>
  getter steps are:
 
- 1. Return [=this=].\[[closedPromise]].
+ 1. Return [=this=].[=WritableStreamDefaultWriter/[[closedPromise]]=].
 </div>
 
 <div algorithm>
@@ -4049,21 +4049,21 @@ are even meant to be generally useful by other specifications.
   1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[backpressure]]=]
      is true, set |writer|.\[[readyPromise]] to [=a new promise=].
   1. Otherwise, set |writer|.\[[readyPromise]] to [=a promise resolved with=] undefined.
-  1. Set |writer|.\[[closedPromise]] to [=a new promise=].
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |state| is "`erroring`",
   1. Set |writer|.\[[readyPromise]] to [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.\[[readyPromise]].\[[PromiseIsHandled]] to true.
-  1. Set |writer|.\[[closedPromise]] to [=a new promise=].
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |state| is "`closed`",
   1. Set |writer|.\[[readyPromise]] to [=a promise resolved with=] undefined.
-  1. Set |writer|.\[[closedPromise]] to [=a promise resolved with=] undefined.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise resolved with=] undefined.
  1. Otherwise,
   1. Assert: |state| is "`errored`".
   1. Let |storedError| be |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.\[[readyPromise]] to [=a promise rejected with=] |storedError|.
   1. Set |writer|.\[[readyPromise]].\[[PromiseIsHandled]] to true.
-  1. Set |writer|.\[[closedPromise]] to [=a promise rejected with=] |storedError|.
-  1. Set |writer|.\[[closedPromise]].\[[PromiseIsHandled]] to true.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected with=] |storedError|.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
 <div algorithm>
@@ -4222,7 +4222,7 @@ the {{WritableStream}}'s public API.
    1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`closed`".
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
- 1. If |writer| is not undefined, [=resolve=] |writer|.\[[closedPromise]] with undefined.
+ 1. If |writer| is not undefined, [=resolve=] |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with undefined.
  1. Assert: |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined.
  1. Assert: |stream|.[=WritableStream/[[storedError]]=] is undefined.
 </div>
@@ -4309,8 +4309,8 @@ the {{WritableStream}}'s public API.
   1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined,
-  1. [=Reject=] |writer|.\[[closedPromise]] with |stream|.[=WritableStream/[[storedError]]=].
-  1. Set |writer|.\[[closedPromise]].\[[PromiseIsHandled]] to true.
+  1. [=Reject=] |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with |stream|.[=WritableStream/[[storedError]]=].
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
 <div algorithm>
@@ -4395,10 +4395,10 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-ensure-closed-promise-rejected">WritableStreamDefaultWriterEnsureClosedPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
- 1. If |writer|.\[[closedPromise]].\[[PromiseState]] is "`pending`", [=reject=]
-    |writer|.\[[closedPromise]] with |error|.
- 1. Otherwise, set |writer|.\[[closedPromise]] to [=a promise rejected with=] |error|.
- 1. Set |writer|.\[[closedPromise]].\[[PromiseIsHandled]] to true.
+ 1. If |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseState]] is "`pending`", [=reject=]
+    |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with |error|.
+ 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected with=] |error|.
+ 1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -972,7 +972,8 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  ignore>stream</var> and |iterator|, are:
 
  1. Let |reader| be |iterator|'s [=ReadableStream async iterator/reader=].
- 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected with=] a {{TypeError}}.
+ 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected
+    with=] a {{TypeError}}.
  1. Let |promise| be [=a new promise=].
  1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
   : [=read request/chunk steps=], given |chunk|
@@ -995,9 +996,11 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  ignore>stream</var>, |iterator|, and |arg|, are:
 
  1. Let |reader| be |iterator|'s [=ReadableStream async iterator/reader=].
- 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise resolved with=] undefined.
- 1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=], as the async iterator machinery
-    guarantees that any previous calls to `next()` have settled before this is called.
+ 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise resolved
+    with=] undefined.
+ 1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=],
+    as the async iterator machinery guarantees that any previous calls to `next()` have settled
+    before this is called.
  1. If |iterator|'s [=ReadableStream async iterator/prevent cancel=] is false:
   1. Let |result| be ! [$ReadableStreamReaderGenericCancel$](|reader|, |arg|).
   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
@@ -1058,8 +1061,8 @@ internal slots described in the following table:
  for="ReadableStreamGenericReader">cancel(|reason|)</dfn>
  method steps are:
 
- 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected with=] a {{TypeError}}
-    exception.
+ 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected
+    with=] a {{TypeError}} exception.
  1. Return ! [$ReadableStreamReaderGenericCancel$]([=this=], |reason|).
 </div>
 
@@ -1202,7 +1205,8 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  for="ReadableStreamDefaultReader">releaseLock()</dfn> method steps are:
 
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
- 1. If [=this=].[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is empty|empty=], throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is empty|empty=],
+    throw a {{TypeError}} exception.
  1. Perform ! [$ReadableStreamReaderGenericRelease$]([=this=]).
 </div>
 
@@ -1335,8 +1339,8 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
  1. If |view|.\[[ByteLength]] is 0, return [=a promise rejected with=] a {{TypeError}} exception.
  1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected with=] a {{TypeError}}
-    exception.
+ 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected
+    with=] a {{TypeError}} exception.
  1. Let |promise| be [=a new promise=].
  1. Let |readIntoRequest| be a new [=read-into request=] with the following [=struct/items=]:
   : [=read-into request/chunk steps=], given |chunk|
@@ -1359,8 +1363,8 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
  for="ReadableStreamBYOBReader">releaseLock()</dfn> method steps are:
 
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
- 1. If [=this=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is empty|empty=], throw a {{TypeError}}
-    exception.
+ 1. If [=this=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is empty|empty=],
+    throw a {{TypeError}} exception.
  1. Perform ! [$ReadableStreamReaderGenericRelease$]([=this=]).
 </div>
 
@@ -1425,8 +1429,8 @@ the following table:
    <td class="non-normative">A [=list=] representing the stream's internal queue of [=chunks=]
   <tr>
    <td><dfn>\[[queueTotalSize]]</dfn>
-   <td class="non-normative">The total size of all the chunks stored in [=ReadableStreamDefaultController/[[queue]]=] (see
-   [[#queue-with-sizes]])
+   <td class="non-normative">The total size of all the chunks stored in
+   [=ReadableStreamDefaultController/[[queue]]=] (see [[#queue-with-sizes]])
   <tr>
    <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying source=] has
@@ -1515,7 +1519,8 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
  1. Perform ! [$ResetQueue$]([=this=]).
- 1. Let |result| be the result of performing [=this=].[=ReadableStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
+ 1. Let |result| be the result of performing
+    [=this=].[=ReadableStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
  1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$]([=this=]).
  1. Return |result|.
 </div>
@@ -1528,7 +1533,8 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  1. Let |stream| be [=this=].[=ReadableStreamGenericReader/[[stream]]=].
  1. If [=this=].[=ReadableStreamDefaultController/[[queue]]=] is not [=list/is empty|empty=],
   1. Let |chunk| be ! [$DequeueValue$]([=this=]).
-  1. If [=this=].[=ReadableStreamDefaultController/[[closeRequested]]=] is true and [=this=].[=ReadableStreamDefaultController/[[queue]]=] [=list/is empty=],
+  1. If [=this=].[=ReadableStreamDefaultController/[[closeRequested]]=] is true and
+     [=this=].[=ReadableStreamDefaultController/[[queue]]=] [=list/is empty=],
    1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$]([=this=]).
    1. Perform ! [$ReadableStreamClose$](|stream|).
   1. Otherwise, perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$]([=this=]).
@@ -1613,8 +1619,8 @@ following table:
    queue entries=] representing the stream's internal queue of [=chunks=]
   <tr>
    <td><dfn>\[[queueTotalSize]]</dfn>
-   <td class="non-normative">The total size, in bytes, of all the chunks stored in [=ReadableByteStreamController/[[queue]]=] (see
-   [[#queue-with-sizes]])
+   <td class="non-normative">The total size, in bytes, of all the chunks stored in
+   [=ReadableByteStreamController/[[queue]]=] (see [[#queue-with-sizes]])
   <tr>
    <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying byte source=] has
@@ -1630,7 +1636,8 @@ following table:
 </table>
 
 <div class="note">
- <p>Although {{ReadableByteStreamController}} instances have [=ReadableByteStreamController/[[queue]]=] and [=ReadableByteStreamController/[[queueTotalSize]]=]
+ <p>Although {{ReadableByteStreamController}} instances have
+ [=ReadableByteStreamController/[[queue]]=] and [=ReadableByteStreamController/[[queueTotalSize]]=]
  slots, we do not use most of the abstract operations in [[#queue-with-sizes]] on them, as the way
  in which we manipulate this queue is rather different than the others in the spec. Instead, we
  update the two slots together manually.
@@ -1737,8 +1744,10 @@ has the following [=struct/items=]:
  The <dfn id="rbs-controller-close" method for="ReadableByteStreamController">close()</dfn> method
  steps are:
 
- 1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}} exception.
- 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not "`readable`", throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}}
+    exception.
+ 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not
+    "`readable`", throw a {{TypeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
 </div>
 
@@ -1749,8 +1758,10 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
  1. If |chunk|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |chunk|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
- 1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}} exception.
- 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not "`readable`", throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}}
+    exception.
+ 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not
+    "`readable`", throw a {{TypeError}} exception.
  1. Return ! [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
 </div>
 
@@ -1776,7 +1787,8 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. Set |firstDescriptor|'s [=pull-into descriptor/bytes filled=] to 0.
  1. Perform ! [$ResetQueue$]([=this=]).
- 1. Let |result| be the result of performing [=this=].[=ReadableByteStreamController/[[cancelAlgorithm]]=], passing in |reason|.
+ 1. Let |result| be the result of performing
+    [=this=].[=ReadableByteStreamController/[[cancelAlgorithm]]=], passing in |reason|.
  1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$]([=this=]).
  1. Return |result|.
 </div>
@@ -1792,8 +1804,9 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
   1. Assert: ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0.
   1. Let |entry| be [=this=].[=ReadableByteStreamController/[[queue]]=][0].
   1. [=list/Remove=] |entry| from [=this=].[=ReadableByteStreamController/[[queue]]=].
-  1. Set [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] to [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] − |entry|'s [=readable byte
-     stream queue entry/byte length=].
+  1. Set [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] to
+     [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] − |entry|'s [=readable byte stream
+     queue entry/byte length=].
   1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$]([=this=]).
   1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |entry|'s [=readable byte stream queue
      entry/buffer=], |entry|'s [=readable byte stream queue entry/byte offset=], |entry|'s
@@ -1892,11 +1905,13 @@ following table:
  The <dfn id="rs-byob-request-respond" method
  for="ReadableStreamBYOBRequest">respond(|bytesWritten|)</dfn> method steps are:
 
- 1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}} exception.
- 1. If [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]]) is true, throw a {{TypeError}}
+ 1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
+ 1. If [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]]) is
+    true, throw a {{TypeError}} exception.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ByteLength]] &gt; 0.
- 1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByeLength]] &gt; 0.
+ 1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByeLength]]
+    &gt; 0.
  1. Perform ? [$ReadableByteStreamControllerRespond$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=], |bytesWritten|).
 </div>
 
@@ -1907,7 +1922,8 @@ following table:
  1. If |view|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
- 1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
+    exception.
  1. Return ? [$ReadableByteStreamControllerRespondWithNewView$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=], |view|).
 </div>
 
@@ -1999,7 +2015,8 @@ are even meant to be generally useful by other specifications.
  steps:
 
  1. Set |stream|.[=ReadableStream/[[state]]=] to "`readable`".
- 1. Set |stream|.[=ReadableStream/[[reader]]=] and |stream|.[=ReadableStream/[[storedError]]=] to undefined.
+ 1. Set |stream|.[=ReadableStream/[[reader]]=] and |stream|.[=ReadableStream/[[storedError]]=] to
+    undefined.
  1. Set |stream|.[=ReadableStream/[[disturbed]]=] to false.
 </div>
 
@@ -2034,9 +2051,9 @@ are even meant to be generally useful by other specifications.
  1. Assert: either |signal| is undefined, or |signal| [=implements=] {{AbortSignal}}.
  1. Assert: ! [$IsReadableStreamLocked$](|source|) is false.
  1. Assert: ! [$IsWritableStreamLocked$](|dest|) is false.
- 1. If |source|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}}, let |reader| be
-   either ! [$AcquireReadableStreamBYOBReader$](|source|) or !
-   [$AcquireReadableStreamDefaultReader$](|source|), at the user agent's discretion.
+ 1. If |source|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
+    let |reader| be either ! [$AcquireReadableStreamBYOBReader$](|source|) or !
+    [$AcquireReadableStreamDefaultReader$](|source|), at the user agent's discretion.
  1. Otherwise, let |reader| be ! [$AcquireReadableStreamDefaultReader$](|source|).
  1. Let |writer| be ! [$AcquireWritableStreamDefaultWriter$](|dest|).
  1. Set |source|.[=ReadableStream/[[disturbed]]=] to true.
@@ -2047,10 +2064,12 @@ are even meant to be generally useful by other specifications.
    1. Let |error| be a new "{{AbortError}}" {{DOMException}}.
    1. Let |actions| be an empty [=ordered set=].
    1. If |preventAbort| is false, [=set/append=] the following action to |actions|:
-     1. If |dest|.[=WritableStream/[[state]]=] is "`writable`", return ! [$WritableStreamAbort$](|dest|, |error|).
+     1. If |dest|.[=WritableStream/[[state]]=] is "`writable`", return !
+        [$WritableStreamAbort$](|dest|, |error|).
      1. Otherwise, return [=a promise resolved with=] undefined.
    1. If |preventCancel| is false, [=set/append=] the following action action to |actions|:
-     1. If |source|.[=ReadableStream/[[state]]=] is "`readable`", return ! [$ReadableStreamCancel$](|source|, |error|).
+     1. If |source|.[=ReadableStream/[[state]]=] is "`readable`", return !
+        [$ReadableStreamCancel$](|source|, |error|).
      1. Otherwise, return [=a promise resolved with=] undefined.
    1. [=Shutdown with an action=] consisting of [=getting a promise to wait for all=] of the actions
       in |actions|, and with |error|.
@@ -2085,24 +2104,25 @@ are even meant to be generally useful by other specifications.
     before performing any reads or writes, since they might lead to immediate shutdown.
   * <strong>Error and close states must be propagated:</strong> the following conditions must be
     applied in order.
-   1. <strong>Errors must be propagated forward:</strong> if |source|.[=ReadableStream/[[state]]=] is or becomes
-      "`errored`", then
+   1. <strong>Errors must be propagated forward:</strong>  if |source|.[=ReadableStream/[[state]]=]
+      is or becomes "`errored`", then
     1. If |preventAbort| is false, [=shutdown with an action=] of ! [$WritableStreamAbort$](|dest|,
        |source|.[=ReadableStream/[[storedError]]=]) and with |source|.[=ReadableStream/[[storedError]]=].
     1. Otherwise, [=shutdown=] with |source|.[=ReadableStream/[[storedError]]=].
-   1. <strong>Errors must be propagated backward:</strong> if |dest|.[=WritableStream/[[state]]=] is or becomes
-      "`errored`", then
+   1. <strong>Errors must be propagated backward:</strong> if |dest|.[=WritableStream/[[state]]=]
+      is or becomes "`errored`", then
     1. If |preventCancel| is false, [=shutdown with an action=] of !
-       [$ReadableStreamCancel$](|source|, |dest|.[=WritableStream/[[storedError]]=]) and with |dest|.[=WritableStream/[[storedError]]=].
+       [$ReadableStreamCancel$](|source|, |dest|.[=WritableStream/[[storedError]]=]) and with
+       |dest|.[=WritableStream/[[storedError]]=].
     1. Otherwise, [=shutdown=] with |dest|.[=WritableStream/[[storedError]]=].
-   1. <strong>Closing must be propagated forward:</strong> if |source|.[=ReadableStream/[[state]]=] is or becomes
-      "`closed`", then
+   1. <strong>Closing must be propagated forward:</strong> if |source|.[=ReadableStream/[[state]]=]
+      is or becomes "`closed`", then
     1. If |preventClose| is false, [=shutdown with an action=] of !
        [$WritableStreamDefaultWriterCloseWithErrorPropagation$](|writer|).
     1. Otherwise, [=shutdown=].
    1. <strong>Closing must be propagated backward:</strong> if !
-      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is true or |dest|.[=WritableStream/[[state]]=] is "`closed`",
-      then
+      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is true or |dest|.[=WritableStream/[[state]]=]
+      is "`closed`", then
     1. Assert: no [=chunks=] have been read or written.
     1. Let |destClosed| be a new {{TypeError}}.
     1. If |preventCancel| is false, [=shutdown with an action=] of !
@@ -2113,8 +2133,8 @@ are even meant to be generally useful by other specifications.
     |originalError|, then:
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
-   1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and ! [$WritableStreamCloseQueuedOrInFlight$](|dest|) is
-      false,
+   1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
+      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
      1. If any [=chunks=] have been read but not yet written, write them to |dest|.
      1. Wait until every [=chunk=] that has been read has been written (i.e. the corresponding
         promises have settled).
@@ -2125,8 +2145,8 @@ are even meant to be generally useful by other specifications.
     ask to shutdown, optionally with an error |error|, then:
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
-   1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and ! [$WritableStreamCloseQueuedOrInFlight$](|dest|) is
-      false,
+   1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
+      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
     1. If any [=chunks=] have been read but not yet written, write them to |dest|.
     1. Wait until every [=chunk=] that has been read has been written (i.e. the corresponding
        promises have settled).
@@ -2186,14 +2206,16 @@ create them does not matter.
      1. If |canceled2| is false and |cloneForBranch2| is true, set |value2| to ?
         [$StructuredDeserialize$](? [$StructuredSerialize$](|value2|), [=the current Realm=]).
      1. If |canceled1| is false, perform ?
-        [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=], |value1|).
+        [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+        |value1|).
      1. If |canceled2| is false, perform ?
-        [$ReadableStreamDefaultControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=], |value2|).
+        [$ReadableStreamDefaultControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+        |value2|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to
-    detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below. We want errors in |stream| to
-    error both branches immediately, so we cannot let successful synchronously-available reads
-    happen ahead of asynchronously-available errors.
+    detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.
+    We want errors in |stream| to error both branches immediately, so we cannot let successful
+    synchronously-available reads happen ahead of asynchronously-available errors.
 
    : [=read request/close steps=]
    ::
@@ -2231,8 +2253,10 @@ create them does not matter.
  1. Set |branch2| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancel2Algorithm|).
  1. [=Upon rejection=] of |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason |r|,
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=], |r|).
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=], |r|).
+  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
+     |r|).
+  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
+     |r|).
   1. [=Resolve=] |cancelPromise| with undefined.
  1. Return « |branch1|, |branch2| ».
 </div>
@@ -2278,7 +2302,8 @@ the {{ReadableStream}}'s public API.
 
  1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamBYOBReader}}.
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`" or "`closed`".
- 1. [=list/Append=] |readRequest| to |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
+ 1. [=list/Append=] |readRequest| to
+    |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
 </div>
 
 <div algorithm>
@@ -2288,7 +2313,8 @@ the {{ReadableStream}}'s public API.
 
  1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamDefaultReader}}.
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
- 1. [=list/Append=] |readRequest| to |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamDefaultReader/[[readRequests]]=].
+ 1. [=list/Append=] |readRequest| to
+    |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamDefaultReader/[[readRequests]]=].
 </div>
 
 <div algorithm>
@@ -2296,7 +2322,8 @@ the {{ReadableStream}}'s public API.
  export>ReadableStreamCancel(|stream|, |reason|)</dfn> performs the following steps:
 
  1. Set |stream|.[=ReadableStream/[[disturbed]]=] to true.
- 1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`", return [=a promise resolved with=] undefined.
+ 1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`", return [=a promise resolved with=]
+    undefined.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", return [=a promise rejected with=]
     |stream|.[=ReadableStream/[[storedError]]=].
  1. Perform ! [$ReadableStreamClose$](|stream|).
@@ -2374,7 +2401,8 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-get-num-read-into-requests">ReadableStreamGetNumReadIntoRequests(|stream|)</dfn>
  performs the following steps:
 
- 1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=]'s [=list/size=].
+ 1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=]'s
+    [=list/size=].
 </div>
 
 <div algorithm>
@@ -2382,7 +2410,8 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-get-num-read-requests">ReadableStreamGetNumReadRequests(|stream|)</dfn>
  performs the following steps:
 
- 1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamDefaultReader/[[readRequests]]=]'s [=list/size=].
+ 1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamDefaultReader/[[readRequests]]=]'s
+    [=list/size=].
 </div>
 
 <div algorithm>
@@ -2432,10 +2461,12 @@ The following abstract operations support the implementation and manipulation of
  1. If |stream|.[=ReadableStream/[[state]]=] is "`readable`",
   1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |stream|.[=ReadableStream/[[state]]=] is "`closed`",
-  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise resolved with=] undefined.
+  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise resolved with=]
+     undefined.
  1. Otherwise,
   1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`errored`".
-  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise rejected with=] |stream|.[=ReadableStream/[[storedError]]=].
+  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise rejected with=]
+     |stream|.[=ReadableStream/[[storedError]]=].
   1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
@@ -2445,11 +2476,13 @@ The following abstract operations support the implementation and manipulation of
  performs the following steps:
 
  1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=] is not undefined.
- 1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[reader]]=] is |reader|.
- 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is "`readable`", [=reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with
-    a {{TypeError}} exception.
- 1. Otherwise, set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise rejected with=] a {{TypeError}}
-    exception.
+ 1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[reader]]=] is
+    |reader|.
+ 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is
+    "`readable`", [=reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with a
+    {{TypeError}} exception.
+ 1. Otherwise, set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise rejected
+    with=] a {{TypeError}} exception.
  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
  1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[reader]]=] to undefined.
  1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=] to undefined.
@@ -2463,10 +2496,10 @@ The following abstract operations support the implementation and manipulation of
  1. Let |stream| be |reader|.[=ReadableStreamGenericReader/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Set |stream|.[=ReadableStream/[[disturbed]]=] to true.
- 1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", perform |readIntoRequest|'s [=read-into request/error
-    steps=] given |stream|.[=ReadableStream/[[storedError]]=].
- 1. Return ! [$ReadableByteStreamControllerPullInto$](|stream|.[=ReadableStream/[[controller]]=], |view|,
-    |readIntoRequest|).
+ 1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", perform |readIntoRequest|'s [=read-into
+    request/error steps=] given |stream|.[=ReadableStream/[[storedError]]=].
+ 1. Return ! [$ReadableByteStreamControllerPullInto$](|stream|.[=ReadableStream/[[controller]]=],
+    |view|, |readIntoRequest|).
 </div>
 
 <div algorithm>
@@ -2477,9 +2510,10 @@ The following abstract operations support the implementation and manipulation of
  1. Let |stream| be |reader|.[=ReadableStreamGenericReader/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Set |stream|.[=ReadableStream/[[disturbed]]=] to true.
- 1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`", perform |readRequest|'s [=read request/close steps=].
- 1. Otherwise, if |stream|.[=ReadableStream/[[state]]=] is "`errored`", perform |readRequest|'s [=read request/error
-    steps=] given |stream|.[=ReadableStream/[[storedError]]=].
+ 1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`", perform |readRequest|'s [=read
+    request/close steps=].
+ 1. Otherwise, if |stream|.[=ReadableStream/[[state]]=] is "`errored`", perform |readRequest|'s
+    [=read request/error steps=] given |stream|.[=ReadableStream/[[storedError]]=].
  1. Otherwise,
   1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
   1. Perform ! |stream|.[=ReadableStream/[[controller]]=].[$ReadableStreamController/[[PullSteps]]$](|readRequest|).
@@ -2491,8 +2525,8 @@ The following abstract operations support the implementation and manipulation of
  performs the following steps:
 
  1. If ! [$IsReadableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
- 1. If |stream|.[=ReadableStream/[[controller]]=] does not [=implement=] {{ReadableByteStreamController}}, throw a
-    {{TypeError}} exception.
+ 1. If |stream|.[=ReadableStream/[[controller]]=] does not [=implement=]
+    {{ReadableByteStreamController}}, throw a {{TypeError}} exception.
  1. Perform ! [$ReadableStreamReaderGenericInitialize$](|reader|, |stream|).
  1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
 </div>
@@ -2603,8 +2637,9 @@ The following abstract operations support the implementation of the
     [$ReadableStreamGetNumReadRequests$](|stream|) > 0, perform !
     [$ReadableStreamFulfillReadRequest$](|stream|, |chunk|, false).
  1. Otherwise,
-  1. Let |result| be the result of performing |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in
-     |chunk|, and interpreting the result as a [=completion record=].
+  1. Let |result| be the result of performing
+     |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in |chunk|,
+     and interpreting the result as a [=completion record=].
   1. If |result| is an abrupt completion,
    1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |result|.\[[Value]]).
    1. Return |result|.
@@ -2647,7 +2682,8 @@ The following abstract operations support the implementation of the
  1. Let |state| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=] − |controller|.[=ReadableStreamDefaultController/[[queueTotalSize]]=].
+ 1. Return |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=] −
+    |controller|.[=ReadableStreamDefaultController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>
@@ -2664,12 +2700,14 @@ The following abstract operations support the implementation of the
  id="readable-stream-default-controller-can-close-or-enqueue">ReadableStreamDefaultControllerCanCloseOrEnqueue(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |state| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].[=ReadableStream/[[state]]=].
- 1. If |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] is false and |state| is "`readable`", return true.
+ 1. Let |state| be
+    |controller|.[=ReadableStreamDefaultController/[[stream]]=].[=ReadableStream/[[state]]=].
+ 1. If |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] is false and |state| is
+    "`readable`", return true.
  1. Otherwise, return false.
 
- <p class="note">The case where |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] is false, but |state| is not
- "`readable`", happens when the stream is errored via
+ <p class="note">The case where |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=]
+ is false, but |state| is not "`readable`", happens when the stream is errored via
  {{ReadableStreamDefaultController/error(e)|controller.error()}}, or when it is closed without its
  controller's {{ReadableStreamDefaultController/close()|controller.close()}} method ever being
  called: e.g., if the stream was closed by a call to
@@ -2685,10 +2723,13 @@ The following abstract operations support the implementation of the
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. Set |controller|.[=ReadableStreamDefaultController/[[stream]]=] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=], |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=], |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=],
+    |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=],
+    |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
     |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
- 1. Set |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=] to |sizeAlgorithm| and |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=]
-    to |highWaterMark|.
+ 1. Set |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=] to
+    |sizeAlgorithm| and |controller|.[=ReadableStreamDefaultController/[[strategyHWM]]=] to
+    |highWaterMark|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
  1. Set |stream|.[=ReadableStream/[[controller]]=] to |controller|.
@@ -2743,7 +2784,8 @@ The following abstract operations support the implementation of the
   1. Return.
  1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
  1. Set |controller|.[=ReadableByteStreamController/[[pulling]]=] to true.
- 1. Let |pullPromise| be the result of performing |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=].
+ 1. Let |pullPromise| be the result of performing
+    |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=].
  1. [=Upon fulfillment=] of |pullPromise|,
   1. Set |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
   1. If |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is true,
@@ -2786,12 +2828,14 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
- 1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
+ 1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or
+    |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] to true.
   1. Return.
  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty,
-  1. Let |firstPendingPullInto| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. Let |firstPendingPullInto| be
+     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If |firstPendingPullInto|'s [=pull-into descriptor/bytes filled=] > 0,
    1. Let |e| be a new {{TypeError}} exception.
    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
@@ -2839,7 +2883,8 @@ The following abstract operations support the implementation of the
  |chunk|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
- 1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
+ 1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or
+    |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
  1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
  1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
  1. Let |byteLength| be |chunk|.\[[ByteLength]].
@@ -2871,8 +2916,10 @@ The following abstract operations support the implementation of the
 
  1. [=list/Append=] a new [=readable byte stream queue entry=] with [=readable byte stream queue
     entry/buffer=] |buffer|, [=readable byte stream queue entry/byte offset=] |byteOffset|, and
-    [=readable byte stream queue entry/byte length=] |byteLength| to |controller|.[=ReadableByteStreamController/[[queue]]=].
- 1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] + |byteLength|.
+    [=readable byte stream queue entry/byte length=] |byteLength| to
+    |controller|.[=ReadableByteStreamController/[[queue]]=].
+ 1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to
+    |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] + |byteLength|.
 </div>
 
 <div algorithm>
@@ -2893,8 +2940,9 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-fill-head-pull-into-descriptor">ReadableByteStreamControllerFillHeadPullIntoDescriptor(|controller|,
  |size|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
- 1. Assert: either |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] [=list/is empty=], or
-    |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0] is |pullIntoDescriptor|.
+ 1. Assert: either |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=]
+    [=list/is empty=], or |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0]
+    is |pullIntoDescriptor|.
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to [=pull-into
     descriptor/bytes filled=] + |size|.
@@ -2908,8 +2956,9 @@ The following abstract operations support the implementation of the
  1. Let |elementSize| be |pullIntoDescriptor|.\[[elementSize]].
  1. Let |currentAlignedBytes| be |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] −
     (|pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] mod |elementSize|).
- 1. Let |maxBytesToCopy| be min(|controller|.[=ReadableByteStreamController/[[queueTotalSize]]=], |pullIntoDescriptor|'s [=pull-into
-    descriptor/byte length=] − |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=]).
+ 1. Let |maxBytesToCopy| be min(|controller|.[=ReadableByteStreamController/[[queueTotalSize]]=],
+    |pullIntoDescriptor|'s [=pull-into descriptor/byte length=] − |pullIntoDescriptor|'s [=pull-into
+    descriptor/bytes filled=]).
  1. Let |maxBytesFilled| be |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] +
     |maxBytesToCopy|.
  1. Let |maxAlignedBytes| be |maxBytesFilled| − (|maxBytesFilled| mod |elementSize|).
@@ -2937,7 +2986,8 @@ The following abstract operations support the implementation of the
       [=readable byte stream queue entry/byte offset=] + |bytesToCopy|.
    1. Set |headOfQueue|'s [=readable byte stream queue entry/byte length=] to |headOfQueue|'s
       [=readable byte stream queue entry/byte length=] − |bytesToCopy|.
-  1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] − |bytesToCopy|.
+  1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to
+     |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] − |bytesToCopy|.
   1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
      |bytesToCopy|, |pullIntoDescriptor|).
   1. Set |totalBytesToCopyRemaining| to |totalBytesToCopyRemaining| − |bytesToCopy|.
@@ -2957,7 +3007,8 @@ The following abstract operations support the implementation of the
  1. Let |state| be |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] − |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=].
+ 1. Return |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] −
+    |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>
@@ -2966,7 +3017,8 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is "`readable`".
- 1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0 and |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
+ 1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0 and
+    |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
   1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
   1. Perform ! [$ReadableStreamClose$](|controller|.[=ReadableByteStreamController/[[stream]]=]).
  1. Otherwise,
@@ -2990,7 +3042,8 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is false.
- 1. [=While=] |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
+ 1. [=While=] |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
+    [=list/is empty|empty=],
   1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, return.
   1. Let |pullIntoDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
@@ -3022,7 +3075,8 @@ The following abstract operations support the implementation of the
     size=] |elementSize|, [=pull-into descriptor/view constructor=] |ctor|, and [=pull-into
     descriptor/reader type=] "`byob`".
  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty,
-  1. [=list/Append=] |pullIntoDescriptor| to |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
+  1. [=list/Append=] |pullIntoDescriptor| to
+     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
   1. Perform ! [$ReadableStreamAddReadIntoRequest$](|stream|, |readIntoRequest|).
   1. Return.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`",
@@ -3043,7 +3097,8 @@ The following abstract operations support the implementation of the
    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
    1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
    1. Return.
- 1. [=list/Append=] |pullIntoDescriptor| to |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
+ 1. [=list/Append=] |pullIntoDescriptor| to
+    |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
  1. Perform ! [$ReadableStreamAddReadIntoRequest$](|stream|, |readIntoRequest|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
 </div>
@@ -3178,10 +3233,12 @@ The following abstract operations support the implementation of the
   1. Assert: ! IsInteger(|autoAllocateChunkSize|) is true.
   1. Assert: |autoAllocateChunkSize| is positive.
  1. Set |controller|.[=ReadableByteStreamController/[[stream]]=] to |stream|.
- 1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
+ 1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and
+    |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to null.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and |controller|.[=ReadableByteStreamController/[[started]]=] to false.
+ 1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and
+    |controller|.[=ReadableByteStreamController/[[started]]=] to false.
  1. Set |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] to |highWaterMark|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
@@ -3434,10 +3491,10 @@ table:
   requests not yet processed by the [=underlying sink=]
 </table>
 
-<p class="note">The [=WritableStream/[[inFlightCloseRequest]]=] slot and [=WritableStream/[[closeRequest]]=] slot are mutually
-exclusive. Similarly, no element will be removed from [=WritableStream/[[writeRequests]]=] while
-[=WritableStream/[[inFlightWriteRequest]]=] is not undefined. Implementations can optimize storage for these slots
-based on these invariants.
+<p class="note">The [=WritableStream/[[inFlightCloseRequest]]=] slot and
+[=WritableStream/[[closeRequest]]=] slot are mutually exclusive. Similarly, no element will be
+removed from [=WritableStream/[[writeRequests]]=] while [=WritableStream/[[inFlightWriteRequest]]=]
+is not undefined. Implementations can optimize storage for these slots based on these invariants.
 
 A <dfn>pending abort request</dfn> is a [=struct=] used to track a request to abort the stream
 before that request is finally processed. It has the following [=struct/items=]:
@@ -3811,8 +3868,8 @@ following table:
  The <dfn id="default-writer-abort" method for="WritableStreamDefaultWriter">abort(|reason|)</dfn>
  method steps are:
 
- 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected with=] a {{TypeError}}
-    exception.
+ 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected
+    with=] a {{TypeError}} exception.
  1. Return ! [$WritableStreamDefaultWriterAbort$]([=this=], |reason|).
 </div>
 
@@ -3841,8 +3898,8 @@ following table:
  The <dfn id="default-writer-write" method for="WritableStreamDefaultWriter">write(|chunk|)</dfn>
  method steps are:
 
- 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected with=] a {{TypeError}}
-    exception.
+ 1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected
+    with=] a {{TypeError}} exception.
  1. Return ! [$WritableStreamDefaultWriterWrite$]([=this=], |chunk|).
 </div>
 
@@ -3887,8 +3944,8 @@ the following table:
    <td class="non-normative">A [=list=] representing the stream's internal queue of [=chunks=]
   <tr>
    <td><dfn>\[[queueTotalSize]]</dfn>
-   <td class="non-normative">The total size of all the chunks stored in [=WritableStreamDefaultController/[[queue]]=] (see
-   [[#queue-with-sizes]])
+   <td class="non-normative">The total size of all the chunks stored in
+   [=WritableStreamDefaultController/[[queue]]=] (see [[#queue-with-sizes]])
   <tr>
    <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying sink=] has finished
@@ -3911,9 +3968,9 @@ the following table:
    write), which writes data to the [=underlying sink=]
 </table>
 
-The <dfn>close sentinel</dfn> is a unique value enqueued into [=WritableStreamDefaultController/[[queue]]=], in lieu of a [=chunk=], to
-signal that the stream is closed. It is only used internally, and is never exposed to web
-developers.
+The <dfn>close sentinel</dfn> is a unique value enqueued into
+[=WritableStreamDefaultController/[[queue]]=], in lieu of a [=chunk=], to signal that the stream is
+closed. It is only used internally, and is never exposed to web developers.
 
 <h4 id="ws-default-controller-prototype">Methods</h4>
 
@@ -3956,7 +4013,8 @@ as such the counterpart internal methods are used polymorphically.
  oldids="writable-stream-default-controller-abort">\[[AbortSteps]](|reason|)</dfn> implements the
  [$WritableStreamController/[[AbortSteps]]$] contract. It performs the following steps:
 
- 1. Let |result| be the result of performing [=this=].[=WritableStreamDefaultController/[[abortAlgorithm]]=], passing |reason|.
+ 1. Let |result| be the result of performing
+    [=this=].[=WritableStreamDefaultController/[[abortAlgorithm]]=], passing |reason|.
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$]([=this=]).
  1. Return |result|.
 </div>
@@ -4019,9 +4077,10 @@ are even meant to be generally useful by other specifications.
  steps:
 
  1. Set |stream|.[=WritableStream/[[state]]=] to "`writable`".
- 1. Set |stream|.[=WritableStream/[[storedError]]=], |stream|.[=WritableStream/[[writer]]=], |stream|.[=WritableStream/[[controller]]=],
-    |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
-    |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
+ 1. Set |stream|.[=WritableStream/[[storedError]]=], |stream|.[=WritableStream/[[writer]]=],
+    |stream|.[=WritableStream/[[controller]]=], |stream|.[=WritableStream/[[inFlightWriteRequest]]=],
+    |stream|.[=WritableStream/[[closeRequest]]=], |stream|.[=WritableStream/[[inFlightCloseRequest]]=]
+    and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.[=WritableStream/[[writeRequests]]=] to a new empty [=list=].
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
 </div>
@@ -4046,23 +4105,30 @@ are even meant to be generally useful by other specifications.
  1. Set |stream|.[=WritableStream/[[writer]]=] to |writer|.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
-  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[backpressure]]=]
-     is true, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a new promise=].
-  1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise resolved with=] undefined.
+  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and
+     |stream|.[=WritableStream/[[backpressure]]=] is true, set
+     |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a new promise=].
+  1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise resolved
+     with=] undefined.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |state| is "`erroring`",
-  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=]
+     |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseIsHandled]] to true.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a new promise=].
  1. Otherwise, if |state| is "`closed`",
-  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise resolved with=] undefined.
-  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise resolved with=] undefined.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise resolved with=]
+     undefined.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise resolved with=]
+     undefined.
  1. Otherwise,
   1. Assert: |state| is "`errored`".
   1. Let |storedError| be |stream|.[=WritableStream/[[storedError]]=].
-  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=] |storedError|.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=]
+     |storedError|.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseIsHandled]] to true.
-  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected with=] |storedError|.
+  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected with=]
+     |storedError|.
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
@@ -4081,9 +4147,9 @@ are even meant to be generally useful by other specifications.
    1. Set |wasAlreadyErroring| to true.
    1. Set |reason| to undefined.
  1. Let |promise| be [=a new promise=].
- 1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to a new [=pending abort request=] whose [=pending abort
-    request/promise=] is |promise|, [=pending abort request/reason=] is |reason|, and [=pending
-    abort request/was already erroring=] is |wasAlreadyErroring|.
+ 1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to a new [=pending abort request=] whose
+    [=pending abort request/promise=] is |promise|, [=pending abort request/reason=] is |reason|,
+    and [=pending abort request/was already erroring=] is |wasAlreadyErroring|.
  1. If |wasAlreadyErroring| is false, perform ! [$WritableStreamStartErroring$](|stream|, |reason|).
  1. Return |promise|.
 </div>
@@ -4100,8 +4166,9 @@ are even meant to be generally useful by other specifications.
  1. Let |promise| be [=a new promise=].
  1. Set |stream|.[=WritableStream/[[closeRequest]]=] to |promise|.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
- 1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and |state| is
-    "`writable`", [=resolve=] |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] with undefined.
+ 1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and
+    |state| is "`writable`", [=resolve=] |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=]
+    with undefined.
  1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.[=WritableStream/[[controller]]=]).
  1. Return |promise|.
 </div>
@@ -4154,8 +4221,8 @@ the {{WritableStream}}'s public API.
  id="writable-stream-close-queued-or-in-flight">WritableStreamCloseQueuedOrInFlight(|stream|)</dfn>
  performs the following steps:
 
- 1. If |stream|.[=WritableStream/[[closeRequest]]=] is undefined and |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined,
-    return false.
+ 1. If |stream|.[=WritableStream/[[closeRequest]]=] is undefined and
+    |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined, return false.
  1. Return true.
 </div>
 
@@ -4194,8 +4261,8 @@ the {{WritableStream}}'s public API.
   1. [=Reject=] |abortRequest|'s [=pending abort request/promise=] with |storedError|.
   1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
   1. Return.
- 1. Let |promise| be ! stream.[=WritableStream/[[controller]]=].\[[AbortSteps]](|abortRequest|'s [=pending abort
-    request/reason=]).
+ 1. Let |promise| be ! stream.[=WritableStream/[[controller]]=].\[[AbortSteps]](|abortRequest|'s
+    [=pending abort request/reason=]).
  1. [=Upon fulfillment=] of |promise|,
   1. [=Resolve=] |abortRequest|'s [=pending abort request/promise=] with undefined.
   1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
@@ -4217,12 +4284,13 @@ the {{WritableStream}}'s public API.
  1. If |state| is "`erroring`",
   1. Set |stream|.[=WritableStream/[[storedError]]=] to undefined.
   1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
-   1. [=Resolve=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=] with
-      undefined.
+   1. [=Resolve=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort
+      request/promise=] with undefined.
    1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`closed`".
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
- 1. If |writer| is not undefined, [=resolve=] |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with undefined.
+ 1. If |writer| is not undefined, [=resolve=]
+    |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with undefined.
  1. Assert: |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined.
  1. Assert: |stream|.[=WritableStream/[[storedError]]=] is undefined.
 </div>
@@ -4237,7 +4305,8 @@ the {{WritableStream}}'s public API.
  1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
-  1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=] with |error|.
+  1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort
+     request/promise=] with |error|.
   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Perform ! WritableStreamDealWithRejection(|stream|, |error|).
 </div>
@@ -4270,7 +4339,8 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. If |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is undefined and
-    |stream|.[=WritableStream/[[controller]]=].[=WritableStream/[[inFlightCloseRequest]]=] is undefined, return false.
+    |stream|.[=WritableStream/[[controller]]=].[=WritableStream/[[inFlightCloseRequest]]=] is
+    undefined, return false.
  1. Return true.
 </div>
 
@@ -4281,7 +4351,8 @@ the {{WritableStream}}'s public API.
 
  1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined.
  1. Assert: |stream|.[=WritableStream/[[closeRequest]]=] is not undefined.
- 1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to |stream|.[=WritableStream/[[closeRequest]]=].
+ 1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to
+    |stream|.[=WritableStream/[[closeRequest]]=].
  1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
 </div>
 
@@ -4305,11 +4376,13 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`errored`".
  1. If |stream|.[=WritableStream/[[closeRequest]]=] is not undefined,
   1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined.
-  1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with |stream|.[=WritableStream/[[storedError]]=].
+  1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with
+     |stream|.[=WritableStream/[[storedError]]=].
   1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined,
-  1. [=Reject=] |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with |stream|.[=WritableStream/[[storedError]]=].
+  1. [=Reject=] |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with
+     |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
@@ -4328,7 +4401,8 @@ the {{WritableStream}}'s public API.
  1. If |writer| is not undefined, perform !
     [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |reason|).
  1. If ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false and
-    |controller|.[=WritableStreamDefaultController/[[started]]=] is true, perform ! [$WritableStreamFinishErroring$](|stream|).
+    |controller|.[=WritableStreamDefaultController/[[started]]=] is true, perform !
+    [$WritableStreamFinishErroring$](|stream|).
 </div>
 
 <div algorithm>
@@ -4339,8 +4413,10 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
- 1. If |writer| is not undefined and |backpressure| is not |stream|.[=WritableStream/[[backpressure]]=],
-  1. If |backpressure| is true, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a new promise=].
+ 1. If |writer| is not undefined and |backpressure| is not
+    |stream|.[=WritableStream/[[backpressure]]=],
+  1. If |backpressure| is true, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to
+     [=a new promise=].
   1. Otherwise,
    1. Assert: |backpressure| is false.
    1. [=Resolve=] |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] with undefined.
@@ -4382,7 +4458,8 @@ The following abstract operations support the implementation and manipulation of
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
     [=a promise resolved with=] undefined.
- 1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
+ 1. If |state| is "`errored`", return [=a promise rejected with=]
+    |stream|.[=WritableStream/[[storedError]]=].
  1. Assert: |state| is "`writable`" or "`erroring`".
  1. Return ! [$WritableStreamDefaultWriterClose$](|writer|).
 
@@ -4395,9 +4472,10 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-ensure-closed-promise-rejected">WritableStreamDefaultWriterEnsureClosedPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
- 1. If |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseState]] is "`pending`", [=reject=]
-    |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with |error|.
- 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected with=] |error|.
+ 1. If |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseState]] is "`pending`",
+    [=reject=] |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] with |error|.
+ 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=] to [=a promise rejected
+    with=] |error|.
  1. Set |writer|.[=WritableStreamDefaultWriter/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
@@ -4406,9 +4484,10 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-ensure-ready-promise-rejected">WritableStreamDefaultWriterEnsureReadyPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
- 1. If |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseState]] is "`pending`", [=reject=]
-    |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] with |error|.
- 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected with=] |error|.
+ 1. If |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseState]] is "`pending`",
+    [=reject=] |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] with |error|.
+ 1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise rejected
+    with=] |error|.
  1. Set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
@@ -4448,14 +4527,16 @@ The following abstract operations support the implementation and manipulation of
  1. Assert: |stream| is not undefined.
  1. Let |controller| be |stream|.[=WritableStream/[[controller]]=].
  1. Let |chunkSize| be ! [$WritableStreamDefaultControllerGetChunkSize$](|controller|, |chunk|).
- 1. If |stream| is not equal to |writer|.[=WritableStreamDefaultWriter/[[stream]]=], return [=a promise rejected with=] a
-    {{TypeError}} exception.
+ 1. If |stream| is not equal to |writer|.[=WritableStreamDefaultWriter/[[stream]]=], return [=a
+    promise rejected with=] a {{TypeError}} exception.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
- 1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
+ 1. If |state| is "`errored`", return [=a promise rejected with=]
+    |stream|.[=WritableStream/[[storedError]]=].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
     [=a promise rejected with=] a {{TypeError}} exception indicating that the stream is closing or
     closed.
- 1. If |state| is "`erroring`", return [=a promise rejected with=] |stream|.[=WritableStream/[[storedError]]=].
+ 1. If |state| is "`erroring`", return [=a promise rejected with=]
+    |stream|.[=WritableStream/[[storedError]]=].
  1. Assert: |state| is "`writable`".
  1. Let |promise| be ! [$WritableStreamAddWriteRequest$](|stream|).
  1. Perform ! [$WritableStreamDefaultControllerWrite$](|controller|, |chunk|, |chunkSize|).
@@ -4599,8 +4680,8 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-error-if-needed">WritableStreamDefaultControllerErrorIfNeeded(|controller|,
  |error|)</dfn> performs the following steps:
 
- 1. If |controller|.[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=] is "`writable`", perform !
-    [$WritableStreamDefaultControllerError$](|controller|, |error|).
+ 1. If |controller|.[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=] is
+    "`writable`", perform ! [$WritableStreamDefaultControllerError$](|controller|, |error|).
 </div>
 
 <div algorithm>
@@ -4617,8 +4698,9 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-get-chunk-size">WritableStreamDefaultControllerGetChunkSize(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Let |returnValue| be the result of performing |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=], passing
-    in |chunk|, and interpreting the result as a [=completion record=].
+ 1. Let |returnValue| be the result of performing
+    |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in |chunk|,
+    and interpreting the result as a [=completion record=].
  1. If |returnValue| is an abrupt completion,
   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|,
      |returnValue|.\[[Value]]).
@@ -4631,7 +4713,8 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-get-desired-size">WritableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
- 1. Return |controller|.[=WritableStreamDefaultController/[[strategyHWM]]=] − |controller|.[=WritableStreamDefaultController/[[queueTotalSize]]=].
+ 1. Return |controller|.[=WritableStreamDefaultController/[[strategyHWM]]=] −
+    |controller|.[=WritableStreamDefaultController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>
@@ -4643,7 +4726,8 @@ The following abstract operations support the implementation of the
  1. Perform ! [$WritableStreamMarkCloseRequestInFlight$](|stream|).
  1. Perform ! [$DequeueValue$](|controller|).
  1. Assert: |controller|.[=WritableStreamDefaultController/[[queue]]=] is empty.
- 1. Let |sinkClosePromise| be the result of performing |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=].
+ 1. Let |sinkClosePromise| be the result of performing
+    |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=].
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
  1. [=Upon fulfillment=] of |sinkClosePromise|,
   1. Perform ! [$WritableStreamFinishInFlightClose$](|stream|).
@@ -4658,8 +4742,8 @@ The following abstract operations support the implementation of the
 
  1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. Perform ! [$WritableStreamMarkFirstWriteRequestInFlight$](|stream|).
- 1. Let |sinkWritePromise| be the result of performing |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=], passing in
-    |chunk|.
+ 1. Let |sinkWritePromise| be the result of performing
+    |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=], passing in |chunk|.
  1. [=Upon fulfillment=] of |sinkWritePromise|,
   1. Perform ! [$WritableStreamFinishInFlightWrite$](|stream|).
   1. Let |state| be |stream|.[=WritableStream/[[state]]=].
@@ -4686,8 +4770,8 @@ The following abstract operations support the implementation of the
      |enqueueResult|.\[[Value]]).
   1. Return.
  1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
- 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[state]]=] is
-    "`writable`",
+ 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and
+    |stream|.[=WritableStream/[[state]]=] is "`writable`",
   1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
   1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
  1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
@@ -4788,8 +4872,8 @@ table:
  <tbody>
   <tr>
    <td><dfn>\[[backpressure]]</dfn>
-   <td class="non-normative">Whether there was backpressure on [=TransformStream/[[readable]]=] the last time it was
-   observed
+   <td class="non-normative">Whether there was backpressure on [=TransformStream/[[readable]]=] the
+   last time it was observed
   <tr>
    <td><dfn>\[[backpressureChangePromise]]</dfn>
    <td class="non-normative">A promise which is fulfilled and replaced every time the value of
@@ -5123,21 +5207,23 @@ are even meant to be generally useful by other specifications.
   1. Return ! [$TransformStreamDefaultSinkAbortAlgorithm$](|stream|, |reason|).
  1. Let |closeAlgorithm| be the following steps:
   1. Return ! [$TransformStreamDefaultSinkCloseAlgorithm$](|stream|).
- 1. Set |stream|.[=TransformStream/[[writable]]=] to ! [$CreateWritableStream$](|startAlgorithm|, |writeAlgorithm|,
-    |closeAlgorithm|, |abortAlgorithm|, |writableHighWaterMark|, |writableSizeAlgorithm|).
+ 1. Set |stream|.[=TransformStream/[[writable]]=] to ! [$CreateWritableStream$](|startAlgorithm|,
+    |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|, |writableHighWaterMark|,
+    |writableSizeAlgorithm|).
  1. Let |pullAlgorithm| be the following steps:
   1. Return ! [$TransformStreamDefaultSourcePullAlgorithm$](|stream|).
  1. Let |cancelAlgorithm| be the following steps, taking a |reason| argument:
   1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |reason|).
   1. Return [=a promise resolved with=] undefined.
- 1. Set |stream|.[=TransformStream/[[readable]]=] to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
-    |cancelAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
- 1. Set |stream|.[=TransformStream/[[backpressure]]=] and |stream|.[=TransformStream/[[backpressureChangePromise]]=] to undefined.
-    <p class="note">The [=TransformStream/[[backpressure]]=] slot is set to undefined so that it can be initialized by
-    [$TransformStreamSetBackpressure$]. Alternatively, implementations can use a strictly boolean
-    value for [=TransformStream/[[backpressure]]=] and change the way it is initialized. This will not be visible to
-    user code so long as the initialization is correctly completed before the transformer's
-    {{Transformer/start|start()}} method is called.
+ 1. Set |stream|.[=TransformStream/[[readable]]=] to ! [$CreateReadableStream$](|startAlgorithm|,
+    |pullAlgorithm|, |cancelAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
+ 1. Set |stream|.[=TransformStream/[[backpressure]]=] and
+    |stream|.[=TransformStream/[[backpressureChangePromise]]=] to undefined.
+    <p class="note">The [=TransformStream/[[backpressure]]=] slot is set to undefined so that it can
+    be initialized by [$TransformStreamSetBackpressure$]. Alternatively, implementations can use a
+    strictly boolean value for [=TransformStream/[[backpressure]]=] and change the way it is
+    initialized. This will not be visible to user code so long as the initialization is correctly
+    completed before the transformer's {{Transformer/start|start()}} method is called.
  1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
  1. Set |stream|.[=TransformStream/[[controller]]=] to undefined.
 </div>
@@ -5166,8 +5252,8 @@ are even meant to be generally useful by other specifications.
     false).
 
  <p class="note">The [$TransformStreamDefaultSinkWriteAlgorithm$] abstract operation could be
- waiting for the promise stored in the [=TransformStream/[[backpressureChangePromise]]=] slot to resolve. The call to
- [$TransformStreamSetBackpressure$] ensures that the promise always resolves.
+ waiting for the promise stored in the [=TransformStream/[[backpressureChangePromise]]=] slot to
+ resolve. The call to [$TransformStreamSetBackpressure$] ensures that the promise always resolves.
 </div>
 
 <div algorithm>
@@ -5196,7 +5282,8 @@ The following abstract operations support the implementaiton of the
  1. Assert: |stream|.[=TransformStream/[[controller]]=] is undefined.
  1. Set |controller|.[=TransformStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=TransformStream/[[controller]]=] to |controller|.
- 1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to |transformAlgorithm|.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to
+    |transformAlgorithm|.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to |flushAlgorithm|.
 </div>
 
@@ -5251,7 +5338,8 @@ The following abstract operations support the implementaiton of the
  It performs the following steps:
 
  1. Let |stream| be |controller|.[=TransformStreamDefaultController/[[stream]]=].
- 1. Let |readableController| be |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
+ 1. Let |readableController| be
+    |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|readableController|) is false, throw
     a {{TypeError}} exception.
  1. Let |enqueueResult| be [$ReadableStreamDefaultControllerEnqueue$](|readableController|,
@@ -5350,11 +5438,13 @@ side=] of [=transform streams=].
 
  1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
- 1. Let |flushPromise| be the result of performing |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=].
+ 1. Let |flushPromise| be the result of performing
+    |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Return the result of [=reacting=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
-   1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", throw |readable|.[=ReadableStream/[[storedError]]=].
+   1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", throw
+      |readable|.[=ReadableStream/[[storedError]]=].
    1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
   1. If |flushPromise| was rejected with reason |r|, then:
    1. Perform ! [$TransformStreamError$](|stream|, |r|).
@@ -5485,8 +5575,9 @@ interface ByteLengthQueuingStrategy {
 
 <h4 id="blqs-internal-slots">Internal slots</h4>
 
-Instances of {{ByteLengthQueuingStrategy}} have a <dfn for="ByteLengthQueuingStrategy">\[[highWaterMark]]</dfn> internal slot, storing the
-value given in the constructor.
+Instances of {{ByteLengthQueuingStrategy}} have a
+<dfn for="ByteLengthQueuingStrategy">\[[highWaterMark]]</dfn> internal slot, storing the value given
+in the constructor.
 
 <div algorithm>
  Additionally, every [=/global object=] |globalObject| has an associated <dfn>byte length queuing
@@ -5534,7 +5625,8 @@ value given in the constructor.
  lt="ByteLengthQueuingStrategy(init)">new ByteLengthQueuingStrategy(|init|)</dfn> constructor steps
  are:
 
- 1. Set [=this=].[=ByteLengthQueuingStrategy/[[highWaterMark]]=] to |init|["{{QueuingStrategyInit/highWaterMark}}"].
+ 1. Set [=this=].[=ByteLengthQueuingStrategy/[[highWaterMark]]=] to
+    |init|["{{QueuingStrategyInit/highWaterMark}}"].
 </div>
 
 <div algorithm>
@@ -5599,8 +5691,8 @@ interface CountQueuingStrategy {
 
 <h4 id="cqs-internal-slots">Internal slots</h4>
 
-Instances of {{CountQueuingStrategy}} have a <dfn for="CountQueuingStrategy">\[[highWaterMark]]</dfn> internal slot, storing the
-value given in the constructor.
+Instances of {{CountQueuingStrategy}} have a <dfn for="CountQueuingStrategy">\[[highWaterMark]]</dfn>
+internal slot, storing the value given in the constructor.
 
 <div algorithm>
  Additionally, every [=/global object=] |globalObject| has an associated <dfn>count queuing strategy
@@ -5647,7 +5739,8 @@ value given in the constructor.
  The <dfn id="cqs-constructor" constructor for="CountQueuingStrategy"
  lt="CountQueuingStrategy(init)">new CountQueuingStrategy(|init|)</dfn> constructor steps are:
 
- 1. Set [=this=].[=CountQueuingStrategy/[[highWaterMark]]=] to |init|["{{QueuingStrategyInit/highWaterMark}}"].
+ 1. Set [=this=].[=CountQueuingStrategy/[[highWaterMark]]=] to
+    |init|["{{QueuingStrategyInit/highWaterMark}}"].
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -5197,7 +5197,7 @@ The following abstract operations support the implementaiton of the
  1. Set |controller|.\[[stream]] to |stream|.
  1. Set |stream|.[=TransformStream/[[controller]]=] to |controller|.
  1. Set |controller|.\[[transformAlgorithm]] to |transformAlgorithm|.
- 1. Set |controller|.\[[flushAlgorithm]] to |flushAlgorithm|.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to |flushAlgorithm|.
 </div>
 
 <div algorithm>
@@ -5237,7 +5237,7 @@ The following abstract operations support the implementaiton of the
  It performs the following steps:
 
  1. Set |controller|.\[[transformAlgorithm]] to undefined.
- 1. Set |controller|.\[[flushAlgorithm]] to undefined.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -5350,7 +5350,7 @@ side=] of [=transform streams=].
 
  1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
- 1. Let |flushPromise| be the result of performing |controller|.\[[flushAlgorithm]].
+ 1. Let |flushPromise| be the result of performing |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Return the result of [=reacting=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:

--- a/index.bs
+++ b/index.bs
@@ -1712,9 +1712,9 @@ has the following [=struct/items=]:
  The <dfn id="rbs-controller-byob-request" attribute
  for="ReadableByteStreamController">byobRequest</dfn> getter steps are:
 
- 1. If [=this=].[=ReadableByteStreamController/[[byobRequest]]=] is null and [=this=].\[[pendingPullIntos]] is not [=list/is
+ 1. If [=this=].[=ReadableByteStreamController/[[byobRequest]]=] is null and [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is
     empty|empty=],
-  1. Let |firstDescriptor| be [=this=].\[[pendingPullIntos]][0].
+  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |firstDescriptor|'s [=pull-into
      descriptor/buffer=], |firstDescriptor|'s [=pull-into descriptor/byte offset=] +
      |firstDescriptor|'s [=pull-into descriptor/bytes filled=], |firstDescriptor|'s [=pull-into
@@ -1772,8 +1772,8 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  id="rbs-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
- 1. If [=this=].\[[pendingPullIntos]] is not [=list/is empty|empty=],
-  1. Let |firstDescriptor| be [=this=].\[[pendingPullIntos]][0].
+ 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
+  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. Set |firstDescriptor|'s [=pull-into descriptor/bytes filled=] to 0.
  1. Perform ! [$ResetQueue$]([=this=]).
  1. Let |result| be the result of performing [=this=].[=ReadableByteStreamController/[[cancelAlgorithm]]=], passing in |reason|.
@@ -1811,7 +1811,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
      length=] |autoAllocateChunkSize|, [=pull-into descriptor/bytes filled=] 0, [=pull-into
      descriptor/element size=] 1, [=pull-into descriptor/view constructor=] {{%Uint8Array%}}, and
      [=pull-into descriptor/reader type=] "`default`".
-  1. [=list/Append=] |pullIntoDescriptor| to [=this=].\[[pendingPullIntos]].
+  1. [=list/Append=] |pullIntoDescriptor| to [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=].
  1. Perform ! [$ReadableStreamAddReadRequest$](|stream|, |readRequest|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$]([=this=]).
 </div>
@@ -2783,7 +2783,7 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
- 1. Set |controller|.\[[pendingPullIntos]] to a new empty [=list=].
+ 1. Set |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] to a new empty [=list=].
 </div>
 
 <div algorithm>
@@ -2796,8 +2796,8 @@ The following abstract operations support the implementation of the
  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] to true.
   1. Return.
- 1. If |controller|.\[[pendingPullIntos]] is not empty,
-  1. Let |firstPendingPullInto| be |controller|.\[[pendingPullIntos]][0].
+ 1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty,
+  1. Let |firstPendingPullInto| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If |firstPendingPullInto|'s [=pull-into descriptor/bytes filled=] > 0,
    1. Let |e| be a new {{TypeError}} exception.
    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
@@ -2899,8 +2899,8 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-fill-head-pull-into-descriptor">ReadableByteStreamControllerFillHeadPullIntoDescriptor(|controller|,
  |size|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
- 1. Assert: either |controller|.\[[pendingPullIntos]] [=list/is empty=], or
-    |controller|.\[[pendingPullIntos]][0] is |pullIntoDescriptor|.
+ 1. Assert: either |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] [=list/is empty=], or
+    |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0] is |pullIntoDescriptor|.
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to [=pull-into
     descriptor/bytes filled=] + |size|.
@@ -2996,9 +2996,9 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is false.
- 1. [=While=] |controller|.\[[pendingPullIntos]] is not [=list/is empty|empty=],
+ 1. [=While=] |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, return.
-  1. Let |pullIntoDescriptor| be |controller|.\[[pendingPullIntos]][0].
+  1. Let |pullIntoDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
      |pullIntoDescriptor|) is true,
    1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
@@ -3027,8 +3027,8 @@ The following abstract operations support the implementation of the
     length=] |byteLength|, [=pull-into descriptor/bytes filled=] 0, [=pull-into descriptor/element
     size=] |elementSize|, [=pull-into descriptor/view constructor=] |ctor|, and [=pull-into
     descriptor/reader type=] "`byob`".
- 1. If |controller|.\[[pendingPullIntos]] is not empty,
-  1. [=list/Append=] |pullIntoDescriptor| to |controller|.\[[pendingPullIntos]].
+ 1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty,
+  1. [=list/Append=] |pullIntoDescriptor| to |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
   1. Perform ! [$ReadableStreamAddReadIntoRequest$](|stream|, |readIntoRequest|).
   1. Return.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`",
@@ -3049,7 +3049,7 @@ The following abstract operations support the implementation of the
    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
    1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
    1. Return.
- 1. [=list/Append=] |pullIntoDescriptor| to |controller|.\[[pendingPullIntos]].
+ 1. [=list/Append=] |pullIntoDescriptor| to |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
  1. Perform ! [$ReadableStreamAddReadIntoRequest$](|stream|, |readIntoRequest|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
 </div>
@@ -3059,7 +3059,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-respond">ReadableByteStreamControllerRespond(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
- 1. Assert: |controller|.\[[pendingPullIntos]] is not empty.
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty.
  1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |bytesWritten|).
 </div>
 
@@ -3115,7 +3115,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-respond-internal">ReadableByteStreamControllerRespondInternal(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
- 1. Let |firstDescriptor| be |controller|.\[[pendingPullIntos]][0].
+ 1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. Let |state| be |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`closed`",
   1. If |bytesWritten| is not 0, throw a {{TypeError}} exception.
@@ -3133,8 +3133,8 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-respond-with-new-view">ReadableByteStreamControllerRespondWithNewView(|controller|,
  |view|)</dfn> performs the following steps:
 
- 1. Assert: |controller|.\[[pendingPullIntos]] is not [=list/is empty|empty=].
- 1. Let |firstDescriptor| be |controller|.\[[pendingPullIntos]][0].
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=].
+ 1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. If |firstDescriptor|'s [=pull-into descriptor/byte offset=] + |firstDescriptor|' [=pull-into
     descriptor/bytes filled=] is not |view|.\[[ByteOffset]], throw a {{RangeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/byte length=] is not |view|.\[[ByteLength]], throw
@@ -3148,8 +3148,8 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-shift-pending-pull-into">ReadableByteStreamControllerShiftPendingPullInto(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |descriptor| be |controller|.\[[pendingPullIntos]][0].
- 1. [=list/Remove=] |descriptor| from |controller|.\[[pendingPullIntos]].
+ 1. Let |descriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+ 1. [=list/Remove=] |descriptor| from |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. Return |descriptor|.
 </div>
@@ -3192,7 +3192,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[autoAllocateChunkSize]]=] to |autoAllocateChunkSize|.
- 1. Set |controller|.\[[pendingPullIntos]] to a new empty [=list=].
+ 1. Set |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] to a new empty [=list=].
  1. Set |stream|.[=ReadableStream/[[controller]]=] to |controller|.
  1. Let |startResult| be the result of performing |startAlgorithm|.
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.

--- a/index.bs
+++ b/index.bs
@@ -3436,7 +3436,7 @@ table:
 
 <p class="note">The \[[inFlightCloseRequest]] slot and [=WritableStream/[[closeRequest]]=] slot are mutually
 exclusive. Similarly, no element will be removed from \[[writeRequests]] while
-\[[inFlightWriteRequest]] is not undefined. Implementations can optimize storage for these slots
+[=WritableStream/[[inFlightWriteRequest]]=] is not undefined. Implementations can optimize storage for these slots
 based on these invariants.
 
 A <dfn>pending abort request</dfn> is a [=struct=] used to track a request to abort the stream
@@ -4020,7 +4020,7 @@ are even meant to be generally useful by other specifications.
 
  1. Set |stream|.\[[state]] to "`writable`".
  1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
-    |stream|.\[[inFlightWriteRequest]], |stream|.[=WritableStream/[[closeRequest]]=],
+    |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
     |stream|.\[[inFlightCloseRequest]] and |stream|.\[[pendingAbortRequest]] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
@@ -4247,9 +4247,9 @@ the {{WritableStream}}'s public API.
  id="writable-stream-finish-in-flight-write">WritableStreamFinishInFlightWrite(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[inFlightWriteRequest]] is not undefined.
- 1. [=Resolve=] |stream|.\[[inFlightWriteRequest]] with undefined.
- 1. Set |stream|.\[[inFlightWriteRequest]] to undefined.
+ 1. Assert: |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is not undefined.
+ 1. [=Resolve=] |stream|.[=WritableStream/[[inFlightWriteRequest]]=] with undefined.
+ 1. Set |stream|.[=WritableStream/[[inFlightWriteRequest]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -4257,9 +4257,9 @@ the {{WritableStream}}'s public API.
  id="writable-stream-finish-in-flight-write-with-error">WritableStreamFinishInFlightWriteWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[inFlightWriteRequest]] is not undefined.
- 1. [=Reject=] |stream|.\[[inFlightWriteRequest]] with |error|.
- 1. Set |stream|.\[[inFlightWriteRequest]] to undefined.
+ 1. Assert: |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is not undefined.
+ 1. [=Reject=] |stream|.[=WritableStream/[[inFlightWriteRequest]]=] with |error|.
+ 1. Set |stream|.[=WritableStream/[[inFlightWriteRequest]]=] to undefined.
  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
  1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |error|).
 </div>
@@ -4269,7 +4269,7 @@ the {{WritableStream}}'s public API.
  id="writable-stream-has-operation-marked-in-flight">WritableStreamHasOperationMarkedInFlight(|stream|)</dfn>
  performs the following steps:
 
- 1. If |stream|.\[[inFlightWriteRequest]] is undefined and
+ 1. If |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is undefined and
     |stream|.[=WritableStream/[[controller]]=].\[[inFlightCloseRequest]] is undefined, return false.
  1. Return true.
 </div>
@@ -4290,11 +4290,11 @@ the {{WritableStream}}'s public API.
  id="writable-stream-mark-first-write-request-in-flight">WritableStreamMarkFirstWriteRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[inFlightWriteRequest]] is undefined.
+ 1. Assert: |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is undefined.
  1. Assert: |stream|.\[[writeRequests]] is not empty.
  1. Let |writeRequest| be |stream|.\[[writeRequests]][0].
  1. [=list/Remove=] |writeRequest| from |stream|.\[[writeRequests]].
- 1. Set |stream|.\[[inFlightWriteRequest]] to |writeRequest|.
+ 1. Set |stream|.[=WritableStream/[[inFlightWriteRequest]]=] to |writeRequest|.
 </div>
 
 <div algorithm>
@@ -4537,7 +4537,7 @@ The following abstract operations support the implementation of the
 
  1. Let |stream| be |controller|.\[[stream]].
  1. If |controller|.\[[started]] is false, return.
- 1. If |stream|.\[[inFlightWriteRequest]] is not undefined, return.
+ 1. If |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is not undefined, return.
  1. Let |state| be |stream|.\[[state]].
  1. Assert: |state| is not "`closed`" or "`errored`".
  1. If |state| is "`erroring`",

--- a/index.bs
+++ b/index.bs
@@ -4021,7 +4021,7 @@ are even meant to be generally useful by other specifications.
  1. Set |stream|.\[[state]] to "`writable`".
  1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
     |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
-    |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.\[[pendingAbortRequest]] to undefined.
+    |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
  1. Set |stream|.[=WritableStream/[[backpressure]]=] to false.
 </div>
@@ -4073,15 +4073,15 @@ are even meant to be generally useful by other specifications.
 
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`closed`" or "`errored`", return [=a promise resolved with=] undefined.
- 1. If |stream|.\[[pendingAbortRequest]] is not undefined, return
-    |stream|.\[[pendingAbortRequest]]'s [=pending abort request/promise=].
+ 1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined, return
+    |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=].
  1. Assert: |state| is "`writable`" or "`erroring`".
  1. Let |wasAlreadyErroring| be false.
  1. If |state| is "`erroring`",
    1. Set |wasAlreadyErroring| to true.
    1. Set |reason| to undefined.
  1. Let |promise| be [=a new promise=].
- 1. Set |stream|.\[[pendingAbortRequest]] to a new [=pending abort request=] whose [=pending abort
+ 1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to a new [=pending abort request=] whose [=pending abort
     request/promise=] is |promise|, [=pending abort request/reason=] is |reason|, and [=pending
     abort request/was already erroring=] is |wasAlreadyErroring|.
  1. If |wasAlreadyErroring| is false, perform ! [$WritableStreamStartErroring$](|stream|, |reason|).
@@ -4185,11 +4185,11 @@ the {{WritableStream}}'s public API.
  1. [=list/For each=] |writeRequest| of |stream|.\[[writeRequests]]:
   1. [=Reject=] |writeRequest| with |storedError|.
  1. Set |stream|.\[[writeRequests]] to an empty [=list=].
- 1. If |stream|.\[[pendingAbortRequest]] is undefined,
+ 1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined,
   1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
   1. Return.
- 1. Let |abortRequest| be |stream|.\[[pendingAbortRequest]].
- 1. Set |stream|.\[[pendingAbortRequest]] to undefined.
+ 1. Let |abortRequest| be |stream|.[=WritableStream/[[pendingAbortRequest]]=].
+ 1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. If |abortRequest|'s [=pending abort request/was already erroring=] is true,
   1. [=Reject=] |abortRequest|'s [=pending abort request/promise=] with |storedError|.
   1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
@@ -4216,14 +4216,14 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
  1. If |state| is "`erroring`",
   1. Set |stream|.\[[storedError]] to undefined.
-  1. If |stream|.\[[pendingAbortRequest]] is not undefined,
-   1. [=Resolve=] |stream|.\[[pendingAbortRequest]]'s [=pending abort request/promise=] with
+  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
+   1. [=Resolve=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=] with
       undefined.
-   1. Set |stream|.\[[pendingAbortRequest]] to undefined.
+   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.\[[state]] to "`closed`".
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, [=resolve=] |writer|.\[[closedPromise]] with undefined.
- 1. Assert: |stream|.\[[pendingAbortRequest]] is undefined.
+ 1. Assert: |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined.
  1. Assert: |stream|.\[[storedError]] is undefined.
 </div>
 
@@ -4236,9 +4236,9 @@ the {{WritableStream}}'s public API.
  1. [=Reject=] |stream|.[=WritableStream/[[inFlightCloseRequest]]=] with |error|.
  1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
- 1. If |stream|.\[[pendingAbortRequest]] is not undefined,
-  1. [=Reject=] |stream|.\[[pendingAbortRequest]]'s [=pending abort request/promise=] with |error|.
-  1. Set |stream|.\[[pendingAbortRequest]] to undefined.
+ 1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
+  1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=] with |error|.
+  1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Perform ! WritableStreamDealWithRejection(|stream|, |error|).
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -4780,29 +4780,29 @@ interface TransformStream {
 Instances of {{TransformStream}} are created with the internal slots described in the following
 table:
 
-<table>
+<table dfn-for="TransformStream">
  <thead>
   <tr>
    <th>Internal Slot</th>
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
   <tr>
-   <td>\[[backpressure]]
+   <td><dfn>\[[backpressure]]</dfn>
    <td class="non-normative">Whether there was backpressure on \[[readable]] the last time it was
    observed
   <tr>
-   <td>\[[backpressureChangePromise]]
+   <td><dfn>\[[backpressureChangePromise]]</dfn>
    <td class="non-normative">A promise which is fulfilled and replaced every time the value of
    \[[backpressure]] changes
   <tr>
-   <td>\[[controller]]
+   <td><dfn>\[[controller]]</dfn>
    <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to
    control \[[readable]] and \[[writable]]
   <tr>
-   <td>\[[readable]]
+   <td><dfn>\[[readable]]</dfn>
    <td class="non-normative">The {{ReadableStream}} instance controlled by this object
   <tr>
-   <td>\[[writable]]
+   <td><dfn>\[[writable]]</dfn>
    <td class="non-normative">The {{WritableStream}} instance controlled by this object
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -3833,7 +3833,7 @@ following table:
 
  1. Let |stream| be [=this=].\[[stream]].
  1. If |stream| is undefined, return.
- 1. Assert: |stream|.\[[writer]] is not undefined.
+ 1. Assert: |stream|.[=WritableStream/[[writer]]=] is not undefined.
  1. Perform ! [$WritableStreamDefaultWriterRelease$]([=this=]).
 </div>
 
@@ -4019,7 +4019,7 @@ are even meant to be generally useful by other specifications.
  steps:
 
  1. Set |stream|.[=WritableStream/[[state]]=] to "`writable`".
- 1. Set |stream|.[=WritableStream/[[storedError]]=], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
+ 1. Set |stream|.[=WritableStream/[[storedError]]=], |stream|.[=WritableStream/[[writer]]=], |stream|.[=WritableStream/[[controller]]=],
     |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
     |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
@@ -4032,7 +4032,7 @@ are even meant to be generally useful by other specifications.
  other specifications that wish to query whether or not a writable stream is [=locked to a writer=].
  It performs the following steps:
 
- 1. If |stream|.\[[writer]] is undefined, return false.
+ 1. If |stream|.[=WritableStream/[[writer]]=] is undefined, return false.
  1. Return true.
 </div>
 
@@ -4043,7 +4043,7 @@ are even meant to be generally useful by other specifications.
 
  1. If ! [$IsWritableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
  1. Set |writer|.\[[stream]] to |stream|.
- 1. Set |stream|.\[[writer]] to |writer|.
+ 1. Set |stream|.[=WritableStream/[[writer]]=] to |writer|.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
   1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[backpressure]]=]
@@ -4099,7 +4099,7 @@ are even meant to be generally useful by other specifications.
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
  1. Let |promise| be [=a new promise=].
  1. Set |stream|.[=WritableStream/[[closeRequest]]=] to |promise|.
- 1. Let |writer| be |stream|.\[[writer]].
+ 1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and |state| is
     "`writable`", [=resolve=] |writer|.\[[readyPromise]] with undefined.
  1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.[=WritableStream/[[controller]]=]).
@@ -4221,7 +4221,7 @@ the {{WritableStream}}'s public API.
       undefined.
    1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`closed`".
- 1. Let |writer| be |stream|.\[[writer]].
+ 1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined, [=resolve=] |writer|.\[[closedPromise]] with undefined.
  1. Assert: |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined.
  1. Assert: |stream|.[=WritableStream/[[storedError]]=] is undefined.
@@ -4307,7 +4307,7 @@ the {{WritableStream}}'s public API.
   1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined.
   1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with |stream|.[=WritableStream/[[storedError]]=].
   1. Set |stream|.[=WritableStream/[[closeRequest]]=] to undefined.
- 1. Let |writer| be |stream|.\[[writer]].
+ 1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined,
   1. [=Reject=] |writer|.\[[closedPromise]] with |stream|.[=WritableStream/[[storedError]]=].
   1. Set |writer|.\[[closedPromise]].\[[PromiseIsHandled]] to true.
@@ -4324,7 +4324,7 @@ the {{WritableStream}}'s public API.
  1. Assert: |controller| is not undefined.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`erroring`".
  1. Set |stream|.[=WritableStream/[[storedError]]=] to |reason|.
- 1. Let |writer| be |stream|.\[[writer]].
+ 1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined, perform !
     [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |reason|).
  1. If ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false and
@@ -4338,7 +4338,7 @@ the {{WritableStream}}'s public API.
 
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
- 1. Let |writer| be |stream|.\[[writer]].
+ 1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined and |backpressure| is not |stream|.[=WritableStream/[[backpressure]]=],
   1. If |backpressure| is true, set |writer|.\[[readyPromise]] to [=a new promise=].
   1. Otherwise,
@@ -4431,11 +4431,11 @@ The following abstract operations support the implementation and manipulation of
 
  1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
- 1. Assert: |stream|.\[[writer]] is |writer|.
+ 1. Assert: |stream|.[=WritableStream/[[writer]]=] is |writer|.
  1. Let |releasedError| be a new {{TypeError}}.
  1. Perform ! [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |releasedError|).
  1. Perform ! [$WritableStreamDefaultWriterEnsureClosedPromiseRejected$](|writer|, |releasedError|).
- 1. Set |stream|.\[[writer]] to undefined.
+ 1. Set |stream|.[=WritableStream/[[writer]]=] to undefined.
  1. Set |writer|.\[[stream]] to undefined.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -4481,7 +4481,7 @@ The following abstract operations support the implementation of the
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm|.
- 1. Set |controller|.\[[strategyHWM]] to |highWaterMark|.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[strategyHWM]]=] to |highWaterMark|.
  1. Set |controller|.\[[writeAlgorithm]] to |writeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to |closeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to |abortAlgorithm|.
@@ -4631,7 +4631,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-get-desired-size">WritableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
- 1. Return |controller|.\[[strategyHWM]] − |controller|.[=WritableStreamDefaultController/[[queueTotalSize]]=].
+ 1. Return |controller|.[=WritableStreamDefaultController/[[strategyHWM]]=] − |controller|.[=WritableStreamDefaultController/[[queueTotalSize]]=].
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -5534,14 +5534,14 @@ value given in the constructor.
  lt="ByteLengthQueuingStrategy(init)">new ByteLengthQueuingStrategy(|init|)</dfn> constructor steps
  are:
 
- 1. Set [=this=].\[[highWaterMark]] to |init|["{{QueuingStrategyInit/highWaterMark}}"].
+ 1. Set [=this=].[=ByteLengthQueuingStrategy/[[highWaterMark]]=] to |init|["{{QueuingStrategyInit/highWaterMark}}"].
 </div>
 
 <div algorithm>
  The <dfn id="blqs-high-water-mark" attribute for="ByteLengthQueuingStrategy">highWaterMark</dfn>
  getter steps are:
 
- 1. Return [=this=].\[[highWaterMark]].
+ 1. Return [=this=].[=ByteLengthQueuingStrategy/[[highWaterMark]]=].
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -2047,7 +2047,7 @@ are even meant to be generally useful by other specifications.
    1. Let |error| be a new "{{AbortError}}" {{DOMException}}.
    1. Let |actions| be an empty [=ordered set=].
    1. If |preventAbort| is false, [=set/append=] the following action to |actions|:
-     1. If |dest|.\[[state]] is "`writable`", return ! [$WritableStreamAbort$](|dest|, |error|).
+     1. If |dest|.[=WritableStream/[[state]]=] is "`writable`", return ! [$WritableStreamAbort$](|dest|, |error|).
      1. Otherwise, return [=a promise resolved with=] undefined.
    1. If |preventCancel| is false, [=set/append=] the following action action to |actions|:
      1. If |source|.[=ReadableStream/[[state]]=] is "`readable`", return ! [$ReadableStreamCancel$](|source|, |error|).
@@ -2090,7 +2090,7 @@ are even meant to be generally useful by other specifications.
     1. If |preventAbort| is false, [=shutdown with an action=] of ! [$WritableStreamAbort$](|dest|,
        |source|.[=ReadableStream/[[storedError]]=]) and with |source|.[=ReadableStream/[[storedError]]=].
     1. Otherwise, [=shutdown=] with |source|.[=ReadableStream/[[storedError]]=].
-   1. <strong>Errors must be propagated backward:</strong> if |dest|.\[[state]] is or becomes
+   1. <strong>Errors must be propagated backward:</strong> if |dest|.[=WritableStream/[[state]]=] is or becomes
       "`errored`", then
     1. If |preventCancel| is false, [=shutdown with an action=] of !
        [$ReadableStreamCancel$](|source|, |dest|.\[[storedError]]) and with |dest|.\[[storedError]].
@@ -2101,7 +2101,7 @@ are even meant to be generally useful by other specifications.
        [$WritableStreamDefaultWriterCloseWithErrorPropagation$](|writer|).
     1. Otherwise, [=shutdown=].
    1. <strong>Closing must be propagated backward:</strong> if !
-      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is true or |dest|.\[[state]] is "`closed`",
+      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is true or |dest|.[=WritableStream/[[state]]=] is "`closed`",
       then
     1. Assert: no [=chunks=] have been read or written.
     1. Let |destClosed| be a new {{TypeError}}.
@@ -2113,7 +2113,7 @@ are even meant to be generally useful by other specifications.
     |originalError|, then:
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
-   1. If |dest|.\[[state]] is "`writable`" and ! [$WritableStreamCloseQueuedOrInFlight$](|dest|) is
+   1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and ! [$WritableStreamCloseQueuedOrInFlight$](|dest|) is
       false,
      1. If any [=chunks=] have been read but not yet written, write them to |dest|.
      1. Wait until every [=chunk=] that has been read has been written (i.e. the corresponding
@@ -2125,7 +2125,7 @@ are even meant to be generally useful by other specifications.
     ask to shutdown, optionally with an error |error|, then:
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
-   1. If |dest|.\[[state]] is "`writable`" and ! [$WritableStreamCloseQueuedOrInFlight$](|dest|) is
+   1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and ! [$WritableStreamCloseQueuedOrInFlight$](|dest|) is
       false,
     1. If any [=chunks=] have been read but not yet written, write them to |dest|.
     1. Wait until every [=chunk=] that has been read has been written (i.e. the corresponding
@@ -3933,7 +3933,7 @@ developers.
  The <dfn id="ws-default-controller-error" method
  for="WritableStreamDefaultController">error(|e|)</dfn> method steps are:
 
- 1. Let |state| be [=this=].\[[stream]].\[[state]].
+ 1. Let |state| be [=this=].\[[stream]].[=WritableStream/[[state]]=].
  1. If |state| is not "`writable`", return.
  1. Perform ! [$WritableStreamDefaultControllerError$]([=this=], |e|).
 </div>
@@ -4018,7 +4018,7 @@ are even meant to be generally useful by other specifications.
  id="initialize-writable-stream">InitializeWritableStream(|stream|)</dfn> performs the following
  steps:
 
- 1. Set |stream|.\[[state]] to "`writable`".
+ 1. Set |stream|.[=WritableStream/[[state]]=] to "`writable`".
  1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.[=WritableStream/[[controller]]=],
     |stream|.[=WritableStream/[[inFlightWriteRequest]]=], |stream|.[=WritableStream/[[closeRequest]]=],
     |stream|.[=WritableStream/[[inFlightCloseRequest]]=] and |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
@@ -4044,7 +4044,7 @@ are even meant to be generally useful by other specifications.
  1. If ! [$IsWritableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
  1. Set |writer|.\[[stream]] to |stream|.
  1. Set |stream|.\[[writer]] to |writer|.
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
   1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[backpressure]]=]
      is true, set |writer|.\[[readyPromise]] to [=a new promise=].
@@ -4071,7 +4071,7 @@ are even meant to be generally useful by other specifications.
  id="writable-stream-abort">WritableStreamAbort(|stream|, |reason|)</dfn> performs the following
  steps:
 
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`closed`" or "`errored`", return [=a promise resolved with=] undefined.
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined, return
     |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=].
@@ -4092,7 +4092,7 @@ are even meant to be generally useful by other specifications.
  <dfn abstract-op lt="WritableStreamClose"
  id="writable-stream-close">WritableStreamClose(|stream|)</dfn> performs the following steps:
 
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`closed`" or "`errored`", return [=a promise rejected with=] a {{TypeError}}
     exception.
  1. Assert: |state| is "`writable`" or "`erroring`".
@@ -4143,7 +4143,7 @@ the {{WritableStream}}'s public API.
  following steps:
 
  1. Assert: ! [$IsWritableStreamLocked$](|stream|) is true.
- 1. Assert: |stream|.\[[state]] is "`writable`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Let |promise| be [=a new promise=].
  1. [=list/Append=] |promise| to |stream|.\[[writeRequests]].
  1. Return |promise|.
@@ -4164,7 +4164,7 @@ the {{WritableStream}}'s public API.
  id="writable-stream-deal-with-rejection">WritableStreamDealWithRejection(|stream|, |error|)</dfn>
  performs the following steps:
 
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
   1. Perform ! [$WritableStreamStartErroring$](|stream|, |error|).
   1. Return.
@@ -4177,9 +4177,9 @@ the {{WritableStream}}'s public API.
  id="writable-stream-finish-erroring">WritableStreamFinishErroring(|stream|, |reason|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[state]] is "`erroring`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`erroring`".
  1. Assert: ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false.
- 1. Set |stream|.\[[state]] to "`errored`".
+ 1. Set |stream|.[=WritableStream/[[state]]=] to "`errored`".
  1. Perform ! |stream|.[=WritableStream/[[controller]]=].\[[ErrorSteps]]().
  1. Let |storedError| be |stream|.\[[storedError]].
  1. [=list/For each=] |writeRequest| of |stream|.\[[writeRequests]]:
@@ -4212,15 +4212,15 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is not undefined.
  1. [=Resolve=] |stream|.[=WritableStream/[[inFlightCloseRequest]]=] with undefined.
  1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
- 1. Let |state| be |stream|.\[[state]].
- 1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
  1. If |state| is "`erroring`",
   1. Set |stream|.\[[storedError]] to undefined.
   1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
    1. [=Resolve=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=] with
       undefined.
    1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
- 1. Set |stream|.\[[state]] to "`closed`".
+ 1. Set |stream|.[=WritableStream/[[state]]=] to "`closed`".
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, [=resolve=] |writer|.\[[closedPromise]] with undefined.
  1. Assert: |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined.
@@ -4235,7 +4235,7 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is not undefined.
  1. [=Reject=] |stream|.[=WritableStream/[[inFlightCloseRequest]]=] with |error|.
  1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
- 1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
   1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=] with |error|.
   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
@@ -4260,7 +4260,7 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is not undefined.
  1. [=Reject=] |stream|.[=WritableStream/[[inFlightWriteRequest]]=] with |error|.
  1. Set |stream|.[=WritableStream/[[inFlightWriteRequest]]=] to undefined.
- 1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
  1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |error|).
 </div>
 
@@ -4302,7 +4302,7 @@ the {{WritableStream}}'s public API.
  id="writable-stream-reject-close-and-closed-promise-if-needed">WritableStreamRejectCloseAndClosedPromiseIfNeeded(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.\[[state]] is "`errored`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`errored`".
  1. If |stream|.[=WritableStream/[[closeRequest]]=] is not undefined,
   1. Assert: |stream|.[=WritableStream/[[inFlightCloseRequest]]=] is undefined.
   1. [=Reject=] |stream|.[=WritableStream/[[closeRequest]]=] with |stream|.\[[storedError]].
@@ -4319,10 +4319,10 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. Assert: |stream|.\[[storedError]] is undefined.
- 1. Assert: |stream|.\[[state]] is "`writable`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Let |controller| be |stream|.[=WritableStream/[[controller]]=].
  1. Assert: |controller| is not undefined.
- 1. Set |stream|.\[[state]] to "`erroring`".
+ 1. Set |stream|.[=WritableStream/[[state]]=] to "`erroring`".
  1. Set |stream|.\[[storedError]] to |reason|.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, perform !
@@ -4336,7 +4336,7 @@ the {{WritableStream}}'s public API.
  id="writable-stream-update-backpressure">WritableStreamUpdateBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[state]] is "`writable`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined and |backpressure| is not |stream|.[=WritableStream/[[backpressure]]=],
@@ -4379,7 +4379,7 @@ The following abstract operations support the implementation and manipulation of
 
  1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
     [=a promise resolved with=] undefined.
  1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.\[[storedError]].
@@ -4418,7 +4418,7 @@ The following abstract operations support the implementation and manipulation of
  performs the following steps:
 
  1. Let |stream| be |writer|.\[[stream]].
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`errored`" or "`erroring`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return ! [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.[=WritableStream/[[controller]]=]).
@@ -4450,7 +4450,7 @@ The following abstract operations support the implementation and manipulation of
  1. Let |chunkSize| be ! [$WritableStreamDefaultControllerGetChunkSize$](|controller|, |chunk|).
  1. If |stream| is not equal to |writer|.\[[stream]], return [=a promise rejected with=] a
     {{TypeError}} exception.
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.\[[storedError]].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
     [=a promise rejected with=] a {{TypeError}} exception indicating that the stream is closing or
@@ -4490,11 +4490,11 @@ The following abstract operations support the implementation of the
  1. Let |startResult| be the result of performing |startAlgorithm|. (This may throw an exception.)
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=] of |startPromise|,
-  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
+  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
   1. Set |controller|.\[[started]] to true.
   1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
-  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
+  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
   1. Set |controller|.\[[started]] to true.
   1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |r|).
 </div>
@@ -4538,7 +4538,7 @@ The following abstract operations support the implementation of the
  1. Let |stream| be |controller|.\[[stream]].
  1. If |controller|.\[[started]] is false, return.
  1. If |stream|.[=WritableStream/[[inFlightWriteRequest]]=] is not undefined, return.
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. Assert: |state| is not "`closed`" or "`errored`".
  1. If |state| is "`erroring`",
   1. Perform ! [$WritableStreamFinishErroring$](|stream|).
@@ -4589,7 +4589,7 @@ The following abstract operations support the implementation of the
  |error|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.\[[stream]].
- 1. Assert: |stream|.\[[state]] is "`writable`".
+ 1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Perform ! [$WritableStreamStartErroring$](|stream|, |error|).
 </div>
@@ -4599,7 +4599,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-error-if-needed">WritableStreamDefaultControllerErrorIfNeeded(|controller|,
  |error|)</dfn> performs the following steps:
 
- 1. If |controller|.\[[stream]].\[[state]] is "`writable`", perform !
+ 1. If |controller|.\[[stream]].[=WritableStream/[[state]]=] is "`writable`", perform !
     [$WritableStreamDefaultControllerError$](|controller|, |error|).
 </div>
 
@@ -4662,7 +4662,7 @@ The following abstract operations support the implementation of the
     |chunk|.
  1. [=Upon fulfillment=] of |sinkWritePromise|,
   1. Perform ! [$WritableStreamFinishInFlightWrite$](|stream|).
-  1. Let |state| be |stream|.\[[state]].
+  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
   1. Assert: |state| is "`writable`" or "`erroring`".
   1. Perform ! [$DequeueValue$](|controller|).
   1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |state| is "`writable`",
@@ -4670,7 +4670,7 @@ The following abstract operations support the implementation of the
    1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
   1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
  1. [=Upon rejection=] of |sinkWritePromise| with |reason|,
-  1. If |stream|.\[[state]] is "`writable`", perform !
+  1. If |stream|.[=WritableStream/[[state]]=] is "`writable`", perform !
      [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
   1. Perform ! [$WritableStreamFinishInFlightWriteWithError$](|stream|, |reason|).
 </div>
@@ -4686,7 +4686,7 @@ The following abstract operations support the implementation of the
      |enqueueResult|.\[[Value]]).
   1. Return.
  1. Let |stream| be |controller|.\[[stream]].
- 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.\[[state]] is
+ 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.[=WritableStream/[[state]]=] is
     "`writable`",
   1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
   1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
@@ -5319,7 +5319,7 @@ side=] of [=transform streams=].
  id="transform-stream-default-sink-write-algorithm">TransformStreamDefaultSinkWriteAlgorithm(|stream|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[writable]].\[[state]] is "`writable`".
+ 1. Assert: |stream|.\[[writable]].[=WritableStream/[[state]]=] is "`writable`".
  1. Let |controller| be |stream|.\[[controller]].
  1. If |stream|.\[[backpressure]] is true,
   1. Let |backpressureChangePromise| be |stream|.\[[backpressureChangePromise]].
@@ -5327,7 +5327,7 @@ side=] of [=transform streams=].
   1. Return the result of [=reacting=] to |backpressureChangePromise| with the following fulfillment
      steps:
    1. Let |writable| be |stream|.\[[writable]].
-   1. Let |state| be |writable|.\[[state]].
+   1. Let |state| be |writable|.[=WritableStream/[[state]]=].
    1. If |state| is "`erroring`", throw |writable|.\[[storedError]].
    1. Assert: |state| is "`writable`".
    1. Return ! [$TransformStreamDefaultControllerPerformTransform$](|controller|, |chunk|).

--- a/index.bs
+++ b/index.bs
@@ -1425,7 +1425,7 @@ the following table:
    <td class="non-normative">A [=list=] representing the stream's internal queue of [=chunks=]
   <tr>
    <td><dfn>\[[queueTotalSize]]</dfn>
-   <td class="non-normative">The total size of all the chunks stored in \[[queue]] (see
+   <td class="non-normative">The total size of all the chunks stored in [=ReadableStreamDefaultController/[[queue]]=] (see
    [[#queue-with-sizes]])
   <tr>
    <td><dfn>\[[started]]</dfn>
@@ -1613,7 +1613,7 @@ following table:
    queue entries=] representing the stream's internal queue of [=chunks=]
   <tr>
    <td><dfn>\[[queueTotalSize]]</dfn>
-   <td class="non-normative">The total size, in bytes, of all the chunks stored in \[[queue]] (see
+   <td class="non-normative">The total size, in bytes, of all the chunks stored in [=ReadableByteStreamController/[[queue]]=] (see
    [[#queue-with-sizes]])
   <tr>
    <td><dfn>\[[started]]</dfn>
@@ -1630,7 +1630,7 @@ following table:
 </table>
 
 <div class="note">
- <p>Although {{ReadableByteStreamController}} instances have \[[queue]] and \[[queueTotalSize]]
+ <p>Although {{ReadableByteStreamController}} instances have [=ReadableByteStreamController/[[queue]]=] and [=ReadableByteStreamController/[[queueTotalSize]]=]
  slots, we do not use most of the abstract operations in [[#queue-with-sizes]] on them, as the way
  in which we manipulate this queue is rather different than the others in the spec. Instead, we
  update the two slots together manually.

--- a/index.bs
+++ b/index.bs
@@ -1526,9 +1526,9 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
  1. Let |stream| be [=this=].[=ReadableStreamGenericReader/[[stream]]=].
- 1. If [=this=].\[[queue]] is not [=list/is empty|empty=],
+ 1. If [=this=].[=ReadableStreamDefaultController/[[queue]]=] is not [=list/is empty|empty=],
   1. Let |chunk| be ! [$DequeueValue$]([=this=]).
-  1. If [=this=].[=ReadableStreamDefaultController/[[closeRequested]]=] is true and [=this=].\[[queue]] [=list/is empty=],
+  1. If [=this=].[=ReadableStreamDefaultController/[[closeRequested]]=] is true and [=this=].[=ReadableStreamDefaultController/[[queue]]=] [=list/is empty=],
    1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$]([=this=]).
    1. Perform ! [$ReadableStreamClose$](|stream|).
   1. Otherwise, perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$]([=this=]).
@@ -1790,8 +1790,8 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
  1. If [=this=].\[[queueTotalSize]] > 0,
   1. Assert: ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0.
-  1. Let |entry| be [=this=].\[[queue]][0].
-  1. [=list/Remove=] |entry| from [=this=].\[[queue]].
+  1. Let |entry| be [=this=].[=ReadableByteStreamController/[[queue]]=][0].
+  1. [=list/Remove=] |entry| from [=this=].[=ReadableByteStreamController/[[queue]]=].
   1. Set [=this=].\[[queueTotalSize]] to [=this=].\[[queueTotalSize]] − |entry|'s [=readable byte
      stream queue entry/byte length=].
   1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$]([=this=]).
@@ -2588,7 +2588,7 @@ The following abstract operations support the implementation of the
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
  1. Let |stream| be |controller|.\[[stream]].
  1. Set |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] to true.
- 1. If |controller|.\[[queue]] [=list/is empty=],
+ 1. If |controller|.[=ReadableStreamDefaultController/[[queue]]=] [=list/is empty=],
   1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
   1. Perform ! [$ReadableStreamClose$](|stream|).
 </div>
@@ -2855,7 +2855,7 @@ The following abstract operations support the implementation of the
    1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
       |transferredBuffer|, |byteOffset|, |byteLength|).
   1. Otherwise,
-   1. Assert: |controller|.\[[queue]] [=list/is empty=].
+   1. Assert: |controller|.[=ReadableByteStreamController/[[queue]]=] [=list/is empty=].
    1. Let |transferredView| be ! [$Construct$]({{%Uint8Array%}}, « |transferredBuffer|,
       |byteOffset|, |byteLength| »).
    1. Perform ! [$ReadableStreamFulfillReadRequest$](|stream|, |transferredView|, false).
@@ -2877,7 +2877,7 @@ The following abstract operations support the implementation of the
 
  1. [=list/Append=] a new [=readable byte stream queue entry=] with [=readable byte stream queue
     entry/buffer=] |buffer|, [=readable byte stream queue entry/byte offset=] |byteOffset|, and
-    [=readable byte stream queue entry/byte length=] |byteLength| to |controller|.\[[queue]].
+    [=readable byte stream queue entry/byte length=] |byteLength| to |controller|.[=ReadableByteStreamController/[[queue]]=].
  1. Set |controller|.\[[queueTotalSize]] to |controller|.\[[queueTotalSize]] + |byteLength|.
 </div>
 
@@ -2925,7 +2925,7 @@ The following abstract operations support the implementation of the
   1. Set |totalBytesToCopyRemaining| to |maxAlignedBytes| − |pullIntoDescriptor|'s [=pull-into
      descriptor/bytes filled=].
   1. Set |ready| to true.
- 1. Let |queue| be |controller|.\[[queue]].
+ 1. Let |queue| be |controller|.[=ReadableByteStreamController/[[queue]]=].
  1. [=While=] |totalBytesToCopyRemaining| > 0,
   1. Let |headOfQueue| be |queue|[0].
   1. Let |bytesToCopy| be min(|totalBytesToCopyRemaining|, |headOfQueue|'s [=readable byte stream

--- a/index.bs
+++ b/index.bs
@@ -1800,7 +1800,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
      [=readable byte stream queue entry/byte length=] »).
   1. Perform |readRequest|'s [=read request/chunk steps=], given |view|.
   1. Return.
- 1. Let |autoAllocateChunkSize| be [=this=].\[[autoAllocateChunkSize]].
+ 1. Let |autoAllocateChunkSize| be [=this=].[=ReadableByteStreamController/[[autoAllocateChunkSize]]=].
  1. If |autoAllocateChunkSize| is not undefined,
   1. Let |buffer| be [$Construct$]({{%ArrayBuffer%}}, « |autoAllocateChunkSize| »).
   1. If |buffer| is an abrupt completion,
@@ -3191,7 +3191,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] to |highWaterMark|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAlgorithm]]=] to |pullAlgorithm|.
  1. Set |controller|.[=ReadableByteStreamController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
- 1. Set |controller|.\[[autoAllocateChunkSize]] to |autoAllocateChunkSize|.
+ 1. Set |controller|.[=ReadableByteStreamController/[[autoAllocateChunkSize]]=] to |autoAllocateChunkSize|.
  1. Set |controller|.\[[pendingPullIntos]] to a new empty [=list=].
  1. Set |stream|.[=ReadableStream/[[controller]]=] to |controller|.
  1. Let |startResult| be the result of performing |startAlgorithm|.

--- a/index.bs
+++ b/index.bs
@@ -4788,7 +4788,7 @@ table:
  <tbody>
   <tr>
    <td><dfn>\[[backpressure]]</dfn>
-   <td class="non-normative">Whether there was backpressure on \[[readable]] the last time it was
+   <td class="non-normative">Whether there was backpressure on [=TransformStream/[[readable]]=] the last time it was
    observed
   <tr>
    <td><dfn>\[[backpressureChangePromise]]</dfn>
@@ -4797,7 +4797,7 @@ table:
   <tr>
    <td><dfn>\[[controller]]</dfn>
    <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to
-   control \[[readable]] and \[[writable]]
+   control [=TransformStream/[[readable]]=] and \[[writable]]
   <tr>
    <td><dfn>\[[readable]]</dfn>
    <td class="non-normative">The {{ReadableStream}} instance controlled by this object
@@ -4959,7 +4959,7 @@ side=], or to terminate or error the stream.
  The <dfn id="ts-readable" attribute for="TransformStream">readable</dfn> getter steps
  are:
 
- 1. Return [=this=].\[[readable]].
+ 1. Return [=this=].[=TransformStream/[[readable]]=].
 </div>
 
 <div algorithm>
@@ -5045,7 +5045,7 @@ the following table:
  The <dfn id="ts-default-controller-desired-size" attribute
  for="TransformStreamDefaultController">desiredSize</dfn> getter steps are:
 
- 1. Let |readableController| be [=this=].\[[stream]].\[[readable]].[=ReadableStream/[[controller]]=].
+ 1. Let |readableController| be [=this=].\[[stream]].[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. Return ! [$ReadableStreamDefaultControllerGetDesiredSize$](|readableController|).
 </div>
 
@@ -5130,7 +5130,7 @@ are even meant to be generally useful by other specifications.
  1. Let |cancelAlgorithm| be the following steps, taking a |reason| argument:
   1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |reason|).
   1. Return [=a promise resolved with=] undefined.
- 1. Set |stream|.\[[readable]] to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
+ 1. Set |stream|.[=TransformStream/[[readable]]=] to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancelAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
  1. Set |stream|.[=TransformStream/[[backpressure]]=] and |stream|.[=TransformStream/[[backpressureChangePromise]]=] to undefined.
     <p class="note">The [=TransformStream/[[backpressure]]=] slot is set to undefined so that it can be initialized by
@@ -5146,7 +5146,7 @@ are even meant to be generally useful by other specifications.
  <dfn abstract-op lt="TransformStreamError"
  id="transform-stream-error">TransformStreamError(|stream|, |e|)</dfn> performs the following steps:
 
- 1. Perform ! [$ReadableStreamDefaultControllerError$](|stream|.\[[readable]].[=ReadableStream/[[controller]]=], |e|).
+ 1. Perform ! [$ReadableStreamDefaultControllerError$](|stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=], |e|).
  1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |e|).
 
  <p class="note">This operation works correctly when one or both sides are already errored. As a
@@ -5251,7 +5251,7 @@ The following abstract operations support the implementaiton of the
  It performs the following steps:
 
  1. Let |stream| be |controller|.\[[stream]].
- 1. Let |readableController| be |stream|.\[[readable]].[=ReadableStream/[[controller]]=].
+ 1. Let |readableController| be |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|readableController|) is false, throw
     a {{TypeError}} exception.
  1. Let |enqueueResult| be [$ReadableStreamDefaultControllerEnqueue$](|readableController|,
@@ -5259,7 +5259,7 @@ The following abstract operations support the implementaiton of the
  1. If |enqueueResult| is an abrupt completion,
    1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|,
       |enqueueResult|.\[[Value]]).
-   1. Throw |stream|.\[[readable]].[=ReadableStream/[[storedError]]=].
+   1. Throw |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[storedError]]=].
  1. Let |backpressure| be !
     [$ReadableStreamDefaultControllerHasBackpressure$](|readableController|).
  1. If |backpressure| is not |stream|.[=TransformStream/[[backpressure]]=],
@@ -5303,7 +5303,7 @@ The following abstract operations support the implementaiton of the
  It performs the following steps:
 
  1. Let |stream| be |controller|.\[[stream]].
- 1. Let |readableController| be |stream|.\[[readable]].[=ReadableStream/[[controller]]=].
+ 1. Let |readableController| be |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
  1. Perform ! [$ReadableStreamDefaultControllerClose$](|readableController|).
  1. Let |error| be a {{TypeError}} exception indicating that the stream has been terminated.
  1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |error|).
@@ -5348,7 +5348,7 @@ side=] of [=transform streams=].
  id="transform-stream-default-sink-close-algorithm">TransformStreamDefaultSinkCloseAlgorithm(|stream|)</dfn>
  performs the following steps:
 
- 1. Let |readable| be |stream|.\[[readable]].
+ 1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
  1. Let |flushPromise| be the result of performing |controller|.\[[flushAlgorithm]].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -1840,17 +1840,17 @@ interface ReadableStreamBYOBRequest {
 Instances of {{ReadableStreamBYOBRequest}} are created with the internal slots described in the
 following table:
 
-<table>
+<table dfn-for="ReadableStreamBYOBRequest">
  <thead>
   <tr>
    <th>Internal Slot</th>
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
  <tr>
-  <td>\[[controller]]
+  <td><dfn>\[[controller]]</dfn>
   <td class="non-normative">The parent {{ReadableByteStreamController}} instance
  <tr>
-  <td>\[[view]]
+  <td><dfn>\[[view]]</dfn>
   <td class="non-normative">A [=typed array=] representing the destination region to which the
   controller can write generated data, or null after the BYOB request has been invalidated.
 </table>

--- a/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
@@ -2,22 +2,12 @@
 
 const { newPromise, resolvePromise, rejectPromise, promiseRejectedWith } = require('./helpers/webidl.js');
 const aos = require('./abstract-ops/readable-streams.js');
+const { mixin } = require('./helpers/miscellaneous.js');
+const ReadableStreamGenericReaderImpl = require('./ReadableStreamGenericReader-impl.js').implementation;
 
-exports.implementation = class ReadableStreamBYOBReaderImpl {
+class ReadableStreamBYOBReaderImpl {
   constructor(globalObject, [stream]) {
     aos.SetUpReadableStreamBYOBReader(this, stream);
-  }
-
-  get closed() {
-    return this._closedPromise;
-  }
-
-  cancel(reason) {
-    if (this._stream === undefined) {
-      return promiseRejectedWith(readerLockException('cancel'));
-    }
-
-    return aos.ReadableStreamReaderGenericCancel(this, reason);
   }
 
   read(view) {
@@ -53,7 +43,11 @@ exports.implementation = class ReadableStreamBYOBReaderImpl {
 
     aos.ReadableStreamReaderGenericRelease(this);
   }
-};
+}
+
+mixin(ReadableStreamBYOBReaderImpl.prototype, ReadableStreamGenericReaderImpl.prototype);
+
+exports.implementation = ReadableStreamBYOBReaderImpl;
 
 function readerLockException(name) {
   return new TypeError('Cannot ' + name + ' a stream using a released reader');

--- a/reference-implementation/lib/ReadableStreamBYOBReader.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBReader.webidl
@@ -2,9 +2,7 @@
 interface ReadableStreamBYOBReader {
   constructor(ReadableStream stream);
 
-  readonly attribute Promise<void> closed;
-
-  Promise<void> cancel(optional any reason);
   Promise<ReadableStreamBYOBReadResult> read(ArrayBufferView view);
   void releaseLock();
 };
+ReadableStreamBYOBReader includes ReadableStreamGenericReader;

--- a/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
@@ -2,22 +2,12 @@
 
 const { newPromise, resolvePromise, rejectPromise, promiseRejectedWith } = require('./helpers/webidl.js');
 const aos = require('./abstract-ops/readable-streams.js');
+const { mixin } = require('./helpers/miscellaneous.js');
+const ReadableStreamGenericReaderImpl = require('./ReadableStreamGenericReader-impl.js').implementation;
 
-exports.implementation = class ReadableStreamDefaultReaderImpl {
+class ReadableStreamDefaultReaderImpl {
   constructor(globalObject, [stream]) {
     aos.SetUpReadableStreamDefaultReader(this, stream);
-  }
-
-  get closed() {
-    return this._closedPromise;
-  }
-
-  cancel(reason) {
-    if (this._stream === undefined) {
-      return promiseRejectedWith(readerLockException('cancel'));
-    }
-
-    return aos.ReadableStreamReaderGenericCancel(this, reason);
   }
 
   read() {
@@ -47,7 +37,11 @@ exports.implementation = class ReadableStreamDefaultReaderImpl {
 
     aos.ReadableStreamReaderGenericRelease(this);
   }
-};
+}
+
+mixin(ReadableStreamDefaultReaderImpl.prototype, ReadableStreamGenericReaderImpl.prototype);
+
+exports.implementation = ReadableStreamDefaultReaderImpl;
 
 function readerLockException(name) {
   return new TypeError('Cannot ' + name + ' a stream using a released reader');

--- a/reference-implementation/lib/ReadableStreamDefaultReader.webidl
+++ b/reference-implementation/lib/ReadableStreamDefaultReader.webidl
@@ -2,9 +2,7 @@
 interface ReadableStreamDefaultReader {
   constructor(ReadableStream stream);
 
-  readonly attribute Promise<void> closed;
-
-  Promise<void> cancel(optional any reason);
   Promise<ReadableStreamDefaultReadResult> read();
   void releaseLock();
 };
+ReadableStreamDefaultReader includes ReadableStreamGenericReader;

--- a/reference-implementation/lib/ReadableStreamGenericReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamGenericReader-impl.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { promiseRejectedWith } = require('./helpers/webidl.js');
+const aos = require('./abstract-ops/readable-streams.js');
+
+exports.implementation = class ReadableStreamGenericReaderImpl {
+  get closed() {
+    return this._closedPromise;
+  }
+
+  cancel(reason) {
+    if (this._stream === undefined) {
+      return promiseRejectedWith(readerLockException('cancel'));
+    }
+
+    return aos.ReadableStreamReaderGenericCancel(this, reason);
+  }
+};
+
+function readerLockException(name) {
+  return new TypeError('Cannot ' + name + ' a stream using a released reader');
+}

--- a/reference-implementation/lib/ReadableStreamGenericReader.webidl
+++ b/reference-implementation/lib/ReadableStreamGenericReader.webidl
@@ -1,0 +1,5 @@
+interface mixin ReadableStreamGenericReader {
+  readonly attribute Promise<void> closed;
+
+  Promise<void> cancel(optional any reason);
+};

--- a/reference-implementation/lib/helpers/miscellaneous.js
+++ b/reference-implementation/lib/helpers/miscellaneous.js
@@ -11,3 +11,14 @@ exports.rethrowAssertionErrorRejection = e => {
     }, 0);
   }
 };
+
+exports.mixin = (target, source) => {
+  const keys = Reflect.ownKeys(source);
+  for (let i = 0; i < keys.length; ++i) {
+    if (keys[i] in target) {
+      continue;
+    }
+
+    Object.defineProperty(target, keys[i], Object.getOwnPropertyDescriptor(source, keys[i]));
+  }
+};


### PR DESCRIPTION
This is a quick experiment to see what would be needed to have cross-links on internal slots. For now, I've only done `ReadableStream`, but I'm pretty confident we can extend this to other classes. I also have not yet taken the line length into account, so some lines may still need wrapping.

The change is mostly mechanical: e.g. find all usages of `\[[disturbed]]` and replace them with `[=ReadableStream/[[disturbed]]=]`. For usages of `[[state]]` and `[[storedError]]`, care must be taken to check whether the usage references the slot on `ReadableStream` or on `WritableStream`.

I'm not sure if this is the most compact way to do it? A link like `[=ReadableStream/[[readableStreamController]]=]` is quite long, but I don't know if there's a way to write only `[=[[readableStreamController]]=]` and have Bikeshed figure out that it needs to use the `ReadableStream` namespace. 🤷 

See #1048.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1050.html" title="Last updated on Aug 13, 2020, 10:48 PM UTC (2ace378)">Preview</a> | <a href="https://whatpr.org/streams/1050/6cd5e81...2ace378.html" title="Last updated on Aug 13, 2020, 10:48 PM UTC (2ace378)">Diff</a>