### PR TITLE
Fix argument order in UnderlyingSinkWriteCallback and TransformerTransformCallback definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3432,7 +3432,7 @@ dictionary UnderlyingSink {
 };
 
 callback UnderlyingSinkStartCallback = any (WritableStreamDefaultController controller);
-callback UnderlyingSinkWriteCallback = Promise<void> (WritableStreamDefaultController controller, optional any chunk);
+callback UnderlyingSinkWriteCallback = Promise<void> (any chunk, WritableStreamDefaultController controller);
 callback UnderlyingSinkCloseCallback = Promise<void> ();
 callback UnderlyingSinkAbortCallback = Promise<void> (optional any reason);
 </xmp>

--- a/index.bs
+++ b/index.bs
@@ -4791,7 +4791,7 @@ dictionary Transformer {
 
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<void> (TransformStreamDefaultController controller);
-callback TransformerTransformCallback = Promise<void> (TransformStreamDefaultController controller, optional any chunk);
+callback TransformerTransformCallback = Promise<void> (any chunk, TransformStreamDefaultController controller);
 </xmp>
 
 <dl>

--- a/reference-implementation/lib/Transformer.webidl
+++ b/reference-implementation/lib/Transformer.webidl
@@ -8,4 +8,4 @@ dictionary Transformer {
 
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<void> (TransformStreamDefaultController controller);
-callback TransformerTransformCallback = Promise<void> (TransformStreamDefaultController controller, optional any chunk);
+callback TransformerTransformCallback = Promise<void> (any chunk, TransformStreamDefaultController controller);

--- a/reference-implementation/lib/UnderlyingSink.webidl
+++ b/reference-implementation/lib/UnderlyingSink.webidl
@@ -7,6 +7,6 @@ dictionary UnderlyingSink {
 };
 
 callback UnderlyingSinkStartCallback = any (WritableStreamDefaultController controller);
-callback UnderlyingSinkWriteCallback = Promise<void> (WritableStreamDefaultController controller, optional any chunk);
+callback UnderlyingSinkWriteCallback = Promise<void> (any chunk, WritableStreamDefaultController controller);
 callback UnderlyingSinkCloseCallback = Promise<void> ();
 callback UnderlyingSinkAbortCallback = Promise<void> (optional any reason);


### PR DESCRIPTION
The WebIDL definition for `UnderlyingSinkWriteCallback` and `TransformerTransformCallback` had `chunk` and `controller` in the wrong order.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1054.html" title="Last updated on Jul 15, 2020, 10:42 PM UTC (ae2573b)">Preview</a> | <a href="https://whatpr.org/streams/1054/6969058...ae2573b.html" title="Last updated on Jul 15, 2020, 10:42 PM UTC (ae2573b)">Diff</a>