### PR TITLE
Editorial: rename internal slots for brevity

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -973,8 +973,7 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  ignore>stream</var> and |iterator|, are:
 
  1. Let |reader| be |iterator|'s [=ReadableStream async iterator/reader=].
- 1. If |reader|.\[[ownerReadableStream]] is undefined, return [=a promise rejected with=] a
-    {{TypeError}}.
+ 1. If |reader|.\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}.
  1. Let |promise| be [=a new promise=].
  1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
   : [=read request/chunk steps=], given |chunk|
@@ -997,7 +996,7 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  ignore>stream</var>, |iterator|, and |arg|, are:
 
  1. Let |reader| be |iterator|'s [=ReadableStream async iterator/reader=].
- 1. If |reader|.\[[ownerReadableStream]] is undefined, return [=a promise resolved with=] undefined.
+ 1. If |reader|.\[[stream]] is undefined, return [=a promise resolved with=] undefined.
  1. Assert: |reader|.\[[readRequests]] is [=list/is empty|empty=], as the async iterator machinery
     guarantees that any previous calls to `next()` have settled before this is called.
  1. If |iterator|'s [=ReadableStream async iterator/prevent cancel=] is false:
@@ -1051,12 +1050,12 @@ following table:
    <td class="non-normative">A promise returned by the reader's
    {{ReadableStreamDefaultReader/closed}} getter
   <tr>
-   <td>\[[ownerReadableStream]]
-   <td class="non-normative">A {{ReadableStream}} instance that owns this reader
-  <tr>
    <td>\[[readRequests]]
    <td class="non-normative">A [=list=] of [=read requests=], used when a [=consumer=] requests
    [=chunks=] sooner than they are available
+  <tr>
+   <td>\[[stream]]
+   <td class="non-normative">A {{ReadableStream}} instance that owns this reader
 </table>
 
 A <dfn export>read request</dfn> is a [=struct=] containing three algorithms to perform in reaction
@@ -1139,8 +1138,8 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  The <dfn id="default-reader-cancel" method for="ReadableStreamDefaultReader">cancel(|reason|)</dfn>
  method steps are:
 
- 1. If [=this=].\[[ownerReadableStream]] is undefined, return [=a promise rejected with=] a
-    {{TypeError}} exception.
+ 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+    exception.
  1. Return ! [$ReadableStreamReaderGenericCancel$]([=this=], |reason|).
 </div>
 
@@ -1148,8 +1147,8 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  The <dfn id="default-reader-read" method for="ReadableStreamDefaultReader">read()</dfn>
  method steps are:
 
- 1. If [=this=].\[[ownerReadableStream]] is undefined, return [=a promise rejected with=] a
-    {{TypeError}} exception.
+ 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+    exception.
  1. Let |promise| be [=a new promise=].
  1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
   : [=read request/chunk steps=], given |chunk|
@@ -1171,7 +1170,7 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  The <dfn id="default-reader-release-lock" method
  for="ReadableStreamDefaultReader">releaseLock()</dfn> method steps are:
 
- 1. If [=this=].\[[ownerReadableStream]] is undefined, return.
+ 1. If [=this=].\[[stream]] is undefined, return.
  1. If [=this=].\[[readRequests]] is not [=list/is empty|empty=], throw a {{TypeError}} exception.
  1. Perform ! [$ReadableStreamReaderGenericRelease$]([=this=]).
 </div>
@@ -1219,12 +1218,12 @@ following table:
    <td class="non-normative">A promise returned by the reader's
    {{ReadableStreamBYOBReader/closed}} getter
   <tr>
-   <td>\[[ownerReadableStream]]
-   <td class="non-normative">A {{ReadableStream}} instance that owns this reader
-  <tr>
    <td>\[[readIntoRequests]]
    <td class="non-normative">A [=list=] of [=read-into requests=], used when a [=consumer=] requests
    [=chunks=] sooner than they are available
+  <tr>
+   <td>\[[stream]]
+   <td class="non-normative">A {{ReadableStream}} instance that owns this reader
 </table>
 
 A <dfn export>read-into request</dfn> is a [=struct=] containing three algorithms to perform in
@@ -1318,8 +1317,8 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
  The <dfn id="byob-reader-cancel" method for="ReadableStreamBYOBReader">cancel(|reason|)</dfn>
  method steps are:
 
- 1. If [=this=].\[[ownerReadableStream]] is undefined, return [=a promise rejected with=] a
-    {{TypeError}} exception.
+ 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+    exception.
  1. Return ! [$ReadableStreamReaderGenericCancel$]([=this=], |reason|).
 </div>
 
@@ -1330,8 +1329,8 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
  1. If |view|.\[[ByteLength]] is 0, return [=a promise rejected with=] a {{TypeError}} exception.
  1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. If [=this=].\[[ownerReadableStream]] is undefined, return [=a promise rejected with=] a
-    {{TypeError}} exception.
+ 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+    exception.
  1. Let |promise| be [=a new promise=].
  1. Let |readIntoRequest| be a new [=read-into request=] with the following [=struct/items=]:
   : [=read-into request/chunk steps=], given |chunk|
@@ -1353,7 +1352,7 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
  The <dfn id="byob-reader-release-lock" method
  for="ReadableStreamBYOBReader">releaseLock()</dfn> method steps are:
 
- 1. If [=this=].\[[ownerReadableStream]] is undefined, return.
+ 1. If [=this=].\[[stream]] is undefined, return.
  1. If [=this=].\[[readIntoRequests]] is not [=list/is empty|empty=], throw a {{TypeError}}
     exception.
  1. Perform ! [$ReadableStreamReaderGenericRelease$]([=this=]).
@@ -2418,7 +2417,7 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-reader-generic-cancel">ReadableStreamReaderGenericCancel(|reader|,
  |reason|)</dfn> performs the following steps:
 
- 1. Let |stream| be |reader|.\[[ownerReadableStream]].
+ 1. Let |stream| be |reader|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Return ! [$ReadableStreamCancel$](|stream|, |reason|).
 </div>
@@ -2428,7 +2427,7 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-reader-generic-initialize">ReadableStreamReaderGenericInitialize(|reader|,
  |stream|)</dfn> performs the following steps:
 
- 1. Set |reader|.\[[ownerReadableStream]] to |stream|.
+ 1. Set |reader|.\[[stream]] to |stream|.
  1. Set |stream|.\[[reader]] to |reader|.
  1. If |stream|.\[[state]] is "`readable`",
   1. Set |reader|.\[[closedPromise]] to [=a new promise=].
@@ -2445,15 +2444,15 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-reader-generic-release">ReadableStreamReaderGenericRelease(|reader|)</dfn>
  performs the following steps:
 
- 1. Assert: |reader|.\[[ownerReadableStream]] is not undefined.
- 1. Assert: |reader|.\[[ownerReadableStream]].\[[reader]] is |reader|.
- 1. If |reader|.\[[ownerReadableStream]].\[[state]] is "`readable`", [=reject=]
-    |reader|.\[[closedPromise]] with a {{TypeError}} exception.
+ 1. Assert: |reader|.\[[stream]] is not undefined.
+ 1. Assert: |reader|.\[[stream]].\[[reader]] is |reader|.
+ 1. If |reader|.\[[stream]].\[[state]] is "`readable`", [=reject=] |reader|.\[[closedPromise]] with
+    a {{TypeError}} exception.
  1. Otherwise, set |reader|.\[[closedPromise]] to [=a promise rejected with=] a {{TypeError}}
     exception.
  1. Set |reader|.\[[closedPromise]].\[[PromiseIsHandled]] to true.
- 1. Set |reader|.\[[ownerReadableStream]].\[[reader]] to undefined.
- 1. Set |reader|.\[[ownerReadableStream]] to undefined.
+ 1. Set |reader|.\[[stream]].\[[reader]] to undefined.
+ 1. Set |reader|.\[[stream]] to undefined.
 </div>
 
 <div algorithm>
@@ -2461,7 +2460,7 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-byob-reader-read">ReadableStreamBYOBReaderRead(|reader|, |view|,
  |readIntoRequest|)</dfn> performs the following steps:
 
- 1. Let |stream| be |reader|.\[[ownerReadableStream]].
+ 1. Let |stream| be |reader|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Set |stream|.\[[disturbed]] to true.
  1. If |stream|.\[[state]] is "`errored`", perform |readIntoRequest|'s [=read-into request/error
@@ -2475,7 +2474,7 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-default-reader-read">ReadableStreamDefaultReaderRead(|reader|,
  |readRequest|)</dfn> performs the following steps:
 
- 1. Let |stream| be |reader|.\[[ownerReadableStream]].
+ 1. Let |stream| be |reader|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Set |stream|.\[[disturbed]] to true.
  1. If |stream|.\[[state]] is "`closed`", perform |readRequest|'s [=read request/close steps=].

--- a/index.bs
+++ b/index.bs
@@ -4795,12 +4795,12 @@ table:
    <td class="non-normative">A promise which is fulfilled and replaced every time the value of
    \[[backpressure]] changes
   <tr>
-   <td>\[[readable]]
-   <td class="non-normative">The {{ReadableStream}} instance controlled by this object
-  <tr>
-   <td>\[[transformStreamController]]
+   <td>\[[controller]]
    <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to
    control \[[readable]] and \[[writable]]
+  <tr>
+   <td>\[[readable]]
+   <td class="non-normative">The {{ReadableStream}} instance controlled by this object
   <tr>
    <td>\[[writable]]
    <td class="non-normative">The {{WritableStream}} instance controlled by this object
@@ -4951,7 +4951,7 @@ side=], or to terminate or error the stream.
  1. Let |startPromise| be [=a new promise=].
  1. If |transformerDict|["{{Transformer/start}}"] [=map/exists=], then [=resolve=] |startPromise|
     with the result of [=invoking=] |transformerDict|["{{Transformer/start}}"] with argument list
-    «&nbsp;[=this=].\[[transformStreamController]]&nbsp;» and [=callback this value=] |transformer|.
+    «&nbsp;[=this=].\[[controller]]&nbsp;» and [=callback this value=] |transformer|.
  1. Otherwise, [=resolve=] |startPromise| with undefined.
 </div>
 
@@ -5003,12 +5003,12 @@ the following table:
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
   <tr>
-   <td>\[[controlledTransformStream]]
-   <td class="non-normative">The {{TransformStream}} instance controlled
-  <tr>
    <td>\[[flushAlgorithm]]
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=transformer=]
+  <tr>
+   <td>\[[stream]]
+   <td class="non-normative">The {{TransformStream}} instance controlled
   <tr>
    <td>\[[transformAlgorithm]]
    <td class="non-normative">A promise-returning algorithm, taking one argument (the [=chunk=] to
@@ -5045,8 +5045,7 @@ the following table:
  The <dfn id="ts-default-controller-desired-size" attribute
  for="TransformStreamDefaultController">desiredSize</dfn> getter steps are:
 
- 1. Let |readableController| be
-    [=this=].\[[controlledTransformStream]].\[[readable]].\[[controller]].
+ 1. Let |readableController| be [=this=].\[[stream]].\[[readable]].\[[controller]].
  1. Return ! [$ReadableStreamDefaultControllerGetDesiredSize$](|readableController|).
 </div>
 
@@ -5140,7 +5139,7 @@ are even meant to be generally useful by other specifications.
     user code so long as the initialization is correctly completed before the transformer's
     {{Transformer/start|start()}} method is called.
  1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
- 1. Set |stream|.\[[transformStreamController]] to undefined.
+ 1. Set |stream|.\[[controller]] to undefined.
 </div>
 
 <div algorithm>
@@ -5160,8 +5159,7 @@ are even meant to be generally useful by other specifications.
  id="transform-stream-error-writable-and-unblock-write">TransformStreamErrorWritableAndUnblockWrite(|stream|,
  |e|)</dfn> performs the following steps:
 
- 1. Perform !
-    [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.\[[transformStreamController]]).
+ 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.\[[controller]]).
  1. Perform !
     [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].\[[controller]], |e|).
  1. If |stream|.\[[backpressure]] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
