### PR TITLE
Editorial: Add lt="reading a chunk"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6195,9 +6195,9 @@ failures should be handled by the calling specification.
  <p class="note">This will throw an exception if |stream| is already [=ReadableStream/locked=].
 </div>
 
-<p algorithm>To <dfn export for="ReadableStreamDefaultReader" lt="read a chunk|reading a chunk">read a chunk</dfn> from a
-{{ReadableStreamDefaultReader}} |reader|, given a [=read request=] |readRequest|, perform !
-[$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
+<p algorithm>To <dfn export for="ReadableStreamDefaultReader" lt="read a chunk|reading a chunk">read
+a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read request=]
+|readRequest|, perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
 
 <div algorithm="read all bytes">
  <p>To <dfn export for="ReadableStreamDefaultReader" lt="read all bytes|reading all bytes">read all
@@ -7294,6 +7294,7 @@ Jake Archibald,
 Jake Verbaten,
 Janessa Det,
 Jason Orendorff,
+Jeffrey Yasskin,
 Jens Nockert,
 Lennart Grahl,
 Mangala Sadhu Sangeet Singh Khalsa,

--- a/index.bs
+++ b/index.bs
@@ -6195,7 +6195,7 @@ failures should be handled by the calling specification.
  <p class="note">This will throw an exception if |stream| is already [=ReadableStream/locked=].
 </div>
 
-<p algorithm>To <dfn export for="ReadableStreamDefaultReader">read a chunk</dfn> from a
+<p algorithm>To <dfn export for="ReadableStreamDefaultReader" lt="read a chunk|reading a chunk">read a chunk</dfn> from a
 {{ReadableStreamDefaultReader}} |reader|, given a [=read request=] |readRequest|, perform !
 [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
 


### PR DESCRIPTION
Call sites for any algorithm that returns a value use the gerund form, so definitions that use the infinitive form have to always include an `lt` to be convenient for callers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1079.html" title="Last updated on Oct 1, 2020, 8:02 PM UTC (23034bb)">Preview</a> | <a href="https://whatpr.org/streams/1079/a669248...23034bb.html" title="Last updated on Oct 1, 2020, 8:02 PM UTC (23034bb)">Diff</a>