### PR TITLE
Fix missing check for autoAllocateChunkSize == 0

### DIFF
--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1401,6 +1401,9 @@ function SetUpReadableByteStreamControllerFromUnderlyingSource(
   }
 
   const autoAllocateChunkSize = underlyingSourceDict.autoAllocateChunkSize;
+  if (autoAllocateChunkSize === 0) {
+    throw new TypeError('autoAllocateChunkSize must be greater than 0');
+  }
 
   SetUpReadableByteStreamController(
     stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, autoAllocateChunkSize


### PR DESCRIPTION
The reference implementation of [`SetUpReadableByteStreamControllerFromUnderlyingSource`](https://streams.spec.whatwg.org/commit-snapshots/660d259fa263e3c0646415a41b6e7b9a13ac4d04/#set-up-readable-byte-stream-controller-from-underlying-source) was missing step 9:
> 9. If _autoAllocateChunkSize_ is 0, then throw a `TypeError` exception.

This missing check was surfaced by a recently added WPT test (web-platform-tests/wpt@d7c07ed6cc486f3335c6a18a62ebae7517803237), but we did not yet roll WPT for this repository, so it went by undetected. This PR adds the missing check, and updates WPT to the latest version.