### PR TITLE
Editorial: Export [[detached]] slots

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -516,8 +516,7 @@ table:
    {{ReadableByteStreamController}} created with the ability to control the state and queue of this
    stream
   <tr>
-   <td><!-- TODO(ricea): Style this as <dfn unused> when that is supported.
-            See https://github.com/tabatkins/bikeshed/issues/1747 --><b>\[[detached]]</b>
+   <td><dfn export>\[[detached]]</dfn>
    <td class="non-normative">A boolean flag set to true when the stream is transferred
   <tr>
    <td><dfn>\[[disturbed]]</dfn>
@@ -3541,7 +3540,7 @@ table:
   <td class="non-normative">A {{WritableStreamDefaultController}} created with the ability to
   control the state and queue of this stream
  <tr>
-  <td><!-- TODO(ricea): Style this as <dfn unused> when that is supported --><b>\[[detached]]</b>
+  <td><dfn export>\[[detached]]</dfn>
   <td class="non-normative">A boolean flag set to true when the stream is transferred
  <tr>
   <td><dfn>\[[inFlightWriteRequest]]</dfn>
@@ -5007,7 +5006,7 @@ table:
    <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to
    control [=TransformStream/[[readable]]=] and [=TransformStream/[[writable]]=]
   <tr>
-   <td><!-- TODO(ricea): Style this as <dfn unused> when that is supported --><b>\[[detached]]</b>
+   <td><dfn export>\[[detached]]</dfn>
    <td class="non-normative">A boolean flag set to true when the stream is transferred
   <tr>
    <td><dfn>\[[readable]]</dfn>

--- a/index.bs
+++ b/index.bs
@@ -516,7 +516,7 @@ table:
    {{ReadableByteStreamController}} created with the ability to control the state and queue of this
    stream
   <tr>
-   <td><dfn export>\[[detached]]</dfn>
+   <td><dfn export>\[[Detached]]</dfn>
    <td class="non-normative">A boolean flag set to true when the stream is transferred
   <tr>
    <td><dfn>\[[disturbed]]</dfn>
@@ -3540,7 +3540,7 @@ table:
   <td class="non-normative">A {{WritableStreamDefaultController}} created with the ability to
   control the state and queue of this stream
  <tr>
-  <td><dfn export>\[[detached]]</dfn>
+  <td><dfn export>\[[Detached]]</dfn>
   <td class="non-normative">A boolean flag set to true when the stream is transferred
  <tr>
   <td><dfn>\[[inFlightWriteRequest]]</dfn>
@@ -5006,7 +5006,7 @@ table:
    <td class="non-normative">A {{TransformStreamDefaultController}} created with the ability to
    control [=TransformStream/[[readable]]=] and [=TransformStream/[[writable]]=]
   <tr>
-   <td><dfn export>\[[detached]]</dfn>
+   <td><dfn export>\[[Detached]]</dfn>
    <td class="non-normative">A boolean flag set to true when the stream is transferred
   <tr>
    <td><dfn>\[[readable]]</dfn>


### PR DESCRIPTION
Use `<dfn export>` for [[detached]] slots since they are part of the
public-facing API (consumed by the HTML standard). See
https://github.com/tabatkins/bikeshed/issues/1747.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1064.html" title="Last updated on Aug 18, 2020, 1:16 AM UTC (9d4ff46)">Preview</a> | <a href="https://whatpr.org/streams/1064/1fd19a0...9d4ff46.html" title="Last updated on Aug 18, 2020, 1:16 AM UTC (9d4ff46)">Diff</a>