### PR TITLE
Editorial: Define "create a ReadableStream" instead of just "create"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6100,7 +6100,7 @@ to grow organically as needed.
 <h4 id="other-specs-rs-create">Creation and manipulation</h4>
 
 <div algorithm="create a ReadableStream">
- To <dfn export for="ReadableStream" lt="create|creating">create</dfn> a {{ReadableStream}} given an
+ To <dfn export lt="create a ReadableStream|creating a ReadableStream">create a ReadableStream</dfn> given an
  optional algorithm <dfn export for="ReadableStream/create"><var>pullAlgorithm</var></dfn>, an
  optional algorithm <dfn export for="ReadableStream/create"><var>cancelAlgorithm</var></dfn>, an
  optional number <dfn export for="ReadableStream/create"><var>highWaterMark</var></dfn> (default 1),


### PR DESCRIPTION
The current definition forces redundant text in callers:

```
... the result of [=ReadableStream/creating=] a {{ReadableStream}} given ...
```

My proposal allows just

```
... the result of [=creating a ReadableStream=] given ...
```

The general principle is that `for` works well for methods of an existing object, where readers will see the object with its type at any call site. We shouldn't use `for` in creation methods where there's no other object of the `for` type at the call site.

This change will, unfortunately, break existing calls to this algorithm. I think we could add an empty `<dfn export for=ReadableStream lt="create|creating"></dfn>` before it to keep those working if you want.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1078.html" title="Last updated on Jan 15, 2021, 7:26 AM UTC (bee3b46)">Preview</a> | <a href="https://whatpr.org/streams/1078/a669248...bee3b46.html" title="Last updated on Jan 15, 2021, 7:26 AM UTC (bee3b46)">Diff</a>