### PR TITLE
Settle reader.[[closedPromise]] before performing close/error steps of read requests

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2358,11 +2358,11 @@ the {{ReadableStream}}'s public API.
  1. Set |stream|.[=ReadableStream/[[state]]=] to "`closed`".
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. If |reader| is undefined, return.
+ 1. [=Resolve=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with undefined.
  1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
   1. [=list/For each=] |readRequest| of |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=],
    1. Perform |readRequest|'s [=read request/close steps=].
   1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to an empty [=list=].
- 1. [=Resolve=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with undefined.
 </div>
 
 <div algorithm>
@@ -2374,6 +2374,8 @@ the {{ReadableStream}}'s public API.
  1. Set |stream|.[=ReadableStream/[[storedError]]=] to |e|.
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. If |reader| is undefined, return.
+ 1. [=Reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with |e|.
+ 1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
  1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
   1. [=list/For each=] |readRequest| of |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=],
     1. Perform |readRequest|'s [=read request/error steps=], given |e|.
@@ -2384,8 +2386,6 @@ the {{ReadableStream}}'s public API.
       |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=],
     1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
    1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
- 1. [=Reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with |e|.
- 1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
 </div>
 
 <div algorithm>

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -463,14 +463,14 @@ function ReadableStreamClose(stream) {
     return;
   }
 
+  resolvePromise(reader._closedPromise, undefined);
+
   if (ReadableStreamDefaultReader.isImpl(reader)) {
     for (const readRequest of reader._readRequests) {
       readRequest.closeSteps();
     }
     reader._readRequests = [];
   }
-
-  resolvePromise(reader._closedPromise, undefined);
 }
 
 function ReadableStreamError(stream, e) {
@@ -484,6 +484,9 @@ function ReadableStreamError(stream, e) {
   if (reader === undefined) {
     return;
   }
+
+  rejectPromise(reader._closedPromise, e);
+  setPromiseIsHandledToTrue(reader._closedPromise);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
     for (const readRequest of reader._readRequests) {
@@ -500,9 +503,6 @@ function ReadableStreamError(stream, e) {
 
     reader._readIntoRequests = [];
   }
-
-  rejectPromise(reader._closedPromise, e);
-  setPromiseIsHandledToTrue(reader._closedPromise);
 }
 
 function ReadableStreamFulfillReadIntoRequest(stream, chunk, done) {

--- a/reference-implementation/lib/helpers/webidl.js
+++ b/reference-implementation/lib/helpers/webidl.js
@@ -23,12 +23,18 @@ function newPromise() {
 
 // https://heycam.github.io/webidl/#resolve
 function resolvePromise(p, value) {
+  if (promiseSideTable.get(p).stateIsPending === false) {
+    return;
+  }
   promiseSideTable.get(p).resolve(value);
   promiseSideTable.get(p).stateIsPending = false;
 }
 
 // https://heycam.github.io/webidl/#reject
 function rejectPromise(p, reason) {
+  if (promiseSideTable.get(p).stateIsPending === false) {
+    return;
+  }
   promiseSideTable.get(p).reject(reason);
   promiseSideTable.get(p).stateIsPending = false;
 }

--- a/reference-implementation/lib/helpers/webidl.js
+++ b/reference-implementation/lib/helpers/webidl.js
@@ -1,4 +1,5 @@
 'use strict';
+const assert = require('assert');
 const { rethrowAssertionErrorRejection } = require('./miscellaneous.js');
 
 const originalPromise = Promise;
@@ -23,18 +24,18 @@ function newPromise() {
 
 // https://heycam.github.io/webidl/#resolve
 function resolvePromise(p, value) {
-  if (promiseSideTable.get(p).stateIsPending === false) {
-    return;
-  }
+  // We intend to only resolve or reject promises that are still pending.
+  // When this is not the case, it usually means there's a bug in the specification that we want to fix.
+  // This assertion is NOT a normative requirement. It is part of the reference implementation only
+  // to help detect bugs in the specification. Other implementors MUST NOT replicate this assertion.
+  assert(stateIsPending(p) === true);
   promiseSideTable.get(p).resolve(value);
   promiseSideTable.get(p).stateIsPending = false;
 }
 
 // https://heycam.github.io/webidl/#reject
 function rejectPromise(p, reason) {
-  if (promiseSideTable.get(p).stateIsPending === false) {
-    return;
-  }
+  assert(stateIsPending(p) === true);
   promiseSideTable.get(p).reject(reason);
   promiseSideTable.get(p).stateIsPending = false;
 }


### PR DESCRIPTION
At least two implementations (#1100, MattiasBuelens/web-streams-polyfill#66) have made the (incorrect) assumption that `reader.[[closedPromise]]` will only be resolved or rejected if the promise is still pending. This is currently not the case: an async iterator may release its lock (and reject `reader.[[closedPromise]]`) right before the stream tries to resolve that same promise again.

With this PR, we now resolve or reject `reader.[[closedPromise]]` **before** going through all pending read requests and running their close or errors steps. This ensures that the stream is already done with all of its own state updates, and the read request's steps can observe and manipulate the "final" state of the stream. Thus, when the async iterator releases its lock, it will replace the `[[closedPromise]]` with a newly rejected promise instead.

This is a small but observable change for both web authors and other specifications:
* For web authors, `reader.closed` will resolve with `undefined` **before** `reader.read()` resolves with `{ done: true, value: undefined }`.
* For other specifications using the ["read a chunk" algorithm](https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk), when their close steps are run, they will now observe that `reader.closed` is already resolved (see [comment on #1100](https://github.com/whatwg/streams/issues/1100#issuecomment-761282151)).

There was also a small bug in the reference implementation of the WebIDL promise helpers. Calling `resolvePromise` or `rejectPromise` on a promise created with `promiseResolvedWith` or `promiseRejectedWith` would throw an error (such as "`promiseSideTable.get(p).resolve` is not a function"). If we attempt to resolve or reject a promise that is already resolved or rejected, we should do nothing instead.

- [x] ~At least two implementers are interested (and none opposed)~ ([skipped](https://github.com/whatwg/streams/pull/1102#issuecomment-775458824)):
   * Chrome (@ricea)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * web-platform-tests/wpt#27236
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1175965
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1691559
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=221576

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1102.html" title="Last updated on Feb 8, 2021, 10:44 PM UTC (dcca4f3)">Preview</a> | <a href="https://whatpr.org/streams/1102/ca74e0e...dcca4f3.html" title="Last updated on Feb 8, 2021, 10:44 PM UTC (dcca4f3)">Diff</a>