### PR TITLE
Editorial: refactor autoAllocateChunkSize checking

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3247,8 +3247,7 @@ The following abstract operations support the implementation of the
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. If |autoAllocateChunkSize| is not undefined,
   1. Assert: ! [$IsInteger$](|autoAllocateChunkSize|) is true.
-  1. Assert: |autoAllocateChunkSize| is non-negative.
-  1. If |autoAllocateChunkSize| is 0, throw a TypeError exception.
+  1. Assert: |autoAllocateChunkSize| is positive.
  1. Set |controller|.[=ReadableByteStreamController/[[stream]]=] to |stream|.
  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and
     |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
@@ -3298,6 +3297,7 @@ The following abstract operations support the implementation of the
  1. Let |autoAllocateChunkSize| be
     |underlyingSourceDict|["{{UnderlyingSource/autoAllocateChunkSize}}"], if it [=map/exists=], or
     undefined otherwise.
+ 1. If |autoAllocateChunkSize| is 0, then throw a {{TypeError}} exception.
  1. Perform ? [$SetUpReadableByteStreamController$](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|, |autoAllocateChunkSize|).
 </div>


### PR DESCRIPTION
This throws the exception only from
SetUpReadableByteStreamControllerFromUnderlyingSource, i.e. from parts
of the spec reached by arbitrary web-developer provided values, instead
of from SetUpReadableByteStreamController, which is deeper in.

Then, we can assert that by the time the value reaches
SetUpReadableByteStreamController, it's positive. This makes any other
specs doing the wrong thing into assertion failures, reserving thrown
exceptions for web-developer provided zeros.

/cc @nidhijaju


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1092.html" title="Last updated on Dec 1, 2020, 4:53 PM UTC (ac10db6)">Preview</a> | <a href="https://whatpr.org/streams/1092/946fac9...ac10db6.html" title="Last updated on Dec 1, 2020, 4:53 PM UTC (ac10db6)">Diff</a>