### PR TITLE
Editorial: various fixes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5328,9 +5328,7 @@ side=] of [=transform streams=].
  1. Return the result of [=reacting=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
    1. If |readable|.\[[state]] is "`errored`", throw |readable|.\[[storedError]].
-   1. Let |readableController| be |readable|.\[[readableStreamController]].
-   1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|readableController|) is true,
-      perform ! [$ReadableStreamDefaultControllerClose$](|readableController|).
+   1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.\[[readableStreamController]]).
   1. If |flushPromise| was rejected with reason |r|, then:
    1. Perform ! [$TransformStreamError$](|stream|, |r|).
    1. Throw |readable|.\[[storedError]].

--- a/index.bs
+++ b/index.bs
@@ -5215,7 +5215,7 @@ The following abstract operations support the implementaiton of the
 
 <div algorithm>
  <dfn abstract-op lt="TransformStreamDefaultControllerEnqueue"
- id="set-up-transform-stream-default-controller-enqueue"
+ id="transform-stream-default-controller-enqueue"
  export>TransformStreamDefaultControllerEnqueue(|controller|, |chunk|)</dfn> is meant to be called
  by other specifications that wish to enqueue [=chunks=] in the [=readable side=], in the same way
  a developer would enqueue chunks using the stream's associated controller object. Specifications
@@ -5241,7 +5241,7 @@ The following abstract operations support the implementaiton of the
 </div>
 <div algorithm>
  <dfn abstract-op lt="TransformStreamDefaultControllerError"
- id="set-up-transform-stream-default-controller-error"
+ id="transform-stream-default-controller-error"
  export>TransformStreamDefaultControllerError(|controller|, |e|)</dfn> is meant to be called by
  other specifications that wish to move the transform stream to an errored state, in the same way a
  developer would error the stream using the stream's associated controller object. Specifications
@@ -5254,7 +5254,7 @@ The following abstract operations support the implementaiton of the
 
 <div algorithm>
  <dfn abstract-op lt="TransformStreamDefaultControllerPerformTransform"
- id="set-up-transform-stream-default-controller-perform-transform">TransformStreamDefaultControllerPerformTransform(|controller|, |chunk|)</dfn>
+ id="transform-stream-default-controller-perform-transform">TransformStreamDefaultControllerPerformTransform(|controller|, |chunk|)</dfn>
  performs the following steps:
 
  1. Let |transformPromise| be the result of performing
@@ -5267,7 +5267,7 @@ The following abstract operations support the implementaiton of the
 
 <div algorithm>
  <dfn abstract-op lt="TransformStreamDefaultControllerTerminate"
- id="set-up-transform-stream-default-controller-terminate"
+ id="transform-stream-default-controller-terminate"
  export>TransformStreamDefaultControllerTerminate(|controller|)</dfn> is meant to be called by
  other specifications that wish to terminate the transform stream, in the same way a
  developer-created stream would be terminated by its associated controller object. Specifications

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -934,7 +934,7 @@ function ReadableByteStreamControllerClearPendingPullIntos(controller) {
 function ReadableByteStreamControllerClose(controller) {
   const stream = controller._controlledReadableStream;
 
-  if (controller._closeRequest === true || stream._state !== 'readable') {
+  if (controller._closeRequested === true || stream._state !== 'readable') {
     return;
   }
 
@@ -990,7 +990,7 @@ function ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescripto
 function ReadableByteStreamControllerEnqueue(controller, chunk) {
   const stream = controller._controlledReadableStream;
 
-  if (controller._closeRequest === true || stream._state !== 'readable') {
+  if (controller._closeRequested === true || stream._state !== 'readable') {
     return;
   }
 

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -244,10 +244,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
     if (readable._state === 'errored') {
       throw readable._storedError;
     }
-    const readableController = readable._readableStreamController;
-    if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === true) {
-      ReadableStreamDefaultControllerClose(readableController);
-    }
+    ReadableStreamDefaultControllerClose(readable._readableStreamController);
   }, r => {
     TransformStreamError(stream, r);
     throw readable._storedError;


### PR DESCRIPTION
* Fix typo in Close/Enqueue checks for readable byte streams. The internal slot is called `[[closeRequested]]` instead of `[[closeRequest]]`. Looks like we missed this in #1029. 😅
* Remove redundant `ReadableStreamDefaultControllerCanCloseOrEnqueue` check in `TransformStreamDefaultSinkCloseAlgorithm`.
* ~Add missing link to `ReadableStreamDefaultControllerEnqueue` inside `ReadableStreamTee`.~ Was already fixed in 63b4407f424d6ad042852b3d225b7c0ffa116b2d.
* Fix link IDs for `TransformStream` abstract ops, which were presumable broken in the WebIDL rewrite.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1051.html" title="Last updated on Jul 6, 2020, 8:48 PM UTC (2ef17ea)">Preview</a> | <a href="https://whatpr.org/streams/1051/63b4407...2ef17ea.html" title="Last updated on Jul 6, 2020, 8:48 PM UTC (2ef17ea)">Diff</a>