### PR TITLE
Remove redundant startPromise declaration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5159,7 +5159,6 @@ side=], or to terminate or error the stream.
     |writableSizeAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
  1. Perform ? [$SetUpTransformStreamDefaultControllerFromTransformer$]([=this=], |transformer|,
     |transformerDict|).
- 1. Let |startPromise| be [=a new promise=].
  1. If |transformerDict|["{{Transformer/start}}"] [=map/exists=], then [=resolve=] |startPromise|
     with the result of [=invoking=] |transformerDict|["{{Transformer/start}}"] with argument list
     «&nbsp;[=this=].[=TransformStream/[[controller]]=]&nbsp;» and [=callback this value=]


### PR DESCRIPTION
Fixes #1065

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1067.html" title="Last updated on Aug 18, 2020, 2:02 AM UTC (ac4b369)">Preview</a> | <a href="https://whatpr.org/streams/1067/1fd19a0...ac4b369.html" title="Last updated on Aug 18, 2020, 2:02 AM UTC (ac4b369)">Diff</a>