### PR TITLE
Editorial: fix missing async in example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6459,7 +6459,7 @@ function makeReadableByteFileStream(filename) {
       fileHandle = await fs.open(filename, "r");
     },
 
-    pull(controller) {
+    async pull(controller) {
       // Even when the consumer is using the default reader, the auto-allocation
       // feature allocates a buffer and passes it to us via byobRequest.
       const v = controller.byobRequest.view;


### PR DESCRIPTION
There's an `await` in the method body, so there should be an `async` in its signature.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1076.html" title="Last updated on Sep 14, 2020, 9:34 PM UTC (2039db6)">Preview</a> | <a href="https://whatpr.org/streams/1076/c067adc...2039db6.html" title="Last updated on Sep 14, 2020, 9:34 PM UTC (2039db6)">Diff</a>