### PR TITLE
Fix couple typos

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -691,7 +691,7 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
    directly read individual [=chunks=] from the stream via its {{ReadableStreamBYOBReader/read()}}
    method, into developer-supplied buffers, allowing more precise control over allocation.
 
- <dt><code><var ignore>readable</var> = <var ignore>stream</var>.{{ReadableStream/pipeThrough(transform, options)|pipeThrough}}({ {{ReadableWritablePair/writable}}, {{ReadableWritablePair/readable}} }[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/preventAbort}}, {{StreamPipeOptions/signal}} }])</code></dt>
+ <dt><code><var ignore>readable</var> = <var ignore>stream</var>.{{ReadableStream/pipeThrough(transform, options)|pipeThrough}}({ {{ReadableWritablePair/writable}}, {{ReadableWritablePair/readable}} }[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventAbort}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/signal}} }])</code></dt>
  <dd>
   <p>Provides a convenient, chainable way of [=piping=] this [=readable stream=] through a
   [=transform stream=] (or any other <code>{ writable, readable }</code> pair). It simply pipes the
@@ -700,7 +700,7 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
   <p>Piping a stream will [=locked to a reader|lock=] it for the duration of the pipe, preventing
   any other consumer from acquiring a reader.
 
- <dt><code>await <var ignore>stream</var>.{{ReadableStream/pipeTo(destination, options)|pipeTo}}(<var ignore>destination</var>[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/preventAbort}}, {{StreamPipeOptions/signal}} }])</code></dt>
+ <dt><code>await <var ignore>stream</var>.{{ReadableStream/pipeTo(destination, options)|pipeTo}}(<var ignore>destination</var>[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventAbort}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/signal}} }])</code></dt>
  <dd>
   <p>[=piping|Pipes=] this [=readable stream=] to a given [=writable stream=] |destination|. The
   way in which the piping process behaves under various error conditions can be customized with a

--- a/index.bs
+++ b/index.bs
@@ -691,7 +691,7 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
    directly read individual [=chunks=] from the stream via its {{ReadableStreamBYOBReader/read()}}
    method, into developer-supplied buffers, allowing more precise control over allocation.
 
- <dt><code><var ignore>readable</var> = <var ignore>stream</var>.{{ReadableStream/pipeThrough(transform, options)|pipeThrough}}({ {{ReadableWritablePair/writable}}, {{ReadableWritablePair/readable}} }[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/signal}} }])</code></dt>
+ <dt><code><var ignore>readable</var> = <var ignore>stream</var>.{{ReadableStream/pipeThrough(transform, options)|pipeThrough}}({ {{ReadableWritablePair/writable}}, {{ReadableWritablePair/readable}} }[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/preventAbort}}, {{StreamPipeOptions/signal}} }])</code></dt>
  <dd>
   <p>Provides a convenient, chainable way of [=piping=] this [=readable stream=] through a
   [=transform stream=] (or any other <code>{ writable, readable }</code> pair). It simply pipes the
@@ -700,7 +700,7 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
   <p>Piping a stream will [=locked to a reader|lock=] it for the duration of the pipe, preventing
   any other consumer from acquiring a reader.
 
- <dt><code>await <var ignore>stream</var>.{{ReadableStream/pipeTo(destination, options)|pipeTo}}(<var ignore>destination</var>[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/signal}} }])</code></dt>
+ <dt><code>await <var ignore>stream</var>.{{ReadableStream/pipeTo(destination, options)|pipeTo}}(<var ignore>destination</var>[, { {{StreamPipeOptions/preventClose}}, {{StreamPipeOptions/preventCancel}}, {{StreamPipeOptions/preventAbort}}, {{StreamPipeOptions/signal}} }])</code></dt>
  <dd>
   <p>[=piping|Pipes=] this [=readable stream=] to a given [=writable stream=] |destination|. The
   way in which the piping process behaves under various error conditions can be customized with a
@@ -1111,7 +1111,7 @@ following table:
 
 <h3 id="byob-reader-class">The {{ReadableStreamBYOBReader}} class</h3>
 
-The {{ReadableStreamDefaultReader}} class represents a [=BYOB reader=] designed to be vended by a
+The {{ReadableStreamBYOBReader}} class represents a [=BYOB reader=] designed to be vended by a
 {{ReadableStream}} instance.
 
 <h4 id="byob-reader-class-definition">Interface definition</h4>


### PR DESCRIPTION
This fixes a bad reference to `ReadableStreamDefaultReader` and replaces a repeated `preventCancel` parameter with the missing `preventAbort`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1052.html" title="Last updated on Jul 7, 2020, 11:48 AM UTC (4375d4e)">Preview</a> | <a href="https://whatpr.org/streams/1052/c63ae9e...4375d4e.html" title="Last updated on Jul 7, 2020, 11:48 AM UTC (4375d4e)">Diff</a>