### PR TITLE
Update WPT

### DIFF
--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -33,7 +33,7 @@ async function main() {
   const testsPath = path.resolve(wptPath, 'streams');
 
   const filterGlobs = process.argv.length >= 3 ? process.argv.slice(2) : ['**/*.html'];
-  const workerTestPattern = /\.(?:dedicated|shared|service)worker(?:\.https)?\.html$/;
+  const anyTestPattern = /\.any\.html$/;
 
   const bundledJS = await bundle(entryPath);
 
@@ -56,8 +56,8 @@ async function main() {
       window.eval(bundledJS);
     },
     filter(testPath) {
-      // Ignore the worker versions
-      if (workerTestPattern.test(testPath)) {
+      // Ignore the window-specific and worker-specific tests
+      if (!anyTestPattern.test(testPath)) {
         return false;
       }
 


### PR DESCRIPTION
In web-platform-tests/wpt#24577, a window-only test was added which uses an `<iframe>` to check that `CountQueuingStrategy.prototype.size` and `ByteLengthQueuingStrategy.prototype.size` return different functions in different realms. However, we cannot emulate this easily with our JSDOM-based test runner, so the reference implementation fails this new test.

This PR changes our test script to only run `.any.js` tests, since these should work regardless of the context. I've verified that all current tests indeed are `.any.js` tests, and still run with this new check. The only test that is excluded is the new `.window.js` test, which we probably don't want (or need) to test against the reference implementation.