### PR TITLE
Editorial: fix extra "the" in controller.error()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5286,7 +5286,7 @@ the following table:
 
  <dt><code><var ignore>controller</var>.{{TransformStreamDefaultController/error()|error}}(<var ignore>e</var>)</code>
  <dd>
-  <p>Errors the both the [=readable side=] and the [=writable side=] of the controlled transform
+  <p>Errors both the [=readable side=] and the [=writable side=] of the controlled transform
   stream, making all future interactions with it fail with the given error <var ignore>e</var>. Any
   [=chunks=] queued for transformation will be discarded.
 


### PR DESCRIPTION
As it says on the tin. 😁


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1070.html" title="Last updated on Aug 25, 2020, 8:27 AM UTC (73e47e0)">Preview</a> | <a href="https://whatpr.org/streams/1070/8652455...73e47e0.html" title="Last updated on Aug 25, 2020, 8:27 AM UTC (73e47e0)">Diff</a>