### PR TITLE
Don't error an errored WritableStream on messageerror

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6146,7 +6146,7 @@ abstract operations are used to implement these "cross-realm transforms".
  1. Add a handler for |port|'s {{MessagePort/messageerror}} event with the following steps:
   1. Let |error| be a new "{{DataCloneError}}" {{DOMException}}.
   1. Perform ! [$CrossRealmTransformSendError$](|port|, |error|).
-  1. Perform ! [$WritableStreamDefaultControllerError$](|controller|, |error|).
+  1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|, |error|).
   1. Disentangle |port|.
  1. Enable |port|'s [=port message queue=].
  1. Let |startAlgorithm| be an algorithm that returns undefined.


### PR DESCRIPTION
<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * The change is not observable.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: Not needed (never had the bug)
   * Firefox: Not needed (unimplemented)
   * Safari: Not needed (unimplemented)

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1069.html" title="Last updated on Aug 27, 2020, 9:05 PM UTC (8c8f6dc)">Preview</a> | <a href="https://whatpr.org/streams/1069/8652455...8c8f6dc.html" title="Last updated on Aug 27, 2020, 9:05 PM UTC (8c8f6dc)">Diff</a>