### PR TITLE
Fix readable byte stream example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -426,19 +426,25 @@ particularly important for the data structure described in [[#queue-with-sizes]]
  const reader = readableStream.getReader({ mode: "byob" });
 
  let startingAB = new ArrayBuffer(1024);
- readInto(startingAB)
-   .then(buffer => console.log("The first 1024 bytes:", buffer))
-   .catch(e => console.error("Something went wrong!", e));
+ const buffer = await readInto(startingAB);
+ console.log("The first 1024 bytes: ", buffer);
 
- function readInto(buffer, offset = 0) {
-   if (offset === buffer.byteLength) {
-     return Promise.resolve(buffer);
-   }
+ async function readInto(buffer) {
+   let offset = 0;
+   let view;
+   let done;
 
-   const view = new Uint8Array(buffer, offset, buffer.byteLength - offset);
-   return reader.read(view).then(newView => {
-     return readInto(newView.buffer, offset + newView.byteLength);
-   });
+   do {
+     ({value: view, done} =
+      await reader.read(new Uint8Array(buffer, offset, buffer.byteLength - offset)));
+     buffer = view.buffer;
+     if (done) {
+       break;
+     }
+     offset += view.byteLength;
+   } while (offset < buffer.byteLength);
+
+   return buffer;
  }
  </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -431,18 +431,16 @@ particularly important for the data structure described in [[#queue-with-sizes]]
 
  async function readInto(buffer) {
    let offset = 0;
-   let view;
-   let done;
 
-   do {
-     ({value: view, done} =
-      await reader.read(new Uint8Array(buffer, offset, buffer.byteLength - offset)));
+   while (offset < buffer.byteLength) {
+     const {value: view, done} =
+      await reader.read(new Uint8Array(buffer, offset, buffer.byteLength - offset));
      buffer = view.buffer;
      if (done) {
        break;
      }
      offset += view.byteLength;
-   } while (offset < buffer.byteLength);
+   }
 
    return buffer;
  }
@@ -451,10 +449,10 @@ particularly important for the data structure described in [[#queue-with-sizes]]
  An important thing to note here is that the final <code>buffer</code> value is different from the
  <code>startingAB</code>, but it (and all intermediate buffers) shares the same backing memory
  allocation. At each step, the buffer is <a href="#transfer-array-buffer">transferred</a> to a new
- {{ArrayBuffer}} object. The <code>newView</code> is a new {{Uint8Array}}, with that {{ArrayBuffer}}
- object as its <code>buffer</code> property, the offset that bytes were written to as its
- <code>byteOffset</code> property, and the number of bytes that were written as its
- <code>byteLength</code> property.
+ {{ArrayBuffer}} object. The <code>view</code> is destructured from the return value of reading a
+ new {{Uint8Array}}, with that {{ArrayBuffer}} object as its <code>buffer</code> property, the
+ offset that bytes were written to as its <code>byteOffset</code> property, and the number of
+ bytes that were written as its <code>byteLength</code> property.
 </div>
 
 <h3 id="rs-class">The {{ReadableStream}} class</h3>

--- a/index.bs
+++ b/index.bs
@@ -7309,6 +7309,7 @@ Marvin Hagemeister,
 Mattias Buelens,
 Michael Mior,
 Mihai Potra,
+Nidhi Jaju,
 Romain Bellessort, <!-- rombel on GitHub -->
 Simon Menke,
 Stephen Sugden,


### PR DESCRIPTION
This change fixes a few bugs in the example for readable byte streams. 
One of the bugs in the existing example is that there seems to be infinite 
recursion for streams that have a total length of less than 1024. 
Furthermore, another bug is the return value of reader.read() is not 
destructured.

In this change, iteration is used instead of recursion, as well as async/
await.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 28, 2020, 1:47 AM UTC)_.

<details>
<summary>More</summary>







_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/streams%231080.)._
</details>