@@ -5195,9 +5193,9 @@ The following abstract operations support the implementaiton of the
  |controller|, |transformAlgorithm|, |flushAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{TransformStream}}.
- 1. Assert: |stream|.\[[transformStreamController]] is undefined.
- 1. Set |controller|.\[[controlledTransformStream]] to |stream|.
- 1. Set |stream|.\[[transformStreamController]] to |controller|.
+ 1. Assert: |stream|.\[[controller]] is undefined.
+ 1. Set |controller|.\[[stream]] to |stream|.
+ 1. Set |stream|.\[[controller]] to |controller|.
  1. Set |controller|.\[[transformAlgorithm]] to |transformAlgorithm|.
  1. Set |controller|.\[[flushAlgorithm]] to |flushAlgorithm|.
 </div>
@@ -5252,7 +5250,7 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledTransformStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Let |readableController| be |stream|.\[[readable]].\[[controller]].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|readableController|) is false, throw
     a {{TypeError}} exception.
@@ -5278,7 +5276,7 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Perform ! [$TransformStreamError$](|controller|.\[[controlledTransformStream]], |e|).
+ 1. Perform ! [$TransformStreamError$](|controller|.\[[stream]], |e|).
 </div>
 
 <div algorithm>
@@ -5290,7 +5288,7 @@ The following abstract operations support the implementaiton of the
     |controller|.\[[transformAlgorithm]], passing |chunk|.
  1. Return the result of [=reacting=] to |transformPromise| with the following
     rejection steps given the argument |r|:
-   1. Perform ! [$TransformStreamError$](|controller|.\[[controlledTransformStream]], |r|).
+   1. Perform ! [$TransformStreamError$](|controller|.\[[stream]], |r|).
    1. Throw |r|.
 </div>
 
@@ -5304,7 +5302,7 @@ The following abstract operations support the implementaiton of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledTransformStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Let |readableController| be |stream|.\[[readable]].\[[controller]].
  1. Perform ! [$ReadableStreamDefaultControllerClose$](|readableController|).
  1. Let |error| be a {{TypeError}} exception indicating that the stream has been terminated.
@@ -5322,7 +5320,7 @@ side=] of [=transform streams=].
  |chunk|)</dfn> performs the following steps:
 
  1. Assert: |stream|.\[[writable]].\[[state]] is "`writable`".
- 1. Let |controller| be |stream|.\[[transformStreamController]].
+ 1. Let |controller| be |stream|.\[[controller]].
  1. If |stream|.\[[backpressure]] is true,
   1. Let |backpressureChangePromise| be |stream|.\[[backpressureChangePromise]].
   1. Assert: |backpressureChangePromise| is not undefined.
@@ -5351,7 +5349,7 @@ side=] of [=transform streams=].
  performs the following steps:
 
  1. Let |readable| be |stream|.\[[readable]].
- 1. Let |controller| be |stream|.\[[transformStreamController]].
+ 1. Let |controller| be |stream|.\[[controller]].
  1. Let |flushPromise| be the result of performing |controller|.\[[flushAlgorithm]].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Return the result of [=reacting=] to |flushPromise|:

--- a/index.bs
+++ b/index.bs
@@ -3400,6 +3400,10 @@ table:
   <td class="non-normative">The promise returned from the writer's
   {{WritableStreamDefaultWriter/close()}} method
  <tr>
+  <td>\[[controller]]
+  <td class="non-normative">A {{WritableStreamDefaultController}} created with the ability to
+  control the state and queue of this stream
+ <tr>
   <td>\[[inFlightWriteRequest]]
   <td class="non-normative">A slot set to the promise for the current in-flight write operation
   while the [=underlying sink=]'s write algorithm is executing and has not yet fulfilled, used to
@@ -3420,10 +3424,6 @@ table:
   <td>\[[storedError]]
   <td class="non-normative">A value indicating how the stream failed, to be given as a failure
   reason or exception when trying to operate on the stream while in the "`errored`" state
- <tr>
-  <td>\[[writableStreamController]]
-  <td class="non-normative">A {{WritableStreamDefaultController}} created with the ability to
-  control the state and queue of this stream
  <tr>
   <td>\[[writer]]
   <td class="non-normative">A {{WritableStreamDefaultWriter}} instance, if the stream is [=locked to
@@ -4019,7 +4019,7 @@ are even meant to be generally useful by other specifications.
  steps:
 
  1. Set |stream|.\[[state]] to "`writable`".
- 1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.\[[writableStreamController]],
+ 1. Set |stream|.\[[storedError]], |stream|.\[[writer]], |stream|.\[[controller]],
     |stream|.\[[inFlightWriteRequest]], |stream|.\[[closeRequest]],
     |stream|.\[[inFlightCloseRequest]] and |stream|.\[[pendingAbortRequest]] to undefined.
  1. Set |stream|.\[[writeRequests]] to a new empty [=list=].
@@ -4102,7 +4102,7 @@ are even meant to be generally useful by other specifications.
  1. Let |writer| be |stream|.\[[writer]].
  1. If |writer| is not undefined, and |stream|.\[[backpressure]] is true, and |state| is
     "`writable`", [=resolve=] |writer|.\[[readyPromise]] with undefined.
- 1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.\[[writableStreamController]]).
+ 1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.\[[controller]]).
  1. Return |promise|.
 </div>
 
@@ -4180,7 +4180,7 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.\[[state]] is "`erroring`".
  1. Assert: ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false.
  1. Set |stream|.\[[state]] to "`errored`".
- 1. Perform ! |stream|.\[[writableStreamController]].\[[ErrorSteps]]().
+ 1. Perform ! |stream|.\[[controller]].\[[ErrorSteps]]().
  1. Let |storedError| be |stream|.\[[storedError]].
  1. [=list/For each=] |writeRequest| of |stream|.\[[writeRequests]]:
   1. [=Reject=] |writeRequest| with |storedError|.
@@ -4194,8 +4194,7 @@ the {{WritableStream}}'s public API.
   1. [=Reject=] |abortRequest|'s [=pending abort request/promise=] with |storedError|.
   1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
   1. Return.
- 1. Let |promise| be !
-    stream.\[[writableStreamController]].\[[AbortSteps]](|abortRequest|'s [=pending abort
+ 1. Let |promise| be ! stream.\[[controller]].\[[AbortSteps]](|abortRequest|'s [=pending abort
     request/reason=]).
  1. [=Upon fulfillment=] of |promise|,
   1. [=Resolve=] |abortRequest|'s [=pending abort request/promise=] with undefined.
@@ -4271,7 +4270,7 @@ the {{WritableStream}}'s public API.
  performs the following steps:
 
  1. If |stream|.\[[inFlightWriteRequest]] is undefined and
-    |stream|.\[[writableStreamController]].\[[inFlightCloseRequest]] is undefined, return false.
+    |stream|.\[[controller]].\[[inFlightCloseRequest]] is undefined, return false.
  1. Return true.
 </div>
 
@@ -4321,7 +4320,7 @@ the {{WritableStream}}'s public API.
 
  1. Assert: |stream|.\[[storedError]] is undefined.
  1. Assert: |stream|.\[[state]] is "`writable`".
- 1. Let |controller| be |stream|.\[[writableStreamController]].
+ 1. Let |controller| be |stream|.\[[controller]].
  1. Assert: |controller| is not undefined.
  1. Set |stream|.\[[state]] to "`erroring`".
  1. Set |stream|.\[[storedError]] to |reason|.
@@ -4422,8 +4421,7 @@ The following abstract operations support the implementation and manipulation of
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`errored"` or `"erroring`", return null.
  1. If |state| is "`closed`", return 0.
- 1. Return !
-    [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.\[[writableStreamController]]).
+ 1. Return ! [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.\[[controller]]).
 </div>
 
 <div algorithm>
@@ -4448,7 +4446,7 @@ The following abstract operations support the implementation and manipulation of
 
  1. Let |stream| be |writer|.\[[ownerWritableStream]].
  1. Assert: |stream| is not undefined.
- 1. Let |controller| be |stream|.\[[writableStreamController]].
+ 1. Let |controller| be |stream|.\[[controller]].
  1. Let |chunkSize| be ! [$WritableStreamDefaultControllerGetChunkSize$](|controller|, |chunk|).
  1. If |stream| is not equal to |writer|.\[[ownerWritableStream]], return [=a promise rejected
     with=] a {{TypeError}} exception.
@@ -4477,9 +4475,9 @@ The following abstract operations support the implementation of the
  |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{WritableStream}}.
- 1. Assert: |stream|.\[[writableStreamController]] is undefined.
+ 1. Assert: |stream|.\[[controller]] is undefined.
  1. Set |controller|.\[[controlledWritableStream]] to |stream|.
- 1. Set |stream|.\[[writableStreamController]] to |controller|.
+ 1. Set |stream|.\[[controller]] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.\[[started]] to false.
  1. Set |controller|.\[[strategySizeAlgorithm]] to |sizeAlgorithm|.
@@ -5165,8 +5163,7 @@ are even meant to be generally useful by other specifications.
  1. Perform !
     [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.\[[transformStreamController]]).
  1. Perform !
-    [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].\[[writableStreamController]],
-    |e|).
+    [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.\[[writable]].\[[controller]], |e|).
  1. If |stream|.\[[backpressure]] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
     false).
 

--- a/index.bs
+++ b/index.bs
@@ -2642,8 +2642,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |controller|.\[[stream]].\[[state]].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return |controller|.\[[strategyHWM]] − |controller|.\[[queueTotalSize]].
@@ -2953,8 +2952,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-get-desired-size">ReadableByteStreamControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[stream]].
- 1. Let |state| be |stream|.\[[state]].
+ 1. Let |state| be |controller|.\[[stream]].\[[state]].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return |controller|.\[[strategyHWM]] − |controller|.\[[queueTotalSize]].
@@ -3110,13 +3108,13 @@ The following abstract operations support the implementation of the
  |bytesWritten|)</dfn> performs the following steps:
 
  1. Let |firstDescriptor| be |controller|.\[[pendingPullIntos]][0].
- 1. Let |stream| be |controller|.\[[stream]].
- 1. If |stream|.\[[state]] is "`closed`",
+ 1. Let |state| be |controller|.\[[stream]].\[[state]].
+ 1. If |state| is "`closed`",
   1. If |bytesWritten| is not 0, throw a {{TypeError}} exception.
   1. Perform ! [$ReadableByteStreamControllerRespondInClosedState$](|controller|,
      |firstDescriptor|).
  1. Otherwise,
-  1. Assert: |stream|.\[[state]] is "`readable`".
+  1. Assert: |state| is "`readable`".
   1. Perform ? [$ReadableByteStreamControllerRespondInReadableState$](|controller|, |bytesWritten|,
      |firstDescriptor|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -503,14 +503,14 @@ table:
    <th>Description (<em>non-normative</em>)
  <tbody>
   <tr>
-   <td>\[[disturbed]]
-   <td class="non-normative">A boolean flag set to true when the stream has been read from or
-   canceled
-  <tr>
-   <td>\[[readableStreamController]]
+   <td>\[[controller]]
    <td class="non-normative">A {{ReadableStreamDefaultController}} or
    {{ReadableByteStreamController}} created with the ability to control the state and queue of this
    stream
+  <tr>
+   <td>\[[disturbed]]
+   <td class="non-normative">A boolean flag set to true when the stream has been read from or
+   canceled
   <tr>
    <td>\[[reader]]
    <td class="non-normative">A {{ReadableStreamDefaultReader}} or {{ReadableStreamBYOBReader}}
@@ -2031,8 +2031,8 @@ are even meant to be generally useful by other specifications.
  1. Assert: either |signal| is undefined, or |signal| [=implements=] {{AbortSignal}}.
  1. Assert: ! [$IsReadableStreamLocked$](|source|) is false.
  1. Assert: ! [$IsWritableStreamLocked$](|dest|) is false.
- 1. If |source|.\[[readableStreamController]] [=implements=] {{ReadableByteStreamController}}, let
-   |reader| be either ! [$AcquireReadableStreamBYOBReader$](|source|) or !
+ 1. If |source|.\[[controller]] [=implements=] {{ReadableByteStreamController}}, let |reader| be
+   either ! [$AcquireReadableStreamBYOBReader$](|source|) or !
    [$AcquireReadableStreamDefaultReader$](|source|), at the user agent's discretion.
  1. Otherwise, let |reader| be ! [$AcquireReadableStreamDefaultReader$](|source|).
  1. Let |writer| be ! [$AcquireWritableStreamDefaultWriter$](|dest|).
@@ -2183,11 +2183,9 @@ create them does not matter.
      1. If |canceled2| is false and |cloneForBranch2| is true, set |value2| to ?
         [$StructuredDeserialize$](? [$StructuredSerialize$](|value2|), [=the current Realm=]).
      1. If |canceled1| is false, perform ?
-        [$ReadableStreamDefaultControllerEnqueue$](|branch1|.\[[readableStreamController]],
-        |value1|).
+        [$ReadableStreamDefaultControllerEnqueue$](|branch1|.\[[controller]], |value1|).
      1. If |canceled2| is false, perform ?
-        [$ReadableStreamDefaultControllerEnqueue$](|branch2|.\[[readableStreamController]],
-        |value2|).
+        [$ReadableStreamDefaultControllerEnqueue$](|branch2|.\[[controller]], |value2|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to
     detect errors, when we use |reader|.\[[closedPromise]] below. We want errors in |stream| to
@@ -2198,9 +2196,9 @@ create them does not matter.
    ::
     1. Set |reading| to false.
     1. If |canceled1| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch1|.\[[readableStreamController]]).
+       [$ReadableStreamDefaultControllerClose$](|branch1|.\[[controller]]).
     1. If |canceled2| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch2|.\[[readableStreamController]]).
+       [$ReadableStreamDefaultControllerClose$](|branch2|.\[[controller]]).
 
    : [=read request/error steps=]
    ::
@@ -2229,10 +2227,8 @@ create them does not matter.
  1. Set |branch2| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancel2Algorithm|).
  1. [=Upon rejection=] of |reader|.\[[closedPromise]] with reason |r|,
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.\[[readableStreamController]],
-     |r|).
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.\[[readableStreamController]],
-     |r|).
+  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.\[[controller]], |r|).
+  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.\[[controller]], |r|).
  1. Return « |branch1|, |branch2| ».
 </div>
 
@@ -2300,7 +2296,7 @@ the {{ReadableStream}}'s public API.
     |stream|.\[[storedError]].
  1. Perform ! [$ReadableStreamClose$](|stream|).
  1. Let |sourceCancelPromise| be !
-    |stream|.\[[readableStreamController]].[$ReadableStreamController/[[CancelSteps]]$](|reason|).
+    |stream|.\[[controller]].[$ReadableStreamController/[[CancelSteps]]$](|reason|).
  1. Return the result of [=reacting=] to |sourceCancelPromise| with a fulfillment step that returns
     undefined.
 </div>
@@ -2470,8 +2466,8 @@ The following abstract operations support the implementation and manipulation of
  1. Set |stream|.\[[disturbed]] to true.
  1. If |stream|.\[[state]] is "`errored`", perform |readIntoRequest|'s [=read-into request/error
     steps=] given |stream|.\[[storedError]].
- 1. Return ! [$ReadableByteStreamControllerPullInto$](|stream|.\[[readableStreamController]],
-    |view|, |readIntoRequest|).
+ 1. Return ! [$ReadableByteStreamControllerPullInto$](|stream|.\[[controller]], |view|,
+    |readIntoRequest|).
 </div>
 
 <div algorithm>
@@ -2487,8 +2483,7 @@ The following abstract operations support the implementation and manipulation of
     steps=] given |stream|.\[[storedError]].
  1. Otherwise,
   1. Assert: |stream|.\[[state]] is "`readable`".
-  1. Perform !
-     |stream|.\[[readableStreamController]].[$ReadableStreamController/[[PullSteps]]$](|readRequest|).
+  1. Perform ! |stream|.\[[controller]].[$ReadableStreamController/[[PullSteps]]$](|readRequest|).
 </div>
 
 <div algorithm>
@@ -2497,8 +2492,8 @@ The following abstract operations support the implementation and manipulation of
  performs the following steps:
 
  1. If ! [$IsReadableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
- 1. If |stream|.\[[readableStreamController]] does not [=implement=]
-    {{ReadableByteStreamController}}, throw a {{TypeError}} exception.
+ 1. If |stream|.\[[controller]] does not [=implement=] {{ReadableByteStreamController}}, throw a
+    {{TypeError}} exception.
  1. Perform ! [$ReadableStreamReaderGenericInitialize$](|reader|, |stream|).
  1. Set |reader|.\[[readIntoRequests]] to a new empty [=list=].
 </div>
@@ -2689,7 +2684,7 @@ The following abstract operations support the implementation of the
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |sizeAlgorithm|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[readableStreamController]] is undefined.
+ 1. Assert: |stream|.\[[controller]] is undefined.
  1. Set |controller|.\[[controlledReadableStream]] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.\[[started]], |controller|.\[[closeRequested]], |controller|.\[[pullAgain]], and
@@ -2698,7 +2693,7 @@ The following abstract operations support the implementation of the
     to |highWaterMark|.
  1. Set |controller|.\[[pullAlgorithm]] to |pullAlgorithm|.
  1. Set |controller|.\[[cancelAlgorithm]] to |cancelAlgorithm|.
- 1. Set |stream|.\[[readableStreamController]] to |controller|.
+ 1. Set |stream|.\[[controller]] to |controller|.
  1. Let |startResult| be the result of performing |startAlgorithm|. (This might throw an exception.)
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=]  of |startPromise|,
@@ -3183,7 +3178,7 @@ The following abstract operations support the implementation of the
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |autoAllocateChunkSize|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.\[[readableStreamController]] is undefined.
+ 1. Assert: |stream|.\[[controller]] is undefined.
  1. If |autoAllocateChunkSize| is not undefined,
   1. Assert: ! IsInteger(|autoAllocateChunkSize|) is true.
   1. Assert: |autoAllocateChunkSize| is positive.
@@ -3197,7 +3192,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.\[[cancelAlgorithm]] to |cancelAlgorithm|.
  1. Set |controller|.\[[autoAllocateChunkSize]] to |autoAllocateChunkSize|.
  1. Set |controller|.\[[pendingPullIntos]] to a new empty [=list=].
- 1. Set |stream|.\[[readableStreamController]] to |controller|.
+ 1. Set |stream|.\[[controller]] to |controller|.
  1. Let |startResult| be the result of performing |startAlgorithm|.
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=]  of |startPromise|,
@@ -5058,7 +5053,7 @@ the following table:
  for="TransformStreamDefaultController">desiredSize</dfn> getter steps are:
 
  1. Let |readableController| be
-    [=this=].\[[controlledTransformStream]].\[[readable]].\[[readableStreamController]].
+    [=this=].\[[controlledTransformStream]].\[[readable]].\[[controller]].
  1. Return ! [$ReadableStreamDefaultControllerGetDesiredSize$](|readableController|).
 </div>
 
@@ -5159,9 +5154,7 @@ are even meant to be generally useful by other specifications.
  <dfn abstract-op lt="TransformStreamError"
  id="transform-stream-error">TransformStreamError(|stream|, |e|)</dfn> performs the following steps:
 
- 1. Perform !
-    [$ReadableStreamDefaultControllerError$](|stream|.\[[readable]].\[[readableStreamController]],
-    |e|).
+ 1. Perform ! [$ReadableStreamDefaultControllerError$](|stream|.\[[readable]].\[[controller]], |e|).
  1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |e|).
 
  <p class="note">This operation works correctly when one or both sides are already errored. As a
@@ -5268,7 +5261,7 @@ The following abstract operations support the implementaiton of the
  It performs the following steps:
 
  1. Let |stream| be |controller|.\[[controlledTransformStream]].
- 1. Let |readableController| be |stream|.\[[readable]].\[[readableStreamController]].
+ 1. Let |readableController| be |stream|.\[[readable]].\[[controller]].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|readableController|) is false, throw
     a {{TypeError}} exception.
  1. Let |enqueueResult| be [$ReadableStreamDefaultControllerEnqueue$](|readableController|,
@@ -5320,7 +5313,7 @@ The following abstract operations support the implementaiton of the
  It performs the following steps:
 
  1. Let |stream| be |controller|.\[[controlledTransformStream]].
- 1. Let |readableController| be |stream|.\[[readable]].\[[readableStreamController]].
+ 1. Let |readableController| be |stream|.\[[readable]].\[[controller]].
  1. Perform ! [$ReadableStreamDefaultControllerClose$](|readableController|).
  1. Let |error| be a {{TypeError}} exception indicating that the stream has been terminated.
  1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |error|).
@@ -5372,7 +5365,7 @@ side=] of [=transform streams=].
  1. Return the result of [=reacting=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
    1. If |readable|.\[[state]] is "`errored`", throw |readable|.\[[storedError]].
-   1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.\[[readableStreamController]]).
+   1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.\[[controller]]).
   1. If |flushPromise| was rejected with reason |r|, then:
    1. Perform ! [$TransformStreamError$](|stream|, |r|).
    1. Throw |readable|.\[[storedError]].

--- a/index.bs
+++ b/index.bs
@@ -1401,9 +1401,6 @@ the following table:
    [=underlying source=], but still has [=chunks=] in its internal queue that have not yet been
    read
   <tr>
-   <td>\[[controlledReadableStream]]
-   <td class="non-normative">The {{ReadableStream}} instance controlled
-  <tr>
    <td>\[[pullAgain]]
    <td class="non-normative">A boolean flag set to true if the stream's mechanisms requested a call
    to the [=underlying source=]'s pull algorithm to pull more data, but the pull could not yet be
@@ -1437,6 +1434,9 @@ the following table:
    <td>\[[strategySizeAlgorithm]]
    <td class="non-normative">An algorithm to calculate the size of enqueued [=chunks=], as part of
    the stream's [=queuing strategy=]
+  <tr>
+   <td>\[[stream]]
+   <td class="non-normative">The {{ReadableStream}} instance controlled
 </table>
 
 <h4 id="rs-default-controller-prototype">Methods and properties</h4>
@@ -1519,7 +1519,7 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  id="rs-default-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
- 1. Let |stream| be [=this=].\[[controlledReadableStream]].
+ 1. Let |stream| be [=this=].\[[stream]].
  1. If [=this=].\[[queue]] is not [=list/is empty|empty=],
   1. Let |chunk| be ! [$DequeueValue$]([=this=]).
   1. If [=this=].\[[closeRequested]] is true and [=this=].\[[queue]] [=list/is empty=],
@@ -1585,9 +1585,6 @@ following table:
    [=underlying byte source=], but still has [=chunks=] in its internal queue that have not yet been
    read
   <tr>
-   <td>\[[controlledReadableStream]]
-   <td class="non-normative">The {{ReadableStream}} instance controlled
-  <tr>
    <td>\[[pullAgain]]
    <td class="non-normative">A boolean flag set to true if the stream's mechanisms requested a call
    to the [=underlying byte source=]'s pull algorithm to pull more data, but the pull could not yet
@@ -1621,6 +1618,9 @@ following table:
    <td class="non-normative">A number supplied to the constructor as part of the stream's [=queuing
    strategy=], indicating the point at which the stream will apply [=backpressure=] to its
    [=underlying byte source=]
+  <tr>
+   <td>\[[stream]]
+   <td class="non-normative">The {{ReadableStream}} instance controlled
 </table>
 
 <div class="note">
@@ -1732,8 +1732,7 @@ has the following [=struct/items=]:
  steps are:
 
  1. If [=this=].\[[closeRequested]] is true, throw a {{TypeError}} exception.
- 1. If [=this=].\[[controlledReadableStream]].\[[state]] is not "`readable`", throw a {{TypeError}}
-    exception.
+ 1. If [=this=].\[[stream]].\[[state]] is not "`readable`", throw a {{TypeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
 </div>
 
@@ -1745,8 +1744,7 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
  1. If |chunk|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
  1. If [=this=].\[[closeRequested]] is true, throw a {{TypeError}} exception.
- 1. If [=this=].\[[controlledReadableStream]].\[[state]] is not "`readable`", throw a {{TypeError}}
-    exception.
+ 1. If [=this=].\[[stream]].\[[state]] is not "`readable`", throw a {{TypeError}} exception.
  1. Return ! [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
 </div>
 
@@ -1782,7 +1780,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  id="rbs-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
- 1. Let |stream| be [=this=].\[[controlledReadableStream]].
+ 1. Let |stream| be [=this=].\[[stream]].
  1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
  1. If [=this=].\[[queueTotalSize]] > 0,
   1. Assert: ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0.
@@ -2539,7 +2537,7 @@ The following abstract operations support the implementation of the
  id="readable-stream-default-controller-should-call-pull">ReadableStreamDefaultControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return false.
  1. If |controller|.\[[started]] is false, return false.
  1. If ! [$IsReadableStreamLocked$](|stream|) is true and !
@@ -2580,7 +2578,7 @@ The following abstract operations support the implementation of the
  It performs the following steps:
 
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Set |controller|.\[[closeRequested]] to true.
  1. If |controller|.\[[queue]] [=list/is empty=],
   1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
@@ -2598,7 +2596,7 @@ The following abstract operations support the implementation of the
  It performs the following steps:
 
  1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If ! [$IsReadableStreamLocked$](|stream|) is true and !
     [$ReadableStreamGetNumReadRequests$](|stream|) > 0, perform !
     [$ReadableStreamFulfillReadRequest$](|stream|, |chunk|, false).
@@ -2626,7 +2624,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If |stream|.\[[state]] is not "`readable`", return.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
@@ -2644,7 +2642,7 @@ The following abstract operations support the implementation of the
 
  It performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
@@ -2665,7 +2663,7 @@ The following abstract operations support the implementation of the
  id="readable-stream-default-controller-can-close-or-enqueue">ReadableStreamDefaultControllerCanCloseOrEnqueue(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |state| be |controller|.\[[controlledReadableStream]].\[[state]].
+ 1. Let |state| be |controller|.\[[stream]].\[[state]].
  1. If |controller|.\[[closeRequested]] is false and |state| is "`readable`", return true.
  1. Otherwise, return false.
 
@@ -2684,7 +2682,7 @@ The following abstract operations support the implementation of the
  |sizeAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream|.\[[controller]] is undefined.
- 1. Set |controller|.\[[controlledReadableStream]] to |stream|.
+ 1. Set |controller|.\[[stream]] to |stream|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.\[[started]], |controller|.\[[closeRequested]], |controller|.\[[pullAgain]], and
     |controller|.\[[pulling]] to false.
@@ -2786,7 +2784,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-close">ReadableByteStreamControllerClose(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If |controller|.\[[closeRequested]] is true or |stream|.\[[state]] is not "`readable`", return.
  1. If |controller|.\[[queueTotalSize]] > 0,
   1. Set |controller|.\[[closeRequested]] to true.
@@ -2839,7 +2837,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-enqueue">ReadableByteStreamControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If |controller|.\[[closeRequested]] is true or |stream|.\[[state]] is not "`readable`", return.
  1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
  1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
@@ -2881,7 +2879,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-error">ReadableByteStreamControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If |stream|.\[[state]] is not "`readable`", return.
  1. Perform ! [$ReadableByteStreamControllerClearPendingPullIntos$](|controller|).
  1. Perform ! [$ResetQueue$](|controller|).
@@ -2955,7 +2953,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-get-desired-size">ReadableByteStreamControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`errored`", return null.
  1. If |state| is "`closed`", return 0.
@@ -2967,10 +2965,10 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-handle-queue-drain">ReadableByteStreamControllerHandleQueueDrain(|controller|)</dfn>
  performs the following steps:
 
- 1. Assert: |controller|.\[[controlledReadableStream]].\[[state]] is "`readable`".
+ 1. Assert: |controller|.\[[stream]].\[[state]] is "`readable`".
  1. If |controller|.\[[queueTotalSize]] is 0 and |controller|.\[[closeRequested]] is true,
   1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
-  1. Perform ! [$ReadableStreamClose$](|controller|.\[[controlledReadableStream]]).
+  1. Perform ! [$ReadableStreamClose$](|controller|.\[[stream]]).
  1. Otherwise,
   1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
 </div>
@@ -2998,8 +2996,7 @@ The following abstract operations support the implementation of the
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
      |pullIntoDescriptor|) is true,
    1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
-   1. Perform !
-      [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.\[[controlledReadableStream]],
+   1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.\[[stream]],
       |pullIntoDescriptor|).
 </div>
 
@@ -3008,7 +3005,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-pull-into">ReadableByteStreamControllerPullInto(|controller|,
  |view|, |readIntoRequest|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Let |elementSize| be 1.
  1. Let |ctor| be {{%DataView%}}.
  1. If |view| has a \[[TypedArrayName]] internal slot (i.e., it is not a {{DataView}}),
@@ -3068,7 +3065,7 @@ The following abstract operations support the implementation of the
  1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to !
     [$TransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Assert: |firstDescriptor|'s [=pull-into descriptor/bytes filled=] is 0.
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
   1. [=While=] ! [$ReadableStreamGetNumReadIntoRequests$](|stream|) > 0,
    1. Let |pullIntoDescriptor| be !
@@ -3102,8 +3099,7 @@ The following abstract operations support the implementation of the
     [$TransferArrayBuffer$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] − |remainderSize|.
- 1. Perform !
-    [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.\[[controlledReadableStream]],
+ 1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.\[[stream]],
     |pullIntoDescriptor|).
  1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
 </div>
@@ -3114,7 +3110,7 @@ The following abstract operations support the implementation of the
  |bytesWritten|)</dfn> performs the following steps:
 
  1. Let |firstDescriptor| be |controller|.\[[pendingPullIntos]][0].
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If |stream|.\[[state]] is "`closed`",
   1. If |bytesWritten| is not 0, throw a {{TypeError}} exception.
   1. Perform ! [$ReadableByteStreamControllerRespondInClosedState$](|controller|,
@@ -3157,7 +3153,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-should-call-pull">ReadableByteStreamControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledReadableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If |stream|.\[[state]] is not "`readable`", return false.
  1. If |controller|.\[[closeRequested]] is true, return false.
  1. If |controller|.\[[started]] is false, return false.
@@ -3181,7 +3177,7 @@ The following abstract operations support the implementation of the
  1. If |autoAllocateChunkSize| is not undefined,
   1. Assert: ! IsInteger(|autoAllocateChunkSize|) is true.
   1. Assert: |autoAllocateChunkSize| is positive.
- 1. Set |controller|.\[[controlledReadableStream]] to |stream|.
+ 1. Set |controller|.\[[stream]] to |stream|.
  1. Set |controller|.\[[pullAgain]] and |controller|.\[[pulling]] to false.
  1. Set |controller|.\[[byobRequest]] to null.
  1. Perform ! [$ResetQueue$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -3883,9 +3883,6 @@ the following table:
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=underlying sink=]
   <tr>
-   <td>\[[controlledWritableStream]]
-   <td class="non-normative">The {{WritableStream}} instance controlled
-  <tr>
    <td>\[[queue]]
    <td class="non-normative">A [=list=] representing the stream's internal queue of [=chunks=]
   <tr>
@@ -3905,6 +3902,9 @@ the following table:
    <td>\[[strategySizeAlgorithm]]
    <td class="non-normative">An algorithm to calculate the size of enqueued [=chunks=], as part of
     the stream's [=queuing strategy=]
+  <tr>
+   <td>\[[stream]]
+   <td class="non-normative">The {{WritableStream}} instance controlled
   <tr>
    <td>\[[writeAlgorithm]]
    <td class="non-normative">A promise-returning algorithm, taking one argument (the [=chunk=] to
@@ -3933,7 +3933,7 @@ developers.
  The <dfn id="ws-default-controller-error" method
  for="WritableStreamDefaultController">error(|e|)</dfn> method steps are:
 
- 1. Let |state| be [=this=].\[[controlledWritableStream]].\[[state]].
+ 1. Let |state| be [=this=].\[[stream]].\[[state]].
  1. If |state| is not "`writable`", return.
  1. Perform ! [$WritableStreamDefaultControllerError$]([=this=], |e|).
 </div>
@@ -4476,7 +4476,7 @@ The following abstract operations support the implementation of the
 
  1. Assert: |stream| [=implements=] {{WritableStream}}.
  1. Assert: |stream|.\[[controller]] is undefined.
- 1. Set |controller|.\[[controlledWritableStream]] to |stream|.
+ 1. Set |controller|.\[[stream]] to |stream|.
  1. Set |stream|.\[[controller]] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
  1. Set |controller|.\[[started]] to false.
@@ -4535,7 +4535,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-advance-queue-if-needed">WritableStreamDefaultControllerAdvanceQueueIfNeeded(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledWritableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If |controller|.\[[started]] is false, return.
  1. If |stream|.\[[inFlightWriteRequest]] is not undefined, return.
  1. Let |state| be |stream|.\[[state]].
@@ -4588,7 +4588,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-error">WritableStreamDefaultControllerError(|controller|,
  |error|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledWritableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Assert: |stream|.\[[state]] is `"writable"`.
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Perform ! [$WritableStreamStartErroring$](|stream|, |error|).
@@ -4599,7 +4599,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-error-if-needed">WritableStreamDefaultControllerErrorIfNeeded(|controller|,
  |error|)</dfn> performs the following steps:
 
- 1. If |controller|.\[[controlledWritableStream]].\[[state]] is "`writable`", perform !
+ 1. If |controller|.\[[stream]].\[[state]] is "`writable`", perform !
     [$WritableStreamDefaultControllerError$](|controller|, |error|).
 </div>
 
@@ -4639,7 +4639,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-process-close">WritableStreamDefaultControllerProcessClose(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledWritableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Perform ! [$WritableStreamMarkCloseRequestInFlight$](|stream|).
  1. Perform ! [$DequeueValue$](|controller|).
  1. Assert: |controller|.\[[queue]] is empty.
@@ -4656,7 +4656,7 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-process-write">WritableStreamDefaultControllerProcessWrite(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Let |stream| be |controller|.\[[controlledWritableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. Perform ! [$WritableStreamMarkFirstWriteRequestInFlight$](|stream|).
  1. Let |sinkWritePromise| be the result of performing |controller|.\[[writeAlgorithm]], passing in
     |chunk|.
@@ -4685,7 +4685,7 @@ The following abstract operations support the implementation of the
   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|,
      |enqueueResult|.\[[Value]]).
   1. Return.
- 1. Let |stream| be |controller|.\[[controlledWritableStream]].
+ 1. Let |stream| be |controller|.\[[stream]].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |stream|.\[[state]] is
     "`writable`",
   1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -3699,12 +3699,12 @@ following table:
    <td class="non-normative">A promise returned by the writer's
    {{WritableStreamDefaultWriter/closed}} getter
   <tr>
-   <td>\[[ownerWritableStream]]
-   <td class="non-normative">A {{WritableStream}} instance that owns this reader
-  <tr>
    <td>\[[readyPromise]]
    <td class="non-normative">A promise returned by the writer's
    {{WritableStreamDefaultWriter/ready}} getter
+  <tr>
+   <td>\[[stream]]
+   <td class="non-normative">A {{WritableStream}} instance that owns this reader
 </table>
 
 <h4 id="default-writer-prototype">Constructor, methods, and properties</h4>
@@ -3796,7 +3796,7 @@ following table:
  The <dfn id="default-writer-desired-size" attribute
  for="WritableStreamDefaultWriter">desiredSize</dfn> getter steps are:
 
- 1. If [=this=].\[[ownerWritableStream]] is undefined, throw a {{TypeError}} exception.
+ 1. If [=this=].\[[stream]] is undefined, throw a {{TypeError}} exception.
  1. Return ! [$WritableStreamDefaultWriterGetDesiredSize$]([=this=]).
 </div>
 
@@ -3811,8 +3811,8 @@ following table:
  The <dfn id="default-writer-abort" method for="WritableStreamDefaultWriter">abort(|reason|)</dfn>
  method steps are:
 
- 1. If [=this=].\[[ownerWritableStream]] is undefined, return [=a promise rejected with=] a
-    {{TypeError}} exception.
+ 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+    exception.
  1. Return ! [$WritableStreamDefaultWriterAbort$]([=this=], |reason|).
 </div>
 
@@ -3820,7 +3820,7 @@ following table:
  The <dfn id="default-writer-close" method for="WritableStreamDefaultWriter">close()</dfn> method
  steps are:
 
- 1. Let |stream| be [=this=].\[[ownerWritableStream]].
+ 1. Let |stream| be [=this=].\[[stream]].
  1. If |stream| is undefined, return [=a promise rejected with=] a {{TypeError}} exception.
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true, return [=a promise rejected
     with=] a {{TypeError}} exception.
@@ -3831,7 +3831,7 @@ following table:
  The <dfn id="default-writer-release-lock" method
  for="WritableStreamDefaultWriter">releaseLock()</dfn> method steps are:
 
- 1. Let |stream| be [=this=].\[[ownerWritableStream]].
+ 1. Let |stream| be [=this=].\[[stream]].
  1. If |stream| is undefined, return.
  1. Assert: |stream|.\[[writer]] is not undefined.
  1. Perform ! [$WritableStreamDefaultWriterRelease$]([=this=]).
@@ -3841,8 +3841,8 @@ following table:
  The <dfn id="default-writer-write" method for="WritableStreamDefaultWriter">write(|chunk|)</dfn>
  method steps are:
 
- 1. If [=this=].\[[ownerWritableStream]] is undefined, return [=a promise rejected with=] a
-    {{TypeError}} exception.
+ 1. If [=this=].\[[stream]] is undefined, return [=a promise rejected with=] a {{TypeError}}
+    exception.
  1. Return ! [$WritableStreamDefaultWriterWrite$]([=this=], |chunk|).
 </div>
 
@@ -4042,7 +4042,7 @@ are even meant to be generally useful by other specifications.
  |stream|)</dfn> performs the following steps:
 
  1. If ! [$IsWritableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
- 1. Set |writer|.\[[ownerWritableStream]] to |stream|.
+ 1. Set |writer|.\[[stream]] to |stream|.
  1. Set |stream|.\[[writer]] to |writer|.
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`writable`",
@@ -4357,7 +4357,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-abort">WritableStreamDefaultWriterAbort(|writer|,
  |reason|)</dfn> performs the following steps:
 
- 1. Let |stream| be |writer|.\[[ownerWritableStream]].
+ 1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Return ! [$WritableStreamAbort$](|stream|, |reason|).
 </div>
@@ -4367,7 +4367,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-close">WritableStreamDefaultWriterClose(|writer|)</dfn> performs
  the following steps:
 
- 1. Let |stream| be |writer|.\[[ownerWritableStream]].
+ 1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Return ! [$WritableStreamClose$](|stream|).
 </div>
@@ -4377,7 +4377,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-close-with-error-propagation">WritableStreamDefaultWriterCloseWithErrorPropagation(|writer|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[ownerWritableStream]].
+ 1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Let |state| be |stream|.\[[state]].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
@@ -4417,7 +4417,7 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-get-desired-size">WritableStreamDefaultWriterGetDesiredSize(|writer|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[ownerWritableStream]].
+ 1. Let |stream| be |writer|.\[[stream]].
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`errored"` or `"erroring`", return null.
  1. If |state| is "`closed`", return 0.
@@ -4429,14 +4429,14 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-release">WritableStreamDefaultWriterRelease(|writer|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[ownerWritableStream]].
+ 1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Assert: |stream|.\[[writer]] is |writer|.
  1. Let |releasedError| be a new {{TypeError}}.
  1. Perform ! [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |releasedError|).
  1. Perform ! [$WritableStreamDefaultWriterEnsureClosedPromiseRejected$](|writer|, |releasedError|).
  1. Set |stream|.\[[writer]] to undefined.
- 1. Set |writer|.\[[ownerWritableStream]] to undefined.
+ 1. Set |writer|.\[[stream]] to undefined.
 </div>
 
 <div algorithm>
@@ -4444,12 +4444,12 @@ The following abstract operations support the implementation and manipulation of
  id="writable-stream-default-writer-write">WritableStreamDefaultWriterWrite(|writer|, |chunk|)</dfn>
  performs the following steps:
 
- 1. Let |stream| be |writer|.\[[ownerWritableStream]].
+ 1. Let |stream| be |writer|.\[[stream]].
  1. Assert: |stream| is not undefined.
  1. Let |controller| be |stream|.\[[controller]].
  1. Let |chunkSize| be ! [$WritableStreamDefaultControllerGetChunkSize$](|controller|, |chunk|).
- 1. If |stream| is not equal to |writer|.\[[ownerWritableStream]], return [=a promise rejected
-    with=] a {{TypeError}} exception.
+ 1. If |stream| is not equal to |writer|.\[[stream]], return [=a promise rejected with=] a
+    {{TypeError}} exception.
  1. Let |state| be |stream|.\[[state]].
  1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.\[[storedError]].
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -33,7 +33,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
       throw new TypeError('The stream has already been closed; do not close it again!');
     }
 
-    const state = this._controlledReadableStream._state;
+    const state = this._stream._state;
     if (state !== 'readable') {
       throw new TypeError(`The stream (in ${state} state) is not in the readable state and cannot be closed`);
     }
@@ -53,7 +53,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
       throw new TypeError('stream is closed or draining');
     }
 
-    const state = this._controlledReadableStream._state;
+    const state = this._stream._state;
     if (state !== 'readable') {
       throw new TypeError(`The stream (in ${state} state) is not in the readable state and cannot be enqueued to`);
     }
@@ -79,7 +79,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
   }
 
   [PullSteps](readRequest) {
-    const stream = this._controlledReadableStream;
+    const stream = this._stream;
     assert(aos.ReadableStreamHasDefaultReader(stream) === true);
 
     if (this._queueTotalSize > 0) {

--- a/reference-implementation/lib/ReadableStream-impl.js
+++ b/reference-implementation/lib/ReadableStream-impl.js
@@ -119,7 +119,7 @@ exports.implementation = class ReadableStreamImpl {
 
   [idlUtils.asyncIteratorNext](iterator) {
     const reader = iterator._reader;
-    if (reader._ownerReadableStream === undefined) {
+    if (reader._stream === undefined) {
       return promiseRejectedWith(
         new TypeError('Cannot get the next iteration result once the reader has been released')
       );
@@ -143,7 +143,7 @@ exports.implementation = class ReadableStreamImpl {
 
   [idlUtils.asyncIteratorReturn](iterator, arg) {
     const reader = iterator._reader;
-    if (reader._ownerReadableStream === undefined) {
+    if (reader._stream === undefined) {
       return promiseResolvedWith(undefined);
     }
 

--- a/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
@@ -13,7 +13,7 @@ exports.implementation = class ReadableStreamBYOBReaderImpl {
   }
 
   cancel(reason) {
-    if (this._ownerReadableStream === undefined) {
+    if (this._stream === undefined) {
       return promiseRejectedWith(readerLockException('cancel'));
     }
 
@@ -28,7 +28,7 @@ exports.implementation = class ReadableStreamBYOBReaderImpl {
       return promiseRejectedWith(new TypeError('view\'s buffer must have non-zero byteLength'));
     }
 
-    if (this._ownerReadableStream === undefined) {
+    if (this._stream === undefined) {
       return promiseRejectedWith(readerLockException('read'));
     }
 
@@ -43,7 +43,7 @@ exports.implementation = class ReadableStreamBYOBReaderImpl {
   }
 
   releaseLock() {
-    if (this._ownerReadableStream === undefined) {
+    if (this._stream === undefined) {
       return;
     }
 

--- a/reference-implementation/lib/ReadableStreamDefaultController-impl.js
+++ b/reference-implementation/lib/ReadableStreamDefaultController-impl.js
@@ -37,7 +37,7 @@ exports.implementation = class ReadableStreamDefaultControllerImpl {
   }
 
   [PullSteps](readRequest) {
-    const stream = this._controlledReadableStream;
+    const stream = this._stream;
 
     if (this._queue.length > 0) {
       const chunk = DequeueValue(this);

--- a/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
@@ -13,7 +13,7 @@ exports.implementation = class ReadableStreamDefaultReaderImpl {
   }
 
   cancel(reason) {
-    if (this._ownerReadableStream === undefined) {
+    if (this._stream === undefined) {
       return promiseRejectedWith(readerLockException('cancel'));
     }
 
@@ -21,7 +21,7 @@ exports.implementation = class ReadableStreamDefaultReaderImpl {
   }
 
   read() {
-    if (this._ownerReadableStream === undefined) {
+    if (this._stream === undefined) {
       return promiseRejectedWith(readerLockException('read from'));
     }
 
@@ -37,7 +37,7 @@ exports.implementation = class ReadableStreamDefaultReaderImpl {
   }
 
   releaseLock() {
-    if (this._ownerReadableStream === undefined) {
+    if (this._stream === undefined) {
       return;
     }
 

--- a/reference-implementation/lib/TransformStream-impl.js
+++ b/reference-implementation/lib/TransformStream-impl.js
@@ -32,7 +32,7 @@ exports.implementation = class TransformStreamImpl {
     aos.SetUpTransformStreamDefaultControllerFromTransformer(this, transformer, transformerDict);
 
     if ('start' in transformerDict) {
-      resolvePromise(startPromise, transformerDict.start.call(transformer, this._transformStreamController));
+      resolvePromise(startPromise, transformerDict.start.call(transformer, this._controller));
     } else {
       resolvePromise(startPromise, undefined);
     }

--- a/reference-implementation/lib/TransformStreamDefaultController-impl.js
+++ b/reference-implementation/lib/TransformStreamDefaultController-impl.js
@@ -5,7 +5,7 @@ const rsAOs = require('./abstract-ops/readable-streams.js');
 
 exports.implementation = class TransformStreamDefaultController {
   get desiredSize() {
-    const readableController = this._controlledTransformStream._readable._readableStreamController;
+    const readableController = this._controlledTransformStream._readable._controller;
     return rsAOs.ReadableStreamDefaultControllerGetDesiredSize(readableController);
   }
 

--- a/reference-implementation/lib/TransformStreamDefaultController-impl.js
+++ b/reference-implementation/lib/TransformStreamDefaultController-impl.js
@@ -5,7 +5,7 @@ const rsAOs = require('./abstract-ops/readable-streams.js');
 
 exports.implementation = class TransformStreamDefaultController {
   get desiredSize() {
-    const readableController = this._controlledTransformStream._readable._controller;
+    const readableController = this._stream._readable._controller;
     return rsAOs.ReadableStreamDefaultControllerGetDesiredSize(readableController);
   }
 

--- a/reference-implementation/lib/WritableStreamDefaultController-impl.js
+++ b/reference-implementation/lib/WritableStreamDefaultController-impl.js
@@ -6,7 +6,7 @@ const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
 
 exports.implementation = class WritableStreamDefaultControllerImpl {
   error(e) {
-    const state = this._controlledWritableStream._state;
+    const state = this._stream._state;
 
     if (state !== 'writable') {
       // The stream is closed, errored or will be soon. The sink can't do anything useful if it gets an error here, so

--- a/reference-implementation/lib/WritableStreamDefaultWriter-impl.js
+++ b/reference-implementation/lib/WritableStreamDefaultWriter-impl.js
@@ -14,7 +14,7 @@ exports.implementation = class WritableStreamDefaultWriterImpl {
   }
 
   get desiredSize() {
-    if (this._ownerWritableStream === undefined) {
+    if (this._stream === undefined) {
       throw defaultWriterLockException('desiredSize');
     }
 
@@ -26,7 +26,7 @@ exports.implementation = class WritableStreamDefaultWriterImpl {
   }
 
   abort(reason) {
-    if (this._ownerWritableStream === undefined) {
+    if (this._stream === undefined) {
       return promiseRejectedWith(defaultWriterLockException('abort'));
     }
 
@@ -34,7 +34,7 @@ exports.implementation = class WritableStreamDefaultWriterImpl {
   }
 
   close() {
-    const stream = this._ownerWritableStream;
+    const stream = this._stream;
 
     if (stream === undefined) {
       return promiseRejectedWith(defaultWriterLockException('close'));
@@ -48,7 +48,7 @@ exports.implementation = class WritableStreamDefaultWriterImpl {
   }
 
   releaseLock() {
-    const stream = this._ownerWritableStream;
+    const stream = this._stream;
 
     if (stream === undefined) {
       return;
@@ -60,7 +60,7 @@ exports.implementation = class WritableStreamDefaultWriterImpl {
   }
 
   write(chunk) {
-    if (this._ownerWritableStream === undefined) {
+    if (this._stream === undefined) {
       return promiseRejectedWith(defaultWriterLockException('write to'));
     }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -789,8 +789,7 @@ function ReadableStreamDefaultControllerError(controller, e) {
 }
 
 function ReadableStreamDefaultControllerGetDesiredSize(controller) {
-  const stream = controller._stream;
-  const state = stream._state;
+  const state = controller._stream._state;
 
   if (state === 'errored') {
     return null;
@@ -1094,8 +1093,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
 }
 
 function ReadableByteStreamControllerGetDesiredSize(controller) {
-  const stream = controller._stream;
-  const state = stream._state;
+  const state = controller._stream._state;
 
   if (state === 'errored') {
     return null;
@@ -1263,16 +1261,16 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
 function ReadableByteStreamControllerRespondInternal(controller, bytesWritten) {
   const firstDescriptor = controller._pendingPullIntos[0];
 
-  const stream = controller._stream;
+  const state = controller._stream._state;
 
-  if (stream._state === 'closed') {
+  if (state === 'closed') {
     if (bytesWritten !== 0) {
       throw new TypeError('bytesWritten must be 0 when calling respond() on a closed stream');
     }
 
     ReadableByteStreamControllerRespondInClosedState(controller, firstDescriptor);
   } else {
-    assert(stream._state === 'readable');
+    assert(state === 'readable');
 
     ReadableByteStreamControllerRespondInReadableState(controller, bytesWritten, firstDescriptor);
   }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -702,7 +702,7 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller) {
 }
 
 function ReadableStreamDefaultControllerShouldCallPull(controller) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) === false) {
     return false;
@@ -736,7 +736,7 @@ function ReadableStreamDefaultControllerClose(controller) {
     return;
   }
 
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   controller._closeRequested = true;
 
@@ -751,7 +751,7 @@ function ReadableStreamDefaultControllerEnqueue(controller, chunk) {
     return;
   }
 
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (IsReadableStreamLocked(stream) === true && ReadableStreamGetNumReadRequests(stream) > 0) {
     ReadableStreamFulfillReadRequest(stream, chunk, false);
@@ -776,7 +776,7 @@ function ReadableStreamDefaultControllerEnqueue(controller, chunk) {
 }
 
 function ReadableStreamDefaultControllerError(controller, e) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (stream._state !== 'readable') {
     return;
@@ -789,7 +789,7 @@ function ReadableStreamDefaultControllerError(controller, e) {
 }
 
 function ReadableStreamDefaultControllerGetDesiredSize(controller) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
   const state = stream._state;
 
   if (state === 'errored') {
@@ -811,7 +811,7 @@ function ReadableStreamDefaultControllerHasBackpressure(controller) {
 }
 
 function ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) {
-  const state = controller._controlledReadableStream._state;
+  const state = controller._stream._state;
 
   if (controller._closeRequested === false && state === 'readable') {
     return true;
@@ -824,7 +824,7 @@ function SetUpReadableStreamDefaultController(
   stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, sizeAlgorithm) {
   assert(stream._controller === undefined);
 
-  controller._controlledReadableStream = stream;
+  controller._stream = stream;
 
   // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
   controller._queue = undefined;
@@ -930,7 +930,7 @@ function ReadableByteStreamControllerClearPendingPullIntos(controller) {
 }
 
 function ReadableByteStreamControllerClose(controller) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (controller._closeRequested === true || stream._state !== 'readable') {
     return;
@@ -986,7 +986,7 @@ function ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescripto
 }
 
 function ReadableByteStreamControllerEnqueue(controller, chunk) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (controller._closeRequested === true || stream._state !== 'readable') {
     return;
@@ -1024,7 +1024,7 @@ function ReadableByteStreamControllerEnqueueChunkToQueue(controller, buffer, byt
 }
 
 function ReadableByteStreamControllerError(controller, e) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (stream._state !== 'readable') {
     return;
@@ -1094,7 +1094,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
 }
 
 function ReadableByteStreamControllerGetDesiredSize(controller) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
   const state = stream._state;
 
   if (state === 'errored') {
@@ -1108,11 +1108,11 @@ function ReadableByteStreamControllerGetDesiredSize(controller) {
 }
 
 function ReadableByteStreamControllerHandleQueueDrain(controller) {
-  assert(controller._controlledReadableStream._state === 'readable');
+  assert(controller._stream._state === 'readable');
 
   if (controller._queueTotalSize === 0 && controller._closeRequested === true) {
     ReadableByteStreamControllerClearAlgorithms(controller);
-    ReadableStreamClose(controller._controlledReadableStream);
+    ReadableStreamClose(controller._stream);
   } else {
     ReadableByteStreamControllerCallPullIfNeeded(controller);
   }
@@ -1142,7 +1142,7 @@ function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(contro
       ReadableByteStreamControllerShiftPendingPullInto(controller);
 
       ReadableByteStreamControllerCommitPullIntoDescriptor(
-        controller._controlledReadableStream,
+        controller._stream,
         pullIntoDescriptor
       );
     }
@@ -1150,7 +1150,7 @@ function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(contro
 }
 
 function ReadableByteStreamControllerPullInto(controller, view, readIntoRequest) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   let elementSize = 1;
   if (view.constructor !== DataView) {
@@ -1223,7 +1223,7 @@ function ReadableByteStreamControllerRespondInClosedState(controller, firstDescr
 
   assert(firstDescriptor.bytesFilled === 0);
 
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
   if (ReadableStreamHasBYOBReader(stream) === true) {
     while (ReadableStreamGetNumReadIntoRequests(stream) > 0) {
       const pullIntoDescriptor = ReadableByteStreamControllerShiftPendingPullInto(controller);
@@ -1255,7 +1255,7 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
 
   pullIntoDescriptor.buffer = TransferArrayBuffer(pullIntoDescriptor.buffer);
   pullIntoDescriptor.bytesFilled -= remainderSize;
-  ReadableByteStreamControllerCommitPullIntoDescriptor(controller._controlledReadableStream, pullIntoDescriptor);
+  ReadableByteStreamControllerCommitPullIntoDescriptor(controller._stream, pullIntoDescriptor);
 
   ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
 }
@@ -1263,7 +1263,7 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
 function ReadableByteStreamControllerRespondInternal(controller, bytesWritten) {
   const firstDescriptor = controller._pendingPullIntos[0];
 
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (stream._state === 'closed') {
     if (bytesWritten !== 0) {
@@ -1304,7 +1304,7 @@ function ReadableByteStreamControllerShiftPendingPullInto(controller) {
 }
 
 function ReadableByteStreamControllerShouldCallPull(controller) {
-  const stream = controller._controlledReadableStream;
+  const stream = controller._stream;
 
   if (stream._state !== 'readable') {
     return false;
@@ -1343,7 +1343,7 @@ function SetUpReadableByteStreamController(stream, controller, startAlgorithm, p
     assert(autoAllocateChunkSize > 0);
   }
 
-  controller._controlledReadableStream = stream;
+  controller._stream = stream;
 
   controller._pullAgain = false;
   controller._pulling = false;

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -360,21 +360,21 @@ function ReadableStreamTee(stream, cloneForBranch2) {
           // }
 
           if (canceled1 === false) {
-            ReadableStreamDefaultControllerEnqueue(branch1._readableStreamController, value1);
+            ReadableStreamDefaultControllerEnqueue(branch1._controller, value1);
           }
 
           if (canceled2 === false) {
-            ReadableStreamDefaultControllerEnqueue(branch2._readableStreamController, value2);
+            ReadableStreamDefaultControllerEnqueue(branch2._controller, value2);
           }
         });
       },
       closeSteps: () => {
         reading = false;
         if (canceled1 === false) {
-          ReadableStreamDefaultControllerClose(branch1._readableStreamController);
+          ReadableStreamDefaultControllerClose(branch1._controller);
         }
         if (canceled2 === false) {
-          ReadableStreamDefaultControllerClose(branch2._readableStreamController);
+          ReadableStreamDefaultControllerClose(branch2._controller);
         }
       },
       errorSteps: () => {
@@ -414,8 +414,8 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   branch2 = CreateReadableStream(startAlgorithm, pullAlgorithm, cancel2Algorithm);
 
   uponRejection(reader._closedPromise, r => {
-    ReadableStreamDefaultControllerError(branch1._readableStreamController, r);
-    ReadableStreamDefaultControllerError(branch2._readableStreamController, r);
+    ReadableStreamDefaultControllerError(branch1._controller, r);
+    ReadableStreamDefaultControllerError(branch2._controller, r);
   });
 
   return [branch1, branch2];
@@ -449,7 +449,7 @@ function ReadableStreamCancel(stream, reason) {
 
   ReadableStreamClose(stream);
 
-  const sourceCancelPromise = stream._readableStreamController[CancelSteps](reason);
+  const sourceCancelPromise = stream._controller[CancelSteps](reason);
   return transformPromiseWith(sourceCancelPromise, () => undefined);
 }
 
@@ -622,7 +622,7 @@ function ReadableStreamBYOBReaderRead(reader, view, readIntoRequest) {
   if (stream._state === 'errored') {
     readIntoRequest.errorSteps(stream._storedError);
   } else {
-    ReadableByteStreamControllerPullInto(stream._readableStreamController, view, readIntoRequest);
+    ReadableByteStreamControllerPullInto(stream._controller, view, readIntoRequest);
   }
 }
 
@@ -639,7 +639,7 @@ function ReadableStreamDefaultReaderRead(reader, readRequest) {
     readRequest.errorSteps(stream._storedError);
   } else {
     assert(stream._state === 'readable');
-    stream._readableStreamController[PullSteps](readRequest);
+    stream._controller[PullSteps](readRequest);
   }
 }
 
@@ -648,7 +648,7 @@ function SetUpReadableStreamBYOBReader(reader, stream) {
     throw new TypeError('This stream has already been locked for exclusive reading by another reader');
   }
 
-  if (!ReadableByteStreamController.isImpl(stream._readableStreamController)) {
+  if (!ReadableByteStreamController.isImpl(stream._controller)) {
     throw new TypeError('Cannot construct a ReadableStreamBYOBReader for a stream not constructed with a byte source');
   }
 
@@ -822,7 +822,7 @@ function ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) {
 
 function SetUpReadableStreamDefaultController(
   stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, sizeAlgorithm) {
-  assert(stream._readableStreamController === undefined);
+  assert(stream._controller === undefined);
 
   controller._controlledReadableStream = stream;
 
@@ -842,7 +842,7 @@ function SetUpReadableStreamDefaultController(
   controller._pullAlgorithm = pullAlgorithm;
   controller._cancelAlgorithm = cancelAlgorithm;
 
-  stream._readableStreamController = controller;
+  stream._controller = controller;
 
   const startResult = startAlgorithm();
   uponPromise(
@@ -1337,7 +1337,7 @@ function ReadableByteStreamControllerShouldCallPull(controller) {
 
 function SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm,
                                            highWaterMark, autoAllocateChunkSize) {
-  assert(stream._readableStreamController === undefined);
+  assert(stream._controller === undefined);
   if (autoAllocateChunkSize !== undefined) {
     assert(Number.isInteger(autoAllocateChunkSize) === true);
     assert(autoAllocateChunkSize > 0);
@@ -1366,7 +1366,7 @@ function SetUpReadableByteStreamController(stream, controller, startAlgorithm, p
 
   controller._pendingPullIntos = [];
 
-  stream._readableStreamController = controller;
+  stream._controller = controller;
 
   const startResult = startAlgorithm();
   uponPromise(

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -571,13 +571,13 @@ function ReadableStreamHasDefaultReader(stream) {
 // Readers
 
 function ReadableStreamReaderGenericCancel(reader, reason) {
-  const stream = reader._ownerReadableStream;
+  const stream = reader._stream;
   assert(stream !== undefined);
   return ReadableStreamCancel(stream, reason);
 }
 
 function ReadableStreamReaderGenericInitialize(reader, stream) {
-  reader._ownerReadableStream = stream;
+  reader._stream = stream;
   stream._reader = reader;
 
   if (stream._state === 'readable') {
@@ -593,10 +593,10 @@ function ReadableStreamReaderGenericInitialize(reader, stream) {
 }
 
 function ReadableStreamReaderGenericRelease(reader) {
-  assert(reader._ownerReadableStream !== undefined);
-  assert(reader._ownerReadableStream._reader === reader);
+  assert(reader._stream !== undefined);
+  assert(reader._stream._reader === reader);
 
-  if (reader._ownerReadableStream._state === 'readable') {
+  if (reader._stream._state === 'readable') {
     rejectPromise(
       reader._closedPromise,
       new TypeError('Reader was released and can no longer be used to monitor the stream\'s closedness')
@@ -608,12 +608,12 @@ function ReadableStreamReaderGenericRelease(reader) {
   }
   setPromiseIsHandledToTrue(reader._closedPromise);
 
-  reader._ownerReadableStream._reader = undefined;
-  reader._ownerReadableStream = undefined;
+  reader._stream._reader = undefined;
+  reader._stream = undefined;
 }
 
 function ReadableStreamBYOBReaderRead(reader, view, readIntoRequest) {
-  const stream = reader._ownerReadableStream;
+  const stream = reader._stream;
 
   assert(stream !== undefined);
 
@@ -627,7 +627,7 @@ function ReadableStreamBYOBReaderRead(reader, view, readIntoRequest) {
 }
 
 function ReadableStreamDefaultReaderRead(reader, readRequest) {
-  const stream = reader._ownerReadableStream;
+  const stream = reader._stream;
 
   assert(stream !== undefined);
 

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -76,7 +76,7 @@ function TransformStreamError(stream, e) {
 
 function TransformStreamErrorWritableAndUnblockWrite(stream, e) {
   TransformStreamDefaultControllerClearAlgorithms(stream._transformStreamController);
-  WritableStreamDefaultControllerErrorIfNeeded(stream._writable._writableStreamController, e);
+  WritableStreamDefaultControllerErrorIfNeeded(stream._writable._controller, e);
   if (stream._backpressure === true) {
     // Pretend that pull() was called to permit any pending write() calls to complete. TransformStreamSetBackpressure()
     // cannot be called from enqueue() or pull() once the ReadableStream is errored, so this will will be the final time

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -70,7 +70,7 @@ function InitializeTransformStream(
 function TransformStreamError(stream, e) {
   verbose('TransformStreamError()');
 
-  ReadableStreamDefaultControllerError(stream._readable._readableStreamController, e);
+  ReadableStreamDefaultControllerError(stream._readable._controller, e);
   TransformStreamErrorWritableAndUnblockWrite(stream, e);
 }
 
@@ -146,7 +146,7 @@ function TransformStreamDefaultControllerEnqueue(controller, chunk) {
   verbose('TransformStreamDefaultControllerEnqueue()');
 
   const stream = controller._controlledTransformStream;
-  const readableController = stream._readable._readableStreamController;
+  const readableController = stream._readable._controller;
   if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === false) {
     throw new TypeError('Readable side is not in a state that permits enqueue');
   }
@@ -186,7 +186,7 @@ function TransformStreamDefaultControllerTerminate(controller) {
   verbose('TransformStreamDefaultControllerTerminate()');
 
   const stream = controller._controlledTransformStream;
-  const readableController = stream._readable._readableStreamController;
+  const readableController = stream._readable._controller;
 
   ReadableStreamDefaultControllerClose(readableController);
 
@@ -242,7 +242,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
     if (readable._state === 'errored') {
       throw readable._storedError;
     }
-    ReadableStreamDefaultControllerClose(readable._readableStreamController);
+    ReadableStreamDefaultControllerClose(readable._controller);
   }, r => {
     TransformStreamError(stream, r);
     throw readable._storedError;

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -64,7 +64,7 @@ function InitializeTransformStream(
   stream._backpressureChangePromise = undefined;
   TransformStreamSetBackpressure(stream, true);
 
-  stream._transformStreamController = undefined;
+  stream._controller = undefined;
 }
 
 function TransformStreamError(stream, e) {
@@ -75,7 +75,7 @@ function TransformStreamError(stream, e) {
 }
 
 function TransformStreamErrorWritableAndUnblockWrite(stream, e) {
-  TransformStreamDefaultControllerClearAlgorithms(stream._transformStreamController);
+  TransformStreamDefaultControllerClearAlgorithms(stream._controller);
   WritableStreamDefaultControllerErrorIfNeeded(stream._writable._controller, e);
   if (stream._backpressure === true) {
     // Pretend that pull() was called to permit any pending write() calls to complete. TransformStreamSetBackpressure()
@@ -104,10 +104,10 @@ function TransformStreamSetBackpressure(stream, backpressure) {
 
 function SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm) {
   assert(TransformStream.isImpl(stream));
-  assert(stream._transformStreamController === undefined);
+  assert(stream._controller === undefined);
 
-  controller._controlledTransformStream = stream;
-  stream._transformStreamController = controller;
+  controller._stream = stream;
+  stream._controller = controller;
 
   controller._transformAlgorithm = transformAlgorithm;
   controller._flushAlgorithm = flushAlgorithm;
@@ -145,7 +145,7 @@ function TransformStreamDefaultControllerClearAlgorithms(controller) {
 function TransformStreamDefaultControllerEnqueue(controller, chunk) {
   verbose('TransformStreamDefaultControllerEnqueue()');
 
-  const stream = controller._controlledTransformStream;
+  const stream = controller._stream;
   const readableController = stream._readable._controller;
   if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === false) {
     throw new TypeError('Readable side is not in a state that permits enqueue');
@@ -171,13 +171,13 @@ function TransformStreamDefaultControllerEnqueue(controller, chunk) {
 }
 
 function TransformStreamDefaultControllerError(controller, e) {
-  TransformStreamError(controller._controlledTransformStream, e);
+  TransformStreamError(controller._stream, e);
 }
 
 function TransformStreamDefaultControllerPerformTransform(controller, chunk) {
   const transformPromise = controller._transformAlgorithm(chunk);
   return transformPromiseWith(transformPromise, undefined, r => {
-    TransformStreamError(controller._controlledTransformStream, r);
+    TransformStreamError(controller._stream, r);
     throw r;
   });
 }
@@ -185,7 +185,7 @@ function TransformStreamDefaultControllerPerformTransform(controller, chunk) {
 function TransformStreamDefaultControllerTerminate(controller) {
   verbose('TransformStreamDefaultControllerTerminate()');
 
-  const stream = controller._controlledTransformStream;
+  const stream = controller._stream;
   const readableController = stream._readable._controller;
 
   ReadableStreamDefaultControllerClose(readableController);
@@ -201,7 +201,7 @@ function TransformStreamDefaultSinkWriteAlgorithm(stream, chunk) {
 
   assert(stream._writable._state === 'writable');
 
-  const controller = stream._transformStreamController;
+  const controller = stream._controller;
 
   if (stream._backpressure === true) {
     const backpressureChangePromise = stream._backpressureChangePromise;
@@ -233,7 +233,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
   // stream._readable cannot change after construction, so caching it across a call to user code is safe.
   const readable = stream._readable;
 
-  const controller = stream._transformStreamController;
+  const controller = stream._controller;
   const flushPromise = controller._flushAlgorithm();
   TransformStreamDefaultControllerClearAlgorithms(controller);
 

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -529,7 +529,7 @@ function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm
   assert(WritableStream.isImpl(stream));
   assert(stream._controller === undefined);
 
-  controller._controlledWritableStream = stream;
+  controller._stream = stream;
   stream._controller = controller;
 
   // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
@@ -595,7 +595,7 @@ function SetUpWritableStreamDefaultControllerFromUnderlyingSink(stream, underlyi
 
 function WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller) {
   verbose('WritableStreamDefaultControllerAdvanceQueueIfNeeded()');
-  const stream = controller._controlledWritableStream;
+  const stream = controller._stream;
 
   if (controller._started === false) {
     return;
@@ -637,7 +637,7 @@ function WritableStreamDefaultControllerClose(controller) {
 }
 
 function WritableStreamDefaultControllerError(controller, error) {
-  const stream = controller._controlledWritableStream;
+  const stream = controller._stream;
 
   assert(stream._state === 'writable');
 
@@ -646,7 +646,7 @@ function WritableStreamDefaultControllerError(controller, error) {
 }
 
 function WritableStreamDefaultControllerErrorIfNeeded(controller, error) {
-  if (controller._controlledWritableStream._state === 'writable') {
+  if (controller._stream._state === 'writable') {
     WritableStreamDefaultControllerError(controller, error);
   }
 }
@@ -670,7 +670,7 @@ function WritableStreamDefaultControllerGetDesiredSize(controller) {
 }
 
 function WritableStreamDefaultControllerProcessClose(controller) {
-  const stream = controller._controlledWritableStream;
+  const stream = controller._stream;
 
   WritableStreamMarkCloseRequestInFlight(stream);
 
@@ -691,7 +691,7 @@ function WritableStreamDefaultControllerProcessClose(controller) {
 }
 
 function WritableStreamDefaultControllerProcessWrite(controller, chunk) {
-  const stream = controller._controlledWritableStream;
+  const stream = controller._stream;
 
   WritableStreamMarkFirstWriteRequestInFlight(stream);
 
@@ -730,7 +730,7 @@ function WritableStreamDefaultControllerWrite(controller, chunk, chunkSize) {
     return;
   }
 
-  const stream = controller._controlledWritableStream;
+  const stream = controller._stream;
   if (WritableStreamCloseQueuedOrInFlight(stream) === false && stream._state === 'writable') {
     const backpressure = WritableStreamDefaultControllerGetBackpressure(controller);
     WritableStreamUpdateBackpressure(stream, backpressure);

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -68,7 +68,7 @@ function InitializeWritableStream(stream) {
 
   // Initialize to undefined first because the constructor of the controller checks this
   // variable to validate the caller.
-  stream._writableStreamController = undefined;
+  stream._controller = undefined;
 
   // Write requests are removed from _writeRequests when write() is called on the underlying sink. This prevents
   // them from being erroneously rejected on error. If a write() call is in-flight, the request is stored here.
@@ -185,7 +185,7 @@ function WritableStreamClose(stream) {
     resolvePromise(writer._readyPromise, undefined);
   }
 
-  WritableStreamDefaultControllerClose(stream._writableStreamController);
+  WritableStreamDefaultControllerClose(stream._controller);
 
   return promise;
 }
@@ -227,7 +227,7 @@ function WritableStreamFinishErroring(stream) {
   assert(stream._state === 'erroring');
   assert(WritableStreamHasOperationMarkedInFlight(stream) === false);
   stream._state = 'errored';
-  stream._writableStreamController[ErrorSteps]();
+  stream._controller[ErrorSteps]();
 
   const storedError = stream._storedError;
   for (const writeRequest of stream._writeRequests) {
@@ -249,7 +249,7 @@ function WritableStreamFinishErroring(stream) {
     return;
   }
 
-  const promise = stream._writableStreamController[AbortSteps](abortRequest.reason);
+  const promise = stream._controller[AbortSteps](abortRequest.reason);
   uponPromise(
     promise,
     () => {
@@ -366,7 +366,7 @@ function WritableStreamStartErroring(stream, reason) {
   assert(stream._storedError === undefined);
   assert(stream._state === 'writable');
 
-  const controller = stream._writableStreamController;
+  const controller = stream._controller;
   assert(controller !== undefined);
 
   stream._state = 'erroring';
@@ -468,7 +468,7 @@ function WritableStreamDefaultWriterGetDesiredSize(writer) {
     return 0;
   }
 
-  return WritableStreamDefaultControllerGetDesiredSize(stream._writableStreamController);
+  return WritableStreamDefaultControllerGetDesiredSize(stream._controller);
 }
 
 function WritableStreamDefaultWriterRelease(writer) {
@@ -494,7 +494,7 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
 
   assert(stream !== undefined);
 
-  const controller = stream._writableStreamController;
+  const controller = stream._controller;
 
   const chunkSize = WritableStreamDefaultControllerGetChunkSize(controller, chunk);
 
@@ -527,10 +527,10 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
 function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm, writeAlgorithm, closeAlgorithm,
                                               abortAlgorithm, highWaterMark, sizeAlgorithm) {
   assert(WritableStream.isImpl(stream));
-  assert(stream._writableStreamController === undefined);
+  assert(stream._controller === undefined);
 
   controller._controlledWritableStream = stream;
-  stream._writableStreamController = controller;
+  stream._controller = controller;
 
   // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
   controller._queue = undefined;

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -136,7 +136,7 @@ function SetUpWritableStreamDefaultWriter(writer, stream) {
     throw new TypeError('This stream has already been locked for exclusive writing by another writer');
   }
 
-  writer._ownerWritableStream = stream;
+  writer._stream = stream;
   stream._writer = writer;
 
   const state = stream._state;
@@ -403,7 +403,7 @@ function WritableStreamUpdateBackpressure(stream, backpressure) {
 
 
 function WritableStreamDefaultWriterAbort(writer, reason) {
-  const stream = writer._ownerWritableStream;
+  const stream = writer._stream;
 
   assert(stream !== undefined);
 
@@ -411,7 +411,7 @@ function WritableStreamDefaultWriterAbort(writer, reason) {
 }
 
 function WritableStreamDefaultWriterClose(writer) {
-  const stream = writer._ownerWritableStream;
+  const stream = writer._stream;
 
   assert(stream !== undefined);
 
@@ -419,7 +419,7 @@ function WritableStreamDefaultWriterClose(writer) {
 }
 
 function WritableStreamDefaultWriterCloseWithErrorPropagation(writer) {
-  const stream = writer._ownerWritableStream;
+  const stream = writer._stream;
 
   assert(stream !== undefined);
 
@@ -457,7 +457,7 @@ function WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error) {
 }
 
 function WritableStreamDefaultWriterGetDesiredSize(writer) {
-  const stream = writer._ownerWritableStream;
+  const stream = writer._stream;
   const state = stream._state;
 
   if (state === 'errored' || state === 'erroring') {
@@ -472,7 +472,7 @@ function WritableStreamDefaultWriterGetDesiredSize(writer) {
 }
 
 function WritableStreamDefaultWriterRelease(writer) {
-  const stream = writer._ownerWritableStream;
+  const stream = writer._stream;
   assert(stream !== undefined);
   assert(stream._writer === writer);
 
@@ -486,11 +486,11 @@ function WritableStreamDefaultWriterRelease(writer) {
   WritableStreamDefaultWriterEnsureClosedPromiseRejected(writer, releasedError);
 
   stream._writer = undefined;
-  writer._ownerWritableStream = undefined;
+  writer._stream = undefined;
 }
 
 function WritableStreamDefaultWriterWrite(writer, chunk) {
-  const stream = writer._ownerWritableStream;
+  const stream = writer._stream;
 
   assert(stream !== undefined);
 
@@ -498,7 +498,7 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
 
   const chunkSize = WritableStreamDefaultControllerGetChunkSize(controller, chunk);
 
-  if (stream !== writer._ownerWritableStream) {
+  if (stream !== writer._stream) {
     return promiseRejectedWith(new TypeError('Cannot write to a stream using a released writer'));
   }
 


### PR DESCRIPTION
Prior to #1035, certain internal slots were used for brand checking, which meant they needed to have unique names. That is no longer a requirement, and so we can use simpler names now.

This PR is done as a series of commits to make review or rebasing easier, but the intention is to squash it into one commit before merging.

This will help un-block https://github.com/whatwg/streams/pull/1050.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1061.html" title="Last updated on Jul 28, 2020, 6:12 PM UTC (8858d73)">Preview</a> | <a href="https://whatpr.org/streams/1061/9b427f5...8858d73.html" title="Last updated on Jul 28, 2020, 6:12 PM UTC (8858d73)">Diff</a>