### PR TITLE
Make quotes around code font words consistent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2269,7 +2269,7 @@ the {{ReadableStream}}'s public API.
  |readRequest|)</dfn> performs the following steps:
 
  1. Assert: |stream|.\[[reader]] [=implements=] {{ReadableStreamBYOBReader}}.
- 1. Assert: |stream|.\[[state]] is "`readable"` or `"closed`".
+ 1. Assert: |stream|.\[[state]] is "`readable`" or "`closed`".
  1. [=list/Append=] |readRequest| to |stream|.\[[reader]].\[[readIntoRequests]].
 </div>
 
@@ -2279,7 +2279,7 @@ the {{ReadableStream}}'s public API.
  performs the following steps:
 
  1. Assert: |stream|.\[[reader]] [=implements=] {{ReadableStreamDefaultReader}}.
- 1. Assert: |stream|.\[[state]] is "`readable"`.
+ 1. Assert: |stream|.\[[state]] is "`readable`".
  1. [=list/Append=] |readRequest| to |stream|.\[[reader]].\[[readRequests]].
 </div>
 
@@ -4070,10 +4070,10 @@ are even meant to be generally useful by other specifications.
  steps:
 
  1. Let |state| be |stream|.\[[state]].
- 1. If |state| is "`closed"` or `"errored`", return [=a promise resolved with=] undefined.
+ 1. If |state| is "`closed`" or "`errored`", return [=a promise resolved with=] undefined.
  1. If |stream|.\[[pendingAbortRequest]] is not undefined, return
     |stream|.\[[pendingAbortRequest]]'s [=pending abort request/promise=].
- 1. Assert: |state| is "`writable"` or `"erroring`".
+ 1. Assert: |state| is "`writable`" or "`erroring`".
  1. Let |wasAlreadyErroring| be false.
  1. If |state| is "`erroring`",
    1. Set |wasAlreadyErroring| to true.
@@ -4091,9 +4091,9 @@ are even meant to be generally useful by other specifications.
  id="writable-stream-close">WritableStreamClose(|stream|)</dfn> performs the following steps:
 
  1. Let |state| be |stream|.\[[state]].
- 1. If |state| is "`closed"` or `"errored`", return [=a promise rejected with=] a {{TypeError}}
+ 1. If |state| is "`closed`" or "`errored`", return [=a promise rejected with=] a {{TypeError}}
     exception.
- 1. Assert: |state| is "`writable"` or `"erroring`".
+ 1. Assert: |state| is "`writable`" or "`erroring`".
  1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
  1. Let |promise| be [=a new promise=].
  1. Set |stream|.\[[closeRequest]] to |promise|.
@@ -4211,7 +4211,7 @@ the {{WritableStream}}'s public API.
  1. [=Resolve=] |stream|.\[[inFlightCloseRequest]] with undefined.
  1. Set |stream|.\[[inFlightCloseRequest]] to undefined.
  1. Let |state| be |stream|.\[[state]].
- 1. Assert: |stream|.\[[state]] is "`writable"` or `"erroring`".
+ 1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
  1. If |state| is "`erroring`",
   1. Set |stream|.\[[storedError]] to undefined.
   1. If |stream|.\[[pendingAbortRequest]] is not undefined,
@@ -4233,7 +4233,7 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.\[[inFlightCloseRequest]] is not undefined.
  1. [=Reject=] |stream|.\[[inFlightCloseRequest]] with |error|.
  1. Set |stream|.\[[inFlightCloseRequest]] to undefined.
- 1. Assert: |stream|.\[[state]] is "`writable"` or `"erroring`".
+ 1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
  1. If |stream|.\[[pendingAbortRequest]] is not undefined,
   1. [=Reject=] |stream|.\[[pendingAbortRequest]]'s [=pending abort request/promise=] with |error|.
   1. Set |stream|.\[[pendingAbortRequest]] to undefined.
@@ -4258,7 +4258,7 @@ the {{WritableStream}}'s public API.
  1. Assert: |stream|.\[[inFlightWriteRequest]] is not undefined.
  1. [=Reject=] |stream|.\[[inFlightWriteRequest]] with |error|.
  1. Set |stream|.\[[inFlightWriteRequest]] to undefined.
- 1. Assert: |stream|.\[[state]] is "`writable"` or `"erroring`".
+ 1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
  1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |error|).
 </div>
 
@@ -4381,7 +4381,7 @@ The following abstract operations support the implementation and manipulation of
  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
     [=a promise resolved with=] undefined.
  1. If |state| is "`errored`", return [=a promise rejected with=] |stream|.\[[storedError]].
- 1. Assert: |state| is "`writable"` or `"erroring`".
+ 1. Assert: |state| is "`writable`" or "`erroring`".
  1. Return ! [$WritableStreamDefaultWriterClose$](|writer|).
 
  <p class="note">This abstract operation helps implement the error propagation semantics of
@@ -4417,7 +4417,7 @@ The following abstract operations support the implementation and manipulation of
 
  1. Let |stream| be |writer|.\[[stream]].
  1. Let |state| be |stream|.\[[state]].
- 1. If |state| is "`errored"` or `"erroring`", return null.
+ 1. If |state| is "`errored`" or "`erroring`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return ! [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.\[[controller]]).
 </div>
@@ -4488,11 +4488,11 @@ The following abstract operations support the implementation of the
  1. Let |startResult| be the result of performing |startAlgorithm|. (This may throw an exception.)
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=] of |startPromise|,
-  1. Assert: |stream|.\[[state]] is "`writable"` or `"erroring`".
+  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
   1. Set |controller|.\[[started]] to true.
   1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
-  1. Assert: |stream|.\[[state]] is "`writable"` or `"erroring`".
+  1. Assert: |stream|.\[[state]] is "`writable`" or "`erroring`".
   1. Set |controller|.\[[started]] to true.
   1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |r|).
 </div>
@@ -4537,7 +4537,7 @@ The following abstract operations support the implementation of the
  1. If |controller|.\[[started]] is false, return.
  1. If |stream|.\[[inFlightWriteRequest]] is not undefined, return.
  1. Let |state| be |stream|.\[[state]].
- 1. Assert: |state| is not "`closed"` or `"errored`".
+ 1. Assert: |state| is not "`closed`" or "`errored`".
  1. If |state| is "`erroring`",
   1. Perform ! [$WritableStreamFinishErroring$](|stream|).
   1. Return.
@@ -4587,7 +4587,7 @@ The following abstract operations support the implementation of the
  |error|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.\[[stream]].
- 1. Assert: |stream|.\[[state]] is `"writable"`.
+ 1. Assert: |stream|.\[[state]] is "`writable`".
  1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Perform ! [$WritableStreamStartErroring$](|stream|, |error|).
 </div>
@@ -4661,7 +4661,7 @@ The following abstract operations support the implementation of the
  1. [=Upon fulfillment=] of |sinkWritePromise|,
   1. Perform ! [$WritableStreamFinishInFlightWrite$](|stream|).
   1. Let |state| be |stream|.\[[state]].
-  1. Assert: |state| is "`writable"` or `"erroring`".
+  1. Assert: |state| is "`writable`" or "`erroring`".
   1. Perform ! [$DequeueValue$](|controller|).
   1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |state| is "`writable`",
    1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).


### PR DESCRIPTION
Some quoted code font words in the standard had a quote in code font on
one side and proportional font on the other side. Fix it so that all
quoted code font words have both quotes in proportional font.

This change is purely editorial.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1062.html" title="Last updated on Aug 4, 2020, 8:25 PM UTC (e47bb85)">Preview</a> | <a href="https://whatpr.org/streams/1062/5a69ed0...e47bb85.html" title="Last updated on Aug 4, 2020, 8:25 PM UTC (e47bb85)">Diff</a>