### PR TITLE
Fix cancelPromise in ReadableStreamTee being resolved twice 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2273,7 +2273,7 @@ create them does not matter.
      |r|).
   1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
      |r|).
-  1. [=Resolve=] |cancelPromise| with undefined.
+  1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
  1. Return « |branch1|, |branch2| ».
 </div>
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -414,7 +414,9 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   uponRejection(reader._closedPromise, r => {
     ReadableStreamDefaultControllerError(branch1._controller, r);
     ReadableStreamDefaultControllerError(branch2._controller, r);
-    resolvePromise(cancelPromise, undefined);
+    if (canceled1 === false || canceled2 === false) {
+      resolvePromise(cancelPromise, undefined);
+    }
   });
 
   return [branch1, branch2];

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -19,7 +19,7 @@
     "nyc": "^15.0.1",
     "opener": "^1.5.1",
     "webidl2js": "^16.2.0",
-    "wpt-runner": "^3.1.0"
+    "wpt-runner": "^3.2.1"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
[The following test](https://github.com/web-platform-tests/wpt/blob/e5e5e7a10cbb968b31c51ad87ce8a3da62bb1b34/streams/readable-streams/tee.any.js#L235-L246) is throwing an `AssertionError`:
```javascript
let controller;
const stream = new ReadableStream({ start(c) { controller = c; } });
const [branch1, branch2] = stream.tee();

controller.error("error");

branch1.cancel().catch(_=>_);
branch2.cancel().catch(_=>_);
```

This can be seen in our CI logs, e.g. [the latest run on `master`](https://github.com/whatwg/streams/runs/1905086996):
```
AssertionError: false == true
    at resolvePromise (eval at setup (/home/runner/work/streams/streams/reference-implementation/run-web-platform-tests.js:56:14), <anonymous>:6894:3)
    at eval (eval at setup (/home/runner/work/streams/streams/reference-implementation/run-web-platform-tests.js:56:14), <anonymous>:4831:5)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
  √ ReadableStream teeing: erroring a teed stream should error both branches
```
which refers to [this line in the reference implementation](https://github.com/whatwg/streams/blob/200c971563b1a695fce3eebe6dab45c348ff0ac0/reference-implementation/lib/helpers/webidl.js#L31):
```javascript
assert(stateIsPending(p) === true);
```
This indicates that we're attempting to resolve an already resolved promise. Although implementers are required to ignore such attempts, we try to avoid doing this in the specification, which is why we added this check in #1102. Unfortunately, it looks like we missed a case where this assertion fails...

This PR fixes it by checking if both branches have already been canceled in _"upon rejection of reader.[[closedPromise]]"_. If that's the case, then we will have already resolved `cancelPromise` and we don't need to resolve it again.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * web-platform-tests/wpt#28153
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1112.html" title="Last updated on Mar 20, 2021, 4:48 PM UTC (cf13bc2)">Preview</a> | <a href="https://whatpr.org/streams/1112/4b5b3cd...cf13bc2.html" title="Last updated on Mar 20, 2021, 4:48 PM UTC (cf13bc2)">Diff</a>