### PR TITLE
Remove obsolete asserts from reference implementation

### DIFF
--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -863,8 +863,6 @@ function SetUpReadableStreamDefaultController(
 
 function SetUpReadableStreamDefaultControllerFromUnderlyingSource(
   stream, underlyingSource, underlyingSourceDict, highWaterMark, sizeAlgorithm) {
-  assert(underlyingSource !== undefined);
-
   const controller = ReadableStreamDefaultController.new(globalThis);
 
   let startAlgorithm = () => undefined;

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -114,8 +114,6 @@ function SetUpTransformStreamDefaultController(stream, controller, transformAlgo
 }
 
 function SetUpTransformStreamDefaultControllerFromTransformer(stream, transformer, transformerDict) {
-  assert(transformer !== undefined);
-
   const controller = TransformStreamDefaultController.new(globalThis);
 
   let transformAlgorithm = chunk => {

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -568,8 +568,6 @@ function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm
 
 function SetUpWritableStreamDefaultControllerFromUnderlyingSink(stream, underlyingSink, underlyingSinkDict,
                                                                 highWaterMark, sizeAlgorithm) {
-  assert(underlyingSink !== undefined);
-
   const controller = WritableStreamDefaultController.new(globalThis);
 
   let startAlgorithm = () => undefined;


### PR DESCRIPTION
These asserts no longer appear in the spec text, since they were made redundant by the WebIDL rewrite. Therefore, they should also be removed from the reference implementation.