### PR TITLE
Add 'Otherwise' to BYOBReaderRead

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2521,7 +2521,7 @@ The following abstract operations support the implementation and manipulation of
  1. Set |stream|.[=ReadableStream/[[disturbed]]=] to true.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", perform |readIntoRequest|'s [=read-into
     request/error steps=] given |stream|.[=ReadableStream/[[storedError]]=].
- 1. Otherwise, return ! [$ReadableByteStreamControllerPullInto$](|stream|.[=ReadableStream/[[controller]]=],
+ 1. Otherwise, perform ! [$ReadableByteStreamControllerPullInto$](|stream|.[=ReadableStream/[[controller]]=],
     |view|, |readIntoRequest|).
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2521,7 +2521,7 @@ The following abstract operations support the implementation and manipulation of
  1. Set |stream|.[=ReadableStream/[[disturbed]]=] to true.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", perform |readIntoRequest|'s [=read-into
     request/error steps=] given |stream|.[=ReadableStream/[[storedError]]=].
- 1. Return ! [$ReadableByteStreamControllerPullInto$](|stream|.[=ReadableStream/[[controller]]=],
+ 1. Otherwise, return ! [$ReadableByteStreamControllerPullInto$](|stream|.[=ReadableStream/[[controller]]=],
     |view|, |readIntoRequest|).
 </div>
 


### PR DESCRIPTION
Currently, in [ReadableStreamBYOBReaderRead](https://streams.spec.whatwg.org/commit-snapshots/41a968974c91e05b20738f77d0b2731ec7391e92/#readable-stream-byob-reader-read), even if the stream.[[state]] is "errored", we still call [ReadableByteStreamControllerPullInto](https://streams.spec.whatwg.org/commit-snapshots/41a968974c91e05b20738f77d0b2731ec7391e92/#readable-byte-stream-controller-pull-into). This causes the second assertion in [AddReadIntoRequest](https://streams.spec.whatwg.org/commit-snapshots/41a968974c91e05b20738f77d0b2731ec7391e92/#readable-stream-add-read-into-request) to fail.

In this change, we wrap the last step of ReadableStreamBYOBReaderRead i.e.

> Return ! ReadableByteStreamControllerPullInto(stream.[[controller]], view, readIntoRequest).

with an "Otherwise" to prevent this from happening.

Fixes https://github.com/whatwg/streams/issues/1091


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1093.html" title="Last updated on Dec 2, 2020, 5:11 AM UTC (aff4db4)">Preview</a> | <a href="https://whatpr.org/streams/1093/e865672...aff4db4.html" title="Last updated on Dec 2, 2020, 5:11 AM UTC (aff4db4)">Diff</a>