### PR TITLE
Add if condition for autoAllocateChunkSize to SetUpReadableByteStreamController()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3247,7 +3247,7 @@ The following abstract operations support the implementation of the
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. If |autoAllocateChunkSize| is not undefined,
   1. Assert: ! [$IsInteger$](|autoAllocateChunkSize|) is true.
-  1. Assert: |autoAllocateChunkSize| is positive.
+  1. Assert: |autoAllocateChunkSize| is non-negative.
   1. If |autoAllocateChunkSize| is 0, throw a TypeError exception.
  1. Set |controller|.[=ReadableByteStreamController/[[stream]]=] to |stream|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and

--- a/index.bs
+++ b/index.bs
@@ -3246,8 +3246,9 @@ The following abstract operations support the implementation of the
 
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. If |autoAllocateChunkSize| is not undefined,
-  1. Assert: ! IsInteger(|autoAllocateChunkSize|) is true.
+  1. Assert: ! [$IsInteger$](|autoAllocateChunkSize|) is true.
   1. Assert: |autoAllocateChunkSize| is positive.
+  1. If |autoAllocateChunkSize| is 0, throw a TypeError exception.
  1. Set |controller|.[=ReadableByteStreamController/[[stream]]=] to |stream|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and
     |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.


### PR DESCRIPTION
Based on https://github.com/whatwg/streams/issues/1089, this adds an if condition to `SetUpReadableByteStreamController()` to check if _autoAllocateChunkSize_ is 0, as the WebIDL only restricts it to be non-negative. Additionally, this change adds a reference to the ECMA spec for `IsInteger()`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1090.html" title="Last updated on Dec 1, 2020, 9:14 AM UTC (7348b42)">Preview</a> | <a href="https://whatpr.org/streams/1090/41a9689...7348b42.html" title="Last updated on Dec 1, 2020, 9:14 AM UTC (7348b42)">Diff</a>