### PR TITLE
Add Reader Type assertions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2393,7 +2393,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-fulfill-read-into-request">ReadableStreamFulfillReadIntoRequest(|stream|,
  |chunk|, |done|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamBYOBReader}}.
+ 1. Assert: ! [$ReadableStreamHasBYOBReader$](|stream|) is true.
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is
     empty|empty=].
@@ -2409,7 +2409,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-fulfill-read-request">ReadableStreamFulfillReadRequest(|stream|, |chunk|,
  |done|)</dfn> performs the following steps:
 
- 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamDefaultReader}}.
+ 1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is
     empty|empty=].
@@ -2424,7 +2424,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-get-num-read-into-requests">ReadableStreamGetNumReadIntoRequests(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamBYOBReader}}.
+ 1. Assert: ! [$ReadableStreamHasBYOBReader$](|stream|) is true.
  1. Return
     |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=]'s
     [=list/size=].
@@ -2435,7 +2435,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-get-num-read-requests">ReadableStreamGetNumReadRequests(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamDefaultReader}}.
+ 1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
  1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamDefaultReader/[[readRequests]]=]'s
     [=list/size=].
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2393,6 +2393,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-fulfill-read-into-request">ReadableStreamFulfillReadIntoRequest(|stream|,
  |chunk|, |done|)</dfn> performs the following steps:
 
+ 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamBYOBReader}}.
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is
     empty|empty=].
@@ -2408,6 +2409,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-fulfill-read-request">ReadableStreamFulfillReadRequest(|stream|, |chunk|,
  |done|)</dfn> performs the following steps:
 
+ 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamDefaultReader}}.
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is
     empty|empty=].
@@ -2422,6 +2424,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-get-num-read-into-requests">ReadableStreamGetNumReadIntoRequests(|stream|)</dfn>
  performs the following steps:
 
+ 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamBYOBReader}}.
  1. Return
     |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=]'s
     [=list/size=].
@@ -2432,6 +2435,7 @@ the {{ReadableStream}}'s public API.
  id="readable-stream-get-num-read-requests">ReadableStreamGetNumReadRequests(|stream|)</dfn>
  performs the following steps:
 
+ 1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamDefaultReader}}.
  1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamDefaultReader/[[readRequests]]=]'s
     [=list/size=].
 </div>


### PR DESCRIPTION
This adds reader type assertions to the beginning of several ReadableStream abstract operations that are only called with one particular type of reader for added clarity.

For example, [ReadableStreamFulfillReadIntoRequest](https://streams.spec.whatwg.org/commit-snapshots/0f419d59b58dde19a08f0a308561cef8ab8b99d5/#readable-stream-fulfill-read-into-request) and [ReadableStreamGetNumReadIntoRequests](https://streams.spec.whatwg.org/commit-snapshots/0f419d59b58dde19a08f0a308561cef8ab8b99d5/#readable-stream-get-num-read-into-requests) should only be called with ReadableStreamBYOBReader. Hence, we add the assertion:

> Assert: _stream_.[[reader]] implements **ReadableStreamBYOBReader**.

Similarly, [ReadableStreamFulfillReadRequest](https://streams.spec.whatwg.org/commit-snapshots/0f419d59b58dde19a08f0a308561cef8ab8b99d5/#readable-stream-fulfill-read-request) and [ReadableStreamGetNumReadRequests](https://streams.spec.whatwg.org/commit-snapshots/0f419d59b58dde19a08f0a308561cef8ab8b99d5/#readable-stream-get-num-read-requests) should only be called with ReadableStreamDefaultReader. Hence, we add the assertion:

> Assert: _stream_.[[reader]] implements **ReadableStreamDefaultReader**.

Closes https://github.com/whatwg/streams/issues/1094.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1095.html" title="Last updated on Dec 4, 2020, 10:24 AM UTC (6d1d32a)">Preview</a> | <a href="https://whatpr.org/streams/1095/0f419d5...6d1d32a.html" title="Last updated on Dec 4, 2020, 10:24 AM UTC (6d1d32a)">Diff</a>