### PR TITLE
Editorial: Remove redundant steps from AcquireDefaultReader & BYOBReader

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1998,7 +1998,6 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
  the following steps:
 
  1. Let |reader| be a [=new=] {{ReadableStreamBYOBReader}}.
- 1. Perform ? [$SetUpReadableStreamBYOBReader$](|reader|, |stream|).
  1. Return |reader|.
 </div>
 
@@ -2008,7 +2007,6 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
  following steps:
 
   1. Let |reader| be a [=new=] {{ReadableStreamDefaultReader}}.
-  1. Perform ? [$SetUpReadableStreamDefaultReader$](|reader|, |stream|).
   1. Return |reader|.
 </div>
 


### PR DESCRIPTION
The second step in both AcquireReader() functions call their respective SetUp() functions, which is redundant as SetUp() is already called inside the constructor in the first step. Hence, this change removes these redundant steps from the standard.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1087.html" title="Last updated on Nov 17, 2020, 4:10 AM UTC (d92e3a5)">Preview</a> | <a href="https://whatpr.org/streams/1087/670bb6a...d92e3a5.html" title="Last updated on Nov 17, 2020, 4:10 AM UTC (d92e3a5)">Diff</a>