### PR TITLE
Support teeing readable byte streams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2328,8 +2328,7 @@ create them does not matter.
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] [=implements=]
     {{ReadableByteStreamController}}.
- 1. Let |reader| be undefined.
- 1. Let |readerType| be undefined.
+ 1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
  1. Let |reading| be false.
  1. Let |canceled1| be false.
  1. Let |canceled2| be false.
@@ -2338,34 +2337,21 @@ create them does not matter.
  1. Let |branch1| be undefined.
  1. Let |branch2| be undefined.
  1. Let |cancelPromise| be [=a new promise=].
- 1. Let |createReader| be the following steps, taking a |newReaderType| argument:
-  1. Let |newReader| be undefined.
-  1. If |newReaderType| is "`default`", set |newReader| to ?
-     [$AcquireReadableStreamDefaultReader$](|stream|).
-  1. Otherwise,
-   1. Assert: |newReaderType| is "`byob`".
-   1. Set |newReader| to ? [$AcquireReadableStreamBYOBReader$](|stream|).
-  1. Set |reader| to |newReader|.
-  1. Set |readerType| to |newReaderType|.
-  1. [=Upon rejection=] of |newReader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
+ 1. Let |forwardReaderError| be the following steps, taking a |thisReader| argument:
+  1. [=Upon rejection=] of |thisReader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
      |r|,
-   1. If |reader| is not |newReader|, return.
+   1. If |reader| is not |thisReader|, return.
    1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
       |r|).
    1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
       |r|).
    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
- 1. Let |releaseReader| be the following steps:
-  1. If |readerType| is "`default`",
-   1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
-  1. Otherwise,
-   1. Assert: |readerType| is "`byob`".
-   1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
-  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
  1. Let |pullWithDefaultReader| be the following steps:
-  1. If |readerType| is not "`default`",
-    1. Perform |releaseReader|.
-    1. Perform |createReader|, given "`default`".
+  1. If |reader| [=implements=] {{ReadableStreamBYOBReader}},
+   1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
+   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+   1. Set |reader| to ! [$AcquireReadableStreamDefaultReader$](|stream|).
+   1. Perform |forwardReaderError|, given |reader|.
   1. Let |readRequest| be a [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
    ::
@@ -2407,9 +2393,11 @@ create them does not matter.
     1. Set |reading| to false.
   1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
  1. Let |pullWithBYOBReader| be the following steps, given |view| and |forBranch2|:
-  1. If |readerType| is not "`byob`",
-    1. Perform |releaseReader|.
-    1. Perform |createReader|, given "`byob`".
+  1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
+   1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
+   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+   1. Set |reader| to ! [$AcquireReadableStreamBYOBReader$](|stream|).
+   1. Perform |forwardReaderError|, given |reader|.
   1. Let |readIntoRequest| be a [=read-into request=] with the following [=struct/items=]:
    : [=read-into request/chunk steps=], given |chunk|
    ::
@@ -2518,12 +2506,11 @@ create them does not matter.
    1. [=Resolve=] |cancelPromise| with |cancelResult|.
   1. Return |cancelPromise|.
  1. Let |startAlgorithm| be an algorithm that returns undefined.
- 1. Perform |createReader|, given "`default`".
-    <!-- TODO This can throw if the stream is locked, is that allowed? -->
  1. Set |branch1| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pull1Algorithm|,
     |cancel1Algorithm|).
  1. Set |branch2| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pull2Algorithm|,
     |cancel2Algorithm|).
+ 1. Perform |forwardReaderError|, given |reader|.
  1. Return « |branch1|, |branch2| ».
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2329,7 +2329,7 @@ create them does not matter.
  1. Let |forwardReaderError| be the following steps, taking a |thisReader| argument:
   1. [=Upon rejection=] of |thisReader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
      |r|,
-   1. If |reader| is not |thisReader|, return.
+   1. If |thisReader| is not |reader|, return.
    1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
       |r|).
    1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=],

--- a/index.bs
+++ b/index.bs
@@ -2407,20 +2407,16 @@ create them does not matter.
        1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
-      1. If |canceled2| is true,
-       1. Set |chunk| to ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
-          chunk.\[[ByteOffset]], 0 »).
-      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
+      1. If |canceled2| is false,
+       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
          |chunk|).
      1. Otherwise,
       1. If |canceled2| is false,
        1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
-      1. If |canceled1| is true,
-       1. Set |chunk| to ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
-          chunk.\[[ByteOffset]], 0 »).
-      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
+      1. If |canceled1| is false,
+       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
          |chunk|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to

--- a/index.bs
+++ b/index.bs
@@ -2376,9 +2376,9 @@ create them does not matter.
    ::
     1. Set |reading| to false.
     1. If |canceled1| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+       [$ReadableByteStreamControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
     1. If |canceled2| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+       [$ReadableByteStreamControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
     1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
        is not [=list/is empty|empty=], perform !
        [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
@@ -2433,9 +2433,9 @@ create them does not matter.
     1. Assert: |chunk|.\[[ByteLength]] is 0.
     1. Set |reading| to false.
     1. If |canceled1| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+       [$ReadableByteStreamControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
     1. If |canceled2| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+       [$ReadableByteStreamControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
     1. If |forBranch2| is true,
      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
         |chunk|).

--- a/index.bs
+++ b/index.bs
@@ -2409,13 +2409,10 @@ create them does not matter.
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
       1. If |canceled2| is true,
-       1. Let |emptyChunk| be ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
+       1. Set |chunk| to ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
           chunk.\[[ByteOffset]], 0 »).
-       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
-          |emptyChunk|).
-      1. Otherwise,
-       1. Perform ! [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=],
-          |chunk|.\[[ByteLength]]).
+      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
+         |chunk|).
      1. Otherwise,
       1. If |canceled2| is false,
        1. Let |clonedChunk| be ! [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk|),
@@ -2423,13 +2420,10 @@ create them does not matter.
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
       1. If |canceled1| is true,
-       1. Let |emptyChunk| be ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
+       1. Set |chunk| to ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
           chunk.\[[ByteOffset]], 0 »).
-       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
-          |emptyChunk|).
-      1. Otherwise,
-       1. Perform ! [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=],
-          |chunk|.\[[ByteLength]]).
+      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
+         |chunk|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to
     detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.

--- a/index.bs
+++ b/index.bs
@@ -2043,10 +2043,9 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateReadableByteStream"
- id="create-readable-byte-stream">CreateReadableByteStream(|startAlgorithm|, |pullAlgorithm|,
- |cancelAlgorithm|[, |highWaterMark|, [, |autoAllocateChunkSize|]])</dfn> performs the following
- steps:
+ <dfn abstract-op lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
+ |pullAlgorithm|, |cancelAlgorithm|[, |highWaterMark|, [, |autoAllocateChunkSize|]])</dfn>
+ performs the following steps:
 
  1. If |highWaterMark| was not passed, set it to 0.
  1. If |autoAllocateChunkSize| was not passed, set it to undefined.
@@ -2237,9 +2236,8 @@ create them does not matter.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultTee"
- id="readable-stream-default-tee">ReadableStreamDefaultTee(|stream|, |cloneForBranch2|)</dfn>
- performs the following steps:
+ <dfn abstract-op lt="ReadableStreamDefaultTee">ReadableStreamDefaultTee(|stream|,
+ |cloneForBranch2|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |cloneForBranch2| is a boolean.
@@ -2321,8 +2319,7 @@ create them does not matter.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamTee"
- id="readable-byte-stream-tee">ReadableByteStreamTee(|stream|)</dfn>
+ <dfn abstract-op lt="ReadableByteStreamTee">ReadableByteStreamTee(|stream|)</dfn>
  performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
@@ -3234,8 +3231,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerGetBYOBRequest"
- id="readable-byte-stream-controller-get-byob-request">ReadableByteStreamControllerGetBYOBRequest(|controller|)</dfn>
+ <dfn abstract-op lt="ReadableByteStreamControllerGetBYOBRequest">ReadableByteStreamControllerGetBYOBRequest(|controller|)</dfn>
  performs the following steps:
 
  1. If |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null and
@@ -6413,8 +6409,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CloneAsUint8Array"
- id="clone-as-uint8-array">CloneAsUint8Array(|O|)</dfn> performs the following steps:
+ <dfn abstract-op lt="CloneAsUint8Array">CloneAsUint8Array(|O|)</dfn> performs the following steps:
 
  1. Assert: [$Type$](|O|) is Object.
  1. Assert: |O| has an \[[ViewedArrayBuffer]] internal slot.

--- a/index.bs
+++ b/index.bs
@@ -2426,24 +2426,25 @@ create them does not matter.
 
    : [=read-into request/close steps=], given |chunk|
    ::
-    1. Assert: |chunk|.\[[ByteLength]] is 0.
     1. Set |reading| to false.
     1. If |canceled1| is false, perform !
        [$ReadableByteStreamControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
     1. If |canceled2| is false, perform !
        [$ReadableByteStreamControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
-    1. If |forBranch2| is true,
-     1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
-        |chunk|).
-     1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-        is not [=list/is empty|empty=], perform !
-        [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
-    1. Otherwise,
-     1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
-        |chunk|).
-     1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-        is not [=list/is empty|empty=], perform !
-        [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
+    1. If |chunk| is not undefined,
+     1. Assert: |chunk|.\[[ByteLength]] is 0.
+     1. If |forBranch2| is true,
+      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
+         |chunk|).
+      1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+         is not [=list/is empty|empty=], perform !
+         [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
+     1. Otherwise,
+      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
+         |chunk|).
+      1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+         is not [=list/is empty|empty=], perform !
+         [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
     1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read-into request/error steps=]

--- a/index.bs
+++ b/index.bs
@@ -2358,8 +2358,8 @@ create them does not matter.
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
      1. Let |chunk1| and |chunk2| be |chunk|.
-     1. If |canceled1| is false and |canceled2| is false, set |chunk2| to !
-        [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk|), [=the current Realm=]).
+     1. If |canceled1| is false and |canceled2| is false, set |chunk2| to ?
+        [$CloneAsUint8Array$](|chunk|).
      1. If |canceled1| is false, perform !
         [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
@@ -2404,8 +2404,7 @@ create them does not matter.
      1. Set |reading| to false.
      1. If |forBranch2| is true,
       1. If |canceled1| is false,
-       1. Let |clonedChunk| be ! [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk|),
-          [=the current Realm=]).
+       1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
       1. If |canceled2| is true,
@@ -2415,8 +2414,7 @@ create them does not matter.
          |chunk|).
      1. Otherwise,
       1. If |canceled2| is false,
-       1. Let |clonedChunk| be ! [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk|),
-          [=the current Realm=]).
+       1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
       1. If |canceled1| is true,
@@ -6431,6 +6429,19 @@ The following abstract operations are a grab-bag of utilities.
  1. Return a new {{ArrayBuffer}} object, created in [=the current Realm=], whose
     \[[ArrayBufferData]] internal slot value is |arrayBufferData| and whose
     \[[ArrayBufferByteLength]] internal slot value is |arrayBufferByteLength|.
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="CloneAsUint8Array"
+ id="clone-as-uint8-array">CloneAsUint8Array(|O|)</dfn> performs the following steps:
+
+ 1. Assert: [$Type$](|O|) is Object.
+ 1. Assert: |O| has an \[[ViewedArrayBuffer]] internal slot.
+ 1. Assert: ! [$IsDetachedBuffer$](|O|.\[[ViewedArrayBuffer]]) is false.
+ 1. Let |buffer| be ? [$CloneArrayBuffer$](|O|.\[[ViewedArrayBuffer]], |O|.\[[ByteOffset]],
+    |O|.\[[ByteLength]], {{%ArrayBuffer%}}).
+ 1. Let |array| be ! [$Construct$]({{%Uint8Array%}}, « |buffer| »).
+ 1. Return |array|.
 </div>
 
 <h2 id="other-specs">Using streams in other specifications</h2>

--- a/index.bs
+++ b/index.bs
@@ -2044,20 +2044,13 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 
 <div algorithm>
  <dfn abstract-op lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
- |pullAlgorithm|, |cancelAlgorithm|[, |highWaterMark|, [, |autoAllocateChunkSize|]])</dfn>
- performs the following steps:
+ |pullAlgorithm|, |cancelAlgorithm|)</dfn> performs the following steps:
 
- 1. If |highWaterMark| was not passed, set it to 0.
- 1. If |autoAllocateChunkSize| was not passed, set it to undefined.
- 1. Assert: ! [$IsNonNegativeNumber$](|highWaterMark|) is true.
- 1. If |autoAllocateChunkSize| is not undefined,
-  1. Assert: ! [$IsInteger$](|autoAllocateChunkSize|) is true.
-  1. Assert: |autoAllocateChunkSize| is positive.
  1. Let |stream| be a [=new=] {{ReadableStream}}.
  1. Perform ! [$InitializeReadableStream$](|stream|).
  1. Let |controller| be a [=new=] {{ReadableByteStreamController}}.
  1. Perform ? [$SetUpReadableByteStreamController$](|stream|, |controller|, |startAlgorithm|,
-    |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|, |autoAllocateChunkSize|).
+    |pullAlgorithm|, |cancelAlgorithm|, 0, undefined).
  1. Return |stream|.
 
  <p class="note">This abstract operation will throw an exception if and only if the supplied

--- a/index.bs
+++ b/index.bs
@@ -2371,21 +2371,16 @@ create them does not matter.
    ::
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
-     1. If |canceled1| is false and |canceled2| is false,
-      1. Let |clonedChunk| be ! [$Construct$](|chunk|.constructor, « |chunk| »).
+     1. Let |chunk1| and |chunk2| be |chunk|.
+     1. If |canceled1| is false and |canceled2| is false, set |chunk2| to !
+        [$Construct$](|chunk|.constructor, « |chunk| »).
          <!-- TODO: Create abstract op for cloning a TypedArray or DataView -->
-      1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
-         |chunk|).
-      1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
-         |clonedChunk|).
-     1. Otherwise, if |canceled1| is false,
-      1. Perform !
-         [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
-         |chunk|).
-     1. Otherwise, if |canceled2| is false,
-      1. Perform !
-         [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
-         |chunk|).
+     1. If |canceled1| is false, perform !
+        [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+        |chunk1|).
+     1. If |canceled2| is false, perform !
+        [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+        |chunk2|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to
     detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.

--- a/index.bs
+++ b/index.bs
@@ -2359,8 +2359,7 @@ create them does not matter.
      1. Set |reading| to false.
      1. Let |chunk1| and |chunk2| be |chunk|.
      1. If |canceled1| is false and |canceled2| is false, set |chunk2| to !
-        [$Construct$](|chunk|.constructor, « |chunk| »).
-         <!-- TODO: Create abstract op for cloning a TypedArray or DataView -->
+        [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk|), [=the current Realm=]).
      1. If |canceled1| is false, perform !
         [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
@@ -2405,8 +2404,8 @@ create them does not matter.
      1. Set |reading| to false.
      1. If |forBranch2| is true,
       1. If |canceled1| is false,
-       1. Let |clonedChunk| be ! [$Construct$](|chunk|.constructor, « |chunk| »).
-          <!-- TODO: Create abstract op for cloning a TypedArray or DataView -->
+       1. Let |clonedChunk| be ! [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk|),
+          [=the current Realm=]).
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
       1. If |canceled2| is true,
@@ -2419,8 +2418,8 @@ create them does not matter.
           |chunk|.\[[ByteLength]]).
      1. Otherwise,
       1. If |canceled2| is false,
-       1. Let |clonedChunk| be ! [$Construct$](|chunk|.constructor, « |chunk| »).
-          <!-- TODO: Create abstract op for cloning a TypedArray or DataView -->
+       1. Let |clonedChunk| be ! [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk|),
+          [=the current Realm=]).
        1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
           |clonedChunk|).
       1. If |canceled1| is true,

--- a/index.bs
+++ b/index.bs
@@ -1789,18 +1789,7 @@ has the following [=struct/items=]:
  The <dfn id="rbs-controller-byob-request" attribute
  for="ReadableByteStreamController">byobRequest</dfn> getter steps are:
 
- 1. If [=this=].[=ReadableByteStreamController/[[byobRequest]]=] is null and [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is
-    empty|empty=],
-  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |firstDescriptor|'s [=pull-into
-     descriptor/buffer=], |firstDescriptor|'s [=pull-into descriptor/byte offset=] +
-     |firstDescriptor|'s [=pull-into descriptor/bytes filled=], |firstDescriptor|'s [=pull-into
-     descriptor/byte length=] − |firstDescriptor|'s [=pull-into descriptor/bytes filled=] »).
-  1. Let |byobRequest| be a [=new=] {{ReadableStreamBYOBRequest}}.
-  1. Set |byobRequest|.[=ReadableStreamBYOBRequest/[[controller]]=] to [=this=].
-  1. Set |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] to |view|.
-  1. Set [=this=].[=ReadableByteStreamController/[[byobRequest]]=] to |byobRequest|.
- 1. Return [=this=].[=ReadableByteStreamController/[[byobRequest]]=].
+ 1. Return ! [$ReadableByteStreamControllerGetBYOBRequest$]([=this=]).
 </div>
 
 <div algorithm>
@@ -3063,6 +3052,25 @@ The following abstract operations support the implementation of the
   1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] &lt;
      |pullIntoDescriptor|'s [=pull-into descriptor/element size=].
  1. Return |ready|.
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="ReadableByteStreamControllerGetBYOBRequest"
+ id="readable-byte-stream-controller-get-byob-request">ReadableByteStreamControllerGetBYOBRequest(|controller|)</dfn>
+ performs the following steps:
+
+ 1. If |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null and
+    |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
+  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |firstDescriptor|'s [=pull-into
+     descriptor/buffer=], |firstDescriptor|'s [=pull-into descriptor/byte offset=] +
+     |firstDescriptor|'s [=pull-into descriptor/bytes filled=], |firstDescriptor|'s [=pull-into
+     descriptor/byte length=] − |firstDescriptor|'s [=pull-into descriptor/bytes filled=] »).
+  1. Let |byobRequest| be a [=new=] {{ReadableStreamBYOBRequest}}.
+  1. Set |byobRequest|.[=ReadableStreamBYOBRequest/[[controller]]=] to |controller|.
+  1. Set |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] to |view|.
+  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to |byobRequest|.
+ 1. Return |controller|.[=ReadableByteStreamController/[[byobRequest]]=].
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -2246,19 +2246,19 @@ create them does not matter.
   1. If |reading| is true, return [=a promise resolved with=] undefined.
   1. Set |reading| to true.
   1. Let |readRequest| be a [=read request=] with the following [=struct/items=]:
-   : [=read request/chunk steps=], given |value|
+   : [=read request/chunk steps=], given |chunk|
    ::
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
-     1. Let |value1| and |value2| be |value|.
-     1. If |canceled2| is false and |cloneForBranch2| is true, set |value2| to ?
-        [$StructuredDeserialize$](? [$StructuredSerialize$](|value2|), [=the current Realm=]).
+     1. Let |chunk1| and |chunk2| be |chunk|.
+     1. If |canceled2| is false and |cloneForBranch2| is true, set |chunk2| to ?
+        [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk2|), [=the current Realm=]).
      1. If |canceled1| is false, perform ?
         [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
-        |value1|).
+        |chunk1|).
      1. If |canceled2| is false, perform ?
         [$ReadableStreamDefaultControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
-        |value2|).
+        |chunk2|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to
     detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.

--- a/index.bs
+++ b/index.bs
@@ -2432,9 +2432,11 @@ create them does not matter.
        [$ReadableByteStreamControllerClose$](|otherBranch|.[=ReadableStream/[[controller]]=]).
     1. If |chunk| is not undefined,
      1. Assert: |chunk|.\[[ByteLength]] is 0.
-     1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+     1. If |byobCanceled| is false, perform !
+        [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
         |chunk|).
-     1. If |otherBranch|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+     1. If |otherCanceled| is false and
+        |otherBranch|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
         is not [=list/is empty|empty=], perform !
         [$ReadableByteStreamControllerRespond$](|otherBranch|.[=ReadableStream/[[controller]]=], 0).
     1. If |byobCanceled| is false or |otherCanceled| is false, [=resolve=] |cancelPromise| with undefined.

--- a/index.bs
+++ b/index.bs
@@ -2328,7 +2328,8 @@ create them does not matter.
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] [=implements=]
     {{ReadableByteStreamController}}.
- 1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
+ 1. Let |reader| be undefined.
+ 1. Let |readerType| be undefined.
  1. Let |reading| be false.
  1. Let |canceled1| be false.
  1. Let |canceled2| be false.
@@ -2337,9 +2338,34 @@ create them does not matter.
  1. Let |branch1| be undefined.
  1. Let |branch2| be undefined.
  1. Let |cancelPromise| be [=a new promise=].
- 1. Let |pullAlgorithm| be the following steps:
-  1. If |reading| is true, return [=a promise resolved with=] undefined.
-  1. Set |reading| to true.
+ 1. Let |createReader| be the following steps, taking a |newReaderType| argument:
+  1. Let |newReader| be undefined.
+  1. If |newReaderType| is "`default`", set |newReader| to ?
+     [$AcquireReadableStreamDefaultReader$](|stream|).
+  1. Otherwise,
+   1. Assert: |newReaderType| is "`byob`".
+   1. Set |newReader| to ? [$AcquireReadableStreamBYOBReader$](|stream|).
+  1. Set |reader| to |newReader|.
+  1. Set |readerType| to |newReaderType|.
+  1. [=Upon rejection=] of |newReader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
+     |r|,
+   1. If |reader| is not |newReader|, return.
+   1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
+      |r|).
+   1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
+      |r|).
+   1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
+ 1. Let |releaseReader| be the following steps:
+  1. If |readerType| is "`default`",
+   1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
+  1. Otherwise,
+   1. Assert: |readerType| is "`byob`".
+   1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
+  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+ 1. Let |pullWithDefaultReader| be the following steps:
+  1. If |readerType| is not "`default`",
+    1. Perform |releaseReader|.
+    1. Perform |createReader|, given "`default`".
   1. Let |readRequest| be a [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
    ::
@@ -2369,31 +2395,116 @@ create them does not matter.
    : [=read request/close steps=]
    ::
     1. Set |reading| to false.
-    1. If |canceled1| is false,
-     1. Perform !
-        [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
-     1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-        is not [=list/is empty|empty=], perform !
-        [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
-    1. If |canceled2| is false,
-     1. Perform !
-        [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
-     1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-        is not [=list/is empty|empty=], perform !
-        [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
+    1. If |canceled1| is false, perform !
+       [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+    1. If |canceled2| is false, perform !
+       [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+    1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+       is not [=list/is empty|empty=], perform !
+       [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
+    1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+       is not [=list/is empty|empty=], perform !
+       [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
     1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read request/error steps=]
    ::
     1. Set |reading| to false.
   1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
+ 1. Let |pullWithBYOBReader| be the following steps, given |view| and |forBranch2|:
+  1. If |readerType| is not "`byob`",
+    1. Perform |releaseReader|.
+    1. Perform |createReader|, given "`byob`".
+  1. Let |readIntoRequest| be a [=read-into request=] with the following [=struct/items=]:
+   : [=read-into request/chunk steps=], given |chunk|
+   ::
+    1. [=Queue a microtask=] to perform the following steps:
+     1. Set |reading| to false.
+     1. If |forBranch2| is true,
+      1. If |canceled1| is false,
+       1. Let |clonedChunk| be ! [$Construct$](|chunk|.constructor, « |chunk| »).
+          <!-- TODO: Create abstract op for cloning a TypedArray or DataView -->
+       1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+          |clonedChunk|).
+      1. If |canceled2| is true,
+       1. Let |emptyChunk| be ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
+          chunk.\[[ByteOffset]], 0 »).
+       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
+          |emptyChunk|).
+      1. Otherwise,
+       1. Perform ! [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=],
+          |chunk|.\[[ByteLength]]).
+     1. Otherwise,
+      1. If |canceled2| is false,
+       1. Let |clonedChunk| be ! [$Construct$](|chunk|.constructor, « |chunk| »).
+          <!-- TODO: Create abstract op for cloning a TypedArray or DataView -->
+       1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+          |clonedChunk|).
+      1. If |canceled1| is true,
+       1. Let |emptyChunk| be ! [$Construct$]({{%Uint8Array%}}, « |chunk|.\[[ViewedArrayBuffer]],
+          chunk.\[[ByteOffset]], 0 »).
+       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
+          |emptyChunk|).
+      1. Otherwise,
+       1. Perform ! [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=],
+          |chunk|.\[[ByteLength]]).
+
+    <p class="note">The microtask delay here is necessary because it takes at least a microtask to
+    detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.
+    We want errors in |stream| to error both branches immediately, so we cannot let successful
+    synchronously-available reads happen ahead of asynchronously-available errors.
+
+   : [=read-into request/close steps=], given |chunk|
+   ::
+    1. Assert: |chunk|.\[[ByteLength]] is 0.
+    1. Set |reading| to false.
+    1. If |canceled1| is false, perform !
+       [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+    1. If |canceled2| is false, perform !
+       [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+    1. If |forBranch2| is true,
+     1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
+        |chunk|).
+     1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+        is not [=list/is empty|empty=], perform !
+        [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
+    1. Otherwise,
+     1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
+        |chunk|).
+     1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+        is not [=list/is empty|empty=], perform !
+        [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
+    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
+
+   : [=read-into request/error steps=]
+   ::
+    1. Set |reading| to false.
+  1. Perform ! [$ReadableStreamBYOBReaderRead$](|reader|, |view|, |readIntoRequest|).
+ 1. Let |pull1Algorithm| be the following steps:
+  1. If |reading| is true, return [=a promise resolved with=] undefined.
+  1. Set |reading| to true.
+  1. Let |byobRequest| be ! [$ReadableByteStreamControllerGetBYOBRequest$](|branch1|.[=ReadableStream/[[controller]]=]).
+  1. If |byobRequest| is null,
+   1. Perform |pullWithDefaultReader|.
+  1. Otherwise,
+   1. Perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and false.
+  1. Return [=a promise resolved with=] undefined.
+ 1. Let |pull2Algorithm| be the following steps:
+  1. If |reading| is true, return [=a promise resolved with=] undefined.
+  1. Set |reading| to true.
+  1. Let |byobRequest| be ! [$ReadableByteStreamControllerGetBYOBRequest$](|branch2|.[=ReadableStream/[[controller]]=]).
+  1. If |byobRequest| is null,
+   1. Perform |pullWithDefaultReader|.
+  1. Otherwise,
+   1. Perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and true.
   1. Return [=a promise resolved with=] undefined.
  1. Let |cancel1Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled1| to true.
   1. Set |reason1| to |reason|.
-  1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-     is not [=list/is empty|empty=], perform !
-     [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
+  1. If |reading| is false and
+     |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+     is not [=list/is empty|empty=],
+   1. Perform ! [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
   1. If |canceled2| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
    1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
@@ -2402,26 +2513,22 @@ create them does not matter.
  1. Let |cancel2Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled2| to true.
   1. Set |reason2| to |reason|.
-  1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-     is not [=list/is empty|empty=], perform !
-     [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
+  1. If |reading| is false and
+     |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+     is not [=list/is empty|empty=],
+   1. Perform ! [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
   1. If |canceled1| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
    1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
    1. [=Resolve=] |cancelPromise| with |cancelResult|.
   1. Return |cancelPromise|.
  1. Let |startAlgorithm| be an algorithm that returns undefined.
- 1. Set |branch1| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pullAlgorithm|,
+ 1. Perform |createReader|, given "`default`".
+    <!-- TODO This can throw if the stream is locked, is that allowed? -->
+ 1. Set |branch1| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pull1Algorithm|,
     |cancel1Algorithm|).
- 1. Set |branch2| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pullAlgorithm|,
+ 1. Set |branch2| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pull2Algorithm|,
     |cancel2Algorithm|).
- 1. [=Upon rejection=] of |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
-    |r|,
-  1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
-     |r|).
-  1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
-     |r|).
-  1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
  1. Return « |branch1|, |branch2| ».
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2238,7 +2238,7 @@ create them does not matter.
 
 <div algorithm>
  <dfn abstract-op lt="ReadableStreamDefaultTee"
- id="readable-stream-default-tee">ReadableStreamTee(|stream|, |cloneForBranch2|)</dfn>
+ id="readable-stream-default-tee">ReadableStreamDefaultTee(|stream|, |cloneForBranch2|)</dfn>
  performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.

--- a/index.bs
+++ b/index.bs
@@ -2439,19 +2439,15 @@ create them does not matter.
   1. If |reading| is true, return [=a promise resolved with=] undefined.
   1. Set |reading| to true.
   1. Let |byobRequest| be ! [$ReadableByteStreamControllerGetBYOBRequest$](|branch1|.[=ReadableStream/[[controller]]=]).
-  1. If |byobRequest| is null,
-   1. Perform |pullWithDefaultReader|.
-  1. Otherwise,
-   1. Perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and false.
+  1. If |byobRequest| is null, perform |pullWithDefaultReader|.
+  1. Otherwise, perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and false.
   1. Return [=a promise resolved with=] undefined.
  1. Let |pull2Algorithm| be the following steps:
   1. If |reading| is true, return [=a promise resolved with=] undefined.
   1. Set |reading| to true.
   1. Let |byobRequest| be ! [$ReadableByteStreamControllerGetBYOBRequest$](|branch2|.[=ReadableStream/[[controller]]=]).
-  1. If |byobRequest| is null,
-   1. Perform |pullWithDefaultReader|.
-  1. Otherwise,
-   1. Perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and true.
+  1. If |byobRequest| is null, perform |pullWithDefaultReader|.
+  1. Otherwise, perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and true.
   1. Return [=a promise resolved with=] undefined.
  1. Let |cancel1Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled1| to true.

--- a/index.bs
+++ b/index.bs
@@ -2397,10 +2397,13 @@ create them does not matter.
      1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
      1. If |otherCanceled| is false,
       1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
+      1. If |byobCanceled| is false, perform !
+         [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+         |chunk|).
       1. Perform ! [$ReadableByteStreamControllerEnqueue$](|otherBranch|.[=ReadableStream/[[controller]]=],
          |clonedChunk|).
-     1. If |byobCanceled| is false,
-      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+     1. Otherwise, if |byobCanceled| is false, perform !
+        [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
         |chunk|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to

--- a/index.bs
+++ b/index.bs
@@ -2252,7 +2252,7 @@ create them does not matter.
      1. Set |reading| to false.
      1. Let |chunk1| and |chunk2| be |chunk|.
      1. If |canceled2| is false and |cloneForBranch2| is true, set |chunk2| to ?
-        [$StructuredDeserialize$](? [$StructuredSerialize$](|chunk2|), [=the current Realm=]).
+        [$StructuredClone$](|chunk2|).
      1. If |canceled1| is false, perform ?
         [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
@@ -6409,6 +6409,13 @@ The following abstract operations are a grab-bag of utilities.
     |O|.\[[ByteLength]], {{%ArrayBuffer%}}).
  1. Let |array| be ! [$Construct$]({{%Uint8Array%}}, « |buffer| »).
  1. Return |array|.
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="StructuredClone">StructuredClone(|v|)</dfn> performs the following steps:
+
+ 1. Let |serialized| be ? [$StructuredSerialize$](|v|).
+ 1. Return ? [$StructuredDeserialize$](|serialized|, [=the current Realm=]).
 </div>
 
 <h2 id="other-specs">Using streams in other specifications</h2>

--- a/index.bs
+++ b/index.bs
@@ -2230,6 +2230,19 @@ create them does not matter.
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |cloneForBranch2| is a boolean.
+ 1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
+  1. Return ? [$ReadableByteStreamTee$](|stream|).
+ 1. Otherwise,
+  1. Return ? [$ReadableStreamDefaultTee$](|stream|, |cloneForBranch2|).
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="ReadableStreamDefaultTee"
+ id="readable-stream-default-tee">ReadableStreamTee(|stream|, |cloneForBranch2|)</dfn>
+ performs the following steps:
+
+ 1. Assert: |stream| [=implements=] {{ReadableStream}}.
+ 1. Assert: |cloneForBranch2| is a boolean.
  1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
  1. Let |reading| be false.
  1. Let |canceled1| be false.
@@ -2308,23 +2321,13 @@ create them does not matter.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamTee2" id="readable-stream-tee2">ReadableStreamTee2(|stream|,
- |cloneForBranch2|)</dfn> will [=tee a readable stream|tee=] a given readable stream.
-
- The second argument, |cloneForBranch2|, governs whether or not the data from the original stream
- will be cloned (using HTML's [=serializable objects=] framework) before appearing in the second of
- the returned branches. This is useful for scenarios where both branches are to be consumed in such
- a way that they might otherwise interfere with each other, such as by [=transferable
- objects|transferring=] their [=chunks=]. However, it does introduce a noticeable asymmetry between
- the two branches, and limits the possible [=chunks=] to serializable ones. [[!HTML]]
-
- <p class="note">In this standard ReadableStreamTee is always called with |cloneForBranch2| set to
- false; other specifications pass true via the [=ReadableStream/tee=] wrapper algorithm.
-
- It performs the following steps:
+ <dfn abstract-op lt="ReadableByteStreamTee"
+ id="readable-byte-stream-tee">ReadableByteStreamTee(|stream|)</dfn>
+ performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
- 1. Assert: |cloneForBranch2| is a boolean.
+ 1. Assert: |stream|.[=ReadableStream/[[controller]]=] [=implements=]
+    {{ReadableByteStreamController}}.
  1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
  1. Let |reading| be false.
  1. Let |canceled1| be false.
@@ -2338,19 +2341,25 @@ create them does not matter.
   1. If |reading| is true, return [=a promise resolved with=] undefined.
   1. Set |reading| to true.
   1. Let |readRequest| be a [=read request=] with the following [=struct/items=]:
-   : [=read request/chunk steps=], given |value|
+   : [=read request/chunk steps=], given |chunk|
    ::
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
-     1. Let |value1| and |value2| be |value|.
-     1. If |canceled2| is false and |cloneForBranch2| is true, set |value2| to ?
-        [$StructuredDeserialize$](? [$StructuredSerialize$](|value2|), [=the current Realm=]).
-     1. If |canceled1| is false, perform ?
-        [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
-        |value1|).
-     1. If |canceled2| is false, perform ?
-        [$ReadableStreamDefaultControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
-        |value2|).
+     1. If |canceled1| is false and |canceled2| is false,
+      1. Let |clonedChunk| be ! [$Construct$](|chunk|.constructor, « |chunk| »).
+         <!-- TODO: Create abstract op for cloning a TypedArray or DataView -->
+      1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+         |chunk|).
+      1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+         |clonedChunk|).
+     1. Otherwise, if |canceled1| is false,
+      1. Perform !
+         [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+         |chunk|).
+     1. Otherwise, if |canceled2| is false,
+      1. Perform !
+         [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+         |chunk|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to
     detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.
@@ -2360,10 +2369,18 @@ create them does not matter.
    : [=read request/close steps=]
    ::
     1. Set |reading| to false.
-    1. If |canceled1| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
-    1. If |canceled2| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+    1. If |canceled1| is false,
+     1. Perform !
+        [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+     1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+        is not [=list/is empty|empty=], perform !
+        [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
+    1. If |canceled2| is false,
+     1. Perform !
+        [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+     1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+        is not [=list/is empty|empty=], perform !
+        [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
     1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read request/error steps=]
@@ -2374,6 +2391,9 @@ create them does not matter.
  1. Let |cancel1Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled1| to true.
   1. Set |reason1| to |reason|.
+  1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+     is not [=list/is empty|empty=], perform !
+     [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
   1. If |canceled2| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
    1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
@@ -2382,21 +2402,24 @@ create them does not matter.
  1. Let |cancel2Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled2| to true.
   1. Set |reason2| to |reason|.
+  1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+     is not [=list/is empty|empty=], perform !
+     [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
   1. If |canceled1| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
    1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
    1. [=Resolve=] |cancelPromise| with |cancelResult|.
   1. Return |cancelPromise|.
  1. Let |startAlgorithm| be an algorithm that returns undefined.
- 1. Set |branch1| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
+ 1. Set |branch1| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancel1Algorithm|).
- 1. Set |branch2| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
+ 1. Set |branch2| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pullAlgorithm|,
     |cancel2Algorithm|).
  1. [=Upon rejection=] of |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
     |r|,
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
+  1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
      |r|).
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
+  1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
      |r|).
   1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
  1. Return « |branch1|, |branch2| ».

--- a/index.bs
+++ b/index.bs
@@ -2475,10 +2475,6 @@ create them does not matter.
  1. Let |cancel1Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled1| to true.
   1. Set |reason1| to |reason|.
-  1. If |reading| is false and
-     |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-     is not [=list/is empty|empty=],
-   1. Perform ! [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
   1. If |canceled2| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
    1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
@@ -2487,10 +2483,6 @@ create them does not matter.
  1. Let |cancel2Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled2| to true.
   1. Set |reason2| to |reason|.
-  1. If |reading| is false and
-     |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-     is not [=list/is empty|empty=],
-   1. Perform ! [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
   1. If |canceled1| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
    1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).

--- a/index.bs
+++ b/index.bs
@@ -2397,13 +2397,13 @@ create them does not matter.
    1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
    1. Set |reader| to ! [$AcquireReadableStreamBYOBReader$](|stream|).
    1. Perform |forwardReaderError|, given |reader|.
+  1. Let |byobBranch| be |branch2| if |forBranch2| is true, and |branch1| otherwise.
+  1. Let |otherBranch| be |branch2| if |forBranch2| is false, and |branch1| otherwise.
   1. Let |readIntoRequest| be a [=read-into request=] with the following [=struct/items=]:
    : [=read-into request/chunk steps=], given |chunk|
    ::
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
-     1. Let |byobBranch| be |branch2| if |forBranch2| is true, and |branch1| otherwise.
-     1. Let |otherBranch| be |branch2| if |forBranch2| is false, and |branch1| otherwise.
      1. Let |byobCanceled| be |canceled2| if |forBranch2| is true, and |canceled1| otherwise.
      1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
      1. If |otherCanceled| is false,
@@ -2422,8 +2422,6 @@ create them does not matter.
    : [=read-into request/close steps=], given |chunk|
    ::
     1. Set |reading| to false.
-    1. Let |byobBranch| be |branch2| if |forBranch2| is true, and |branch1| otherwise.
-    1. Let |otherBranch| be |branch2| if |forBranch2| is false, and |branch1| otherwise.
     1. Let |byobCanceled| be |canceled2| if |forBranch2| is true, and |canceled1| otherwise.
     1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
     1. If |byobCanceled| is false, perform !

--- a/index.bs
+++ b/index.bs
@@ -2054,15 +2054,10 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateReadableByteStream" id="create-readable-byte-stream"
- export>CreateReadableByteStream(|startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|[,
- |highWaterMark|, [, |autoAllocateChunkSize|]])</dfn> is meant to be called from other
- specifications that wish to create {{ReadableStream}} instances that represent [=readable byte
- streams=]. The |pullAlgorithm| and |cancelAlgorithm| algorithms must return promises; if supplied,
- |highWaterMark| must be a non-negative, non-NaN number, and, if supplied, |autoAllocateChunkSize|
- must be a positive integer.
-
- It performs the following steps:
+ <dfn abstract-op lt="CreateReadableByteStream"
+ id="create-readable-byte-stream">CreateReadableByteStream(|startAlgorithm|, |pullAlgorithm|,
+ |cancelAlgorithm|[, |highWaterMark|, [, |autoAllocateChunkSize|]])</dfn> performs the following
+ steps:
 
  1. If |highWaterMark| was not passed, set it to 0.
  1. If |autoAllocateChunkSize| was not passed, set it to undefined.

--- a/index.bs
+++ b/index.bs
@@ -764,8 +764,9 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
   resulting branches; a composite cancellation reason will then be propagated to the stream's
   [=underlying source=].
 
-  <p>Note that the [=chunks=] seen in each branch will be the same object. If the chunks are not
-  immutable, this could allow interference between the two branches.
+  <p>If this stream is a [=readable byte stream=], then each branch will receive its own copy of
+  each [=chunk=]. If not, then the chunks seen in each branch will be the same object.
+  If the chunks are not immutable, this could allow interference between the two branches.
 </dl>
 
 <div algorithm>
@@ -2214,6 +2215,9 @@ create them does not matter.
  a way that they might otherwise interfere with each other, such as by [=transferable
  objects|transferring=] their [=chunks=]. However, it does introduce a noticeable asymmetry between
  the two branches, and limits the possible [=chunks=] to serializable ones. [[!HTML]]
+
+ If |stream| is a [=readable byte stream=], then |cloneForBranch2| is ignored and chunks are cloned
+ unconditionally.
 
  <p class="note">In this standard ReadableStreamTee is always called with |cloneForBranch2| set to
  false; other specifications pass true via the [=ReadableStream/tee=] wrapper algorithm.

--- a/index.bs
+++ b/index.bs
@@ -2223,9 +2223,8 @@ create them does not matter.
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |cloneForBranch2| is a boolean.
  1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
-  1. Return ? [$ReadableByteStreamTee$](|stream|).
- 1. Otherwise,
-  1. Return ? [$ReadableStreamDefaultTee$](|stream|, |cloneForBranch2|).
+    return ? [$ReadableByteStreamTee$](|stream|).
+ 1. Return ? [$ReadableStreamDefaultTee$](|stream|, |cloneForBranch2|).
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -2251,8 +2251,14 @@ create them does not matter.
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
      1. Let |chunk1| and |chunk2| be |chunk|.
-     1. If |canceled2| is false and |cloneForBranch2| is true, set |chunk2| to ?
-        [$StructuredClone$](|chunk2|).
+     1. If |canceled2| is false and |cloneForBranch2| is true,
+      1. Let |cloneResult| be [$StructuredClone$](|chunk2|).
+      1. If |cloneResult| is an abrupt completion,
+       1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. [=Resolve=] |cancelPromise| with ! [$ReadableStreamCancel$](|stream|, |cloneResult|.\[[Value]]).
+       1. Return.
+      1. Otherwise, set |chunk2| to |cloneResult|.\[[Value]].
      1. If |canceled1| is false, perform !
         [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
@@ -2347,8 +2353,14 @@ create them does not matter.
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
      1. Let |chunk1| and |chunk2| be |chunk|.
-     1. If |canceled1| is false and |canceled2| is false, set |chunk2| to ?
-        [$CloneAsUint8Array$](|chunk|).
+     1. If |canceled1| is false and |canceled2| is false,
+      1. Let |cloneResult| be [$CloneAsUint8Array$](|chunk|).
+      1. If |cloneResult| is an abrupt completion,
+       1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. [=Resolve=] |cancelPromise| with ! [$ReadableStreamCancel$](|stream|, |cloneResult|.\[[Value]]).
+       1. Return.
+      1. Otherwise, set |chunk2| to |cloneResult|.\[[Value]].
      1. If |canceled1| is false, perform !
         [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
@@ -2396,7 +2408,13 @@ create them does not matter.
      1. Let |byobCanceled| be |canceled2| if |forBranch2| is true, and |canceled1| otherwise.
      1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
      1. If |otherCanceled| is false,
-      1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
+      1. Let |cloneResult| be [$CloneAsUint8Array$](|chunk|).
+      1. If |cloneResult| is an abrupt completion,
+       1. Perform ! [$ReadableByteStreamControllerError$](|byobBranch|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. Perform ! [$ReadableByteStreamControllerError$](|otherBranch|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. [=Resolve=] |cancelPromise| with ! [$ReadableStreamCancel$](|stream|, |cloneResult|.\[[Value]]).
+       1. Return.
+      1. Otherwise, let |clonedChunk| be |cloneResult|.\[[Value]].
       1. If |byobCanceled| is false, perform !
          [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
          |chunk|).

--- a/index.bs
+++ b/index.bs
@@ -2253,10 +2253,10 @@ create them does not matter.
      1. Let |chunk1| and |chunk2| be |chunk|.
      1. If |canceled2| is false and |cloneForBranch2| is true, set |chunk2| to ?
         [$StructuredClone$](|chunk2|).
-     1. If |canceled1| is false, perform ?
+     1. If |canceled1| is false, perform !
         [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
-     1. If |canceled2| is false, perform ?
+     1. If |canceled2| is false, perform !
         [$ReadableStreamDefaultControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
         |chunk2|).
 

--- a/index.bs
+++ b/index.bs
@@ -2054,6 +2054,34 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
+ <dfn abstract-op lt="CreateReadableByteStream" id="create-readable-byte-stream"
+ export>CreateReadableByteStream(|startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|[,
+ |highWaterMark|, [, |autoAllocateChunkSize|]])</dfn> is meant to be called from other
+ specifications that wish to create {{ReadableStream}} instances that represent [=readable byte
+ streams=]. The |pullAlgorithm| and |cancelAlgorithm| algorithms must return promises; if supplied,
+ |highWaterMark| must be a non-negative, non-NaN number, and, if supplied, |autoAllocateChunkSize|
+ must be a positive integer.
+
+ It performs the following steps:
+
+ 1. If |highWaterMark| was not passed, set it to 0.
+ 1. If |autoAllocateChunkSize| was not passed, set it to undefined.
+ 1. Assert: ! [$IsNonNegativeNumber$](|highWaterMark|) is true.
+ 1. If |autoAllocateChunkSize| is not undefined,
+  1. Assert: ! [$IsInteger$](|autoAllocateChunkSize|) is true.
+  1. Assert: |autoAllocateChunkSize| is positive.
+ 1. Let |stream| be a [=new=] {{ReadableStream}}.
+ 1. Perform ! [$InitializeReadableStream$](|stream|).
+ 1. Let |controller| be a [=new=] {{ReadableByteStreamController}}.
+ 1. Perform ? [$SetUpReadableByteStreamController$](|stream|, |controller|, |startAlgorithm|,
+    |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|, |autoAllocateChunkSize|).
+ 1. Return |stream|.
+
+ <p class="note">This abstract operation will throw an exception if and only if the supplied
+ |startAlgorithm| throws.
+</div>
+
+<div algorithm>
  <dfn abstract-op lt="InitializeReadableStream"
  id="initialize-readable-stream">InitializeReadableStream(|stream|)</dfn> performs the following
  steps:

--- a/index.bs
+++ b/index.bs
@@ -2402,22 +2402,17 @@ create them does not matter.
    ::
     1. [=Queue a microtask=] to perform the following steps:
      1. Set |reading| to false.
-     1. If |forBranch2| is true,
-      1. If |canceled1| is false,
-       1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
-       1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
-          |clonedChunk|).
-      1. If |canceled2| is false,
-       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
-         |chunk|).
-     1. Otherwise,
-      1. If |canceled2| is false,
-       1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
-       1. Perform ! [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
-          |clonedChunk|).
-      1. If |canceled1| is false,
-       1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
-         |chunk|).
+     1. Let |byobBranch| be |branch2| if |forBranch2| is true, and |branch1| otherwise.
+     1. Let |otherBranch| be |branch2| if |forBranch2| is false, and |branch1| otherwise.
+     1. Let |byobCanceled| be |canceled2| if |forBranch2| is true, and |canceled1| otherwise.
+     1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
+     1. If |otherCanceled| is false,
+      1. Let |clonedChunk| be ? [$CloneAsUint8Array$](|chunk|).
+      1. Perform ! [$ReadableByteStreamControllerEnqueue$](|otherBranch|.[=ReadableStream/[[controller]]=],
+         |clonedChunk|).
+     1. If |byobCanceled| is false,
+      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+        |chunk|).
 
     <p class="note">The microtask delay here is necessary because it takes at least a microtask to
     detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.
@@ -2427,25 +2422,22 @@ create them does not matter.
    : [=read-into request/close steps=], given |chunk|
    ::
     1. Set |reading| to false.
-    1. If |canceled1| is false, perform !
-       [$ReadableByteStreamControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
-    1. If |canceled2| is false, perform !
-       [$ReadableByteStreamControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+    1. Let |byobBranch| be |branch2| if |forBranch2| is true, and |branch1| otherwise.
+    1. Let |otherBranch| be |branch2| if |forBranch2| is false, and |branch1| otherwise.
+    1. Let |byobCanceled| be |canceled2| if |forBranch2| is true, and |canceled1| otherwise.
+    1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
+    1. If |byobCanceled| is false, perform !
+       [$ReadableByteStreamControllerClose$](|byobBranch|.[=ReadableStream/[[controller]]=]).
+    1. If |otherCanceled| is false, perform !
+       [$ReadableByteStreamControllerClose$](|otherBranch|.[=ReadableStream/[[controller]]=]).
     1. If |chunk| is not undefined,
      1. Assert: |chunk|.\[[ByteLength]] is 0.
-     1. If |forBranch2| is true,
-      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch2|.[=ReadableStream/[[controller]]=],
-         |chunk|).
-      1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-         is not [=list/is empty|empty=], perform !
-         [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
-     1. Otherwise,
-      1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|branch1|.[=ReadableStream/[[controller]]=],
-         |chunk|).
-      1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
-         is not [=list/is empty|empty=], perform !
-         [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
-    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
+     1. Perform ! [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+        |chunk|).
+     1. If |otherBranch|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
+        is not [=list/is empty|empty=], perform !
+        [$ReadableByteStreamControllerRespond$](|otherBranch|.[=ReadableStream/[[controller]]=], 0).
+    1. If |byobCanceled| is false or |otherCanceled| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read-into request/error steps=]
    ::

--- a/index.bs
+++ b/index.bs
@@ -2307,6 +2307,101 @@ create them does not matter.
  1. Return « |branch1|, |branch2| ».
 </div>
 
+<div algorithm>
+ <dfn abstract-op lt="ReadableStreamTee2" id="readable-stream-tee2">ReadableStreamTee2(|stream|,
+ |cloneForBranch2|)</dfn> will [=tee a readable stream|tee=] a given readable stream.
+
+ The second argument, |cloneForBranch2|, governs whether or not the data from the original stream
+ will be cloned (using HTML's [=serializable objects=] framework) before appearing in the second of
+ the returned branches. This is useful for scenarios where both branches are to be consumed in such
+ a way that they might otherwise interfere with each other, such as by [=transferable
+ objects|transferring=] their [=chunks=]. However, it does introduce a noticeable asymmetry between
+ the two branches, and limits the possible [=chunks=] to serializable ones. [[!HTML]]
+
+ <p class="note">In this standard ReadableStreamTee is always called with |cloneForBranch2| set to
+ false; other specifications pass true via the [=ReadableStream/tee=] wrapper algorithm.
+
+ It performs the following steps:
+
+ 1. Assert: |stream| [=implements=] {{ReadableStream}}.
+ 1. Assert: |cloneForBranch2| is a boolean.
+ 1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
+ 1. Let |reading| be false.
+ 1. Let |canceled1| be false.
+ 1. Let |canceled2| be false.
+ 1. Let |reason1| be undefined.
+ 1. Let |reason2| be undefined.
+ 1. Let |branch1| be undefined.
+ 1. Let |branch2| be undefined.
+ 1. Let |cancelPromise| be [=a new promise=].
+ 1. Let |pullAlgorithm| be the following steps:
+  1. If |reading| is true, return [=a promise resolved with=] undefined.
+  1. Set |reading| to true.
+  1. Let |readRequest| be a [=read request=] with the following [=struct/items=]:
+   : [=read request/chunk steps=], given |value|
+   ::
+    1. [=Queue a microtask=] to perform the following steps:
+     1. Set |reading| to false.
+     1. Let |value1| and |value2| be |value|.
+     1. If |canceled2| is false and |cloneForBranch2| is true, set |value2| to ?
+        [$StructuredDeserialize$](? [$StructuredSerialize$](|value2|), [=the current Realm=]).
+     1. If |canceled1| is false, perform ?
+        [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+        |value1|).
+     1. If |canceled2| is false, perform ?
+        [$ReadableStreamDefaultControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+        |value2|).
+
+    <p class="note">The microtask delay here is necessary because it takes at least a microtask to
+    detect errors, when we use |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] below.
+    We want errors in |stream| to error both branches immediately, so we cannot let successful
+    synchronously-available reads happen ahead of asynchronously-available errors.
+
+   : [=read request/close steps=]
+   ::
+    1. Set |reading| to false.
+    1. If |canceled1| is false, perform !
+       [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+    1. If |canceled2| is false, perform !
+       [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
+
+   : [=read request/error steps=]
+   ::
+    1. Set |reading| to false.
+  1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
+  1. Return [=a promise resolved with=] undefined.
+ 1. Let |cancel1Algorithm| be the following steps, taking a |reason| argument:
+  1. Set |canceled1| to true.
+  1. Set |reason1| to |reason|.
+  1. If |canceled2| is true,
+   1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
+   1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
+   1. [=Resolve=] |cancelPromise| with |cancelResult|.
+  1. Return |cancelPromise|.
+ 1. Let |cancel2Algorithm| be the following steps, taking a |reason| argument:
+  1. Set |canceled2| to true.
+  1. Set |reason2| to |reason|.
+  1. If |canceled1| is true,
+   1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
+   1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
+   1. [=Resolve=] |cancelPromise| with |cancelResult|.
+  1. Return |cancelPromise|.
+ 1. Let |startAlgorithm| be an algorithm that returns undefined.
+ 1. Set |branch1| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
+    |cancel1Algorithm|).
+ 1. Set |branch2| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
+    |cancel2Algorithm|).
+ 1. [=Upon rejection=] of |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
+    |r|,
+  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
+     |r|).
+  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
+     |r|).
+  1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
+ 1. Return « |branch1|, |branch2| ».
+</div>
+
 <h4 id="rs-abstract-ops-used-by-controllers">Interfacing with controllers</h4>
 
 In terms of specification factoring, the way that the {{ReadableStream}} class encapsulates the

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -5,23 +5,9 @@ const { CancelSteps, PullSteps } = require('./abstract-ops/internal-methods.js')
 const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
 const aos = require('./abstract-ops/readable-streams.js');
 
-const ReadableStreamBYOBRequest = require('../generated/ReadableStreamBYOBRequest.js');
-
 exports.implementation = class ReadableByteStreamControllerImpl {
   get byobRequest() {
-    if (this._byobRequest === null && this._pendingPullIntos.length > 0) {
-      const firstDescriptor = this._pendingPullIntos[0];
-      const view = new Uint8Array(firstDescriptor.buffer,
-                                  firstDescriptor.byteOffset + firstDescriptor.bytesFilled,
-                                  firstDescriptor.byteLength - firstDescriptor.bytesFilled);
-
-      const byobRequest = ReadableStreamBYOBRequest.new(globalThis);
-      byobRequest._controller = this;
-      byobRequest._view = view;
-      this._byobRequest = byobRequest;
-    }
-
-    return this._byobRequest;
+    return aos.ReadableByteStreamControllerGetBYOBRequest(this);
   }
 
   get desiredSize() {

--- a/reference-implementation/lib/abstract-ops/miscellaneous.js
+++ b/reference-implementation/lib/abstract-ops/miscellaneous.js
@@ -15,3 +15,8 @@ exports.IsNonNegativeNumber = v => {
 
   return true;
 };
+
+// Implements StructuredDeserialize(StructuredSerialize(view)), but only for typed arrays and DataViews
+exports.CloneArrayBufferView = view => {
+  return new view.constructor(view.buffer.slice(), view.byteOffset, view.byteLength);
+};

--- a/reference-implementation/lib/abstract-ops/miscellaneous.js
+++ b/reference-implementation/lib/abstract-ops/miscellaneous.js
@@ -16,7 +16,7 @@ exports.IsNonNegativeNumber = v => {
   return true;
 };
 
-// Implements StructuredDeserialize(StructuredSerialize(view)), but only for typed arrays and DataViews
-exports.CloneArrayBufferView = view => {
-  return new view.constructor(view.buffer.slice(), view.byteOffset, view.byteLength);
+exports.CloneAsUint8Array = O => {
+  const buffer = O.buffer.slice(O.byteOffset, O.byteOffset + O.byteLength);
+  return new Uint8Array(buffer);
 };

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -588,8 +588,10 @@ function ReadableByteStreamTee(stream) {
         if (chunk !== undefined) {
           assert(chunk.byteLength === 0);
 
-          ReadableByteStreamControllerRespondWithNewView(byobBranch._controller, chunk);
-          if (otherBranch._controller._pendingPullIntos.length > 0) {
+          if (byobCanceled === false) {
+            ReadableByteStreamControllerRespondWithNewView(byobBranch._controller, chunk);
+          }
+          if (otherCanceled === false && otherBranch._controller._pendingPullIntos.length > 0) {
             ReadableByteStreamControllerRespond(otherBranch._controller, 0);
           }
         }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -465,7 +465,7 @@ function ReadableByteStreamTee(stream) {
 
   function forwardReaderError(thisReader) {
     uponRejection(thisReader._closedPromise, r => {
-      if (reader !== thisReader) {
+      if (thisReader !== reader) {
         return;
       }
       ReadableByteStreamControllerError(branch1._controller, r);

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -6,7 +6,7 @@ const { promiseResolvedWith, promiseRejectedWith, newPromise, resolvePromise, re
   require('../helpers/webidl.js');
 const { CanTransferArrayBuffer, CopyDataBlockBytes, CreateArrayFromList, IsDetachedBuffer, TransferArrayBuffer } =
   require('./ecmascript.js');
-const { IsNonNegativeNumber } = require('./miscellaneous.js');
+const { CloneArrayBufferView, IsNonNegativeNumber } = require('./miscellaneous.js');
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
         WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterRelease,
@@ -503,7 +503,7 @@ function ReadableByteStreamTee(stream) {
           const chunk1 = chunk;
           let chunk2 = chunk;
           if (canceled1 === false && canceled2 === false) {
-            chunk2 = new chunk.constructor(chunk);
+            chunk2 = CloneArrayBufferView(chunk);
           }
 
           if (canceled1 === false) {
@@ -558,7 +558,7 @@ function ReadableByteStreamTee(stream) {
 
           if (forBranch2 === true) {
             if (canceled1 === false) {
-              const clonedChunk = new chunk.constructor(chunk);
+              const clonedChunk = CloneArrayBufferView(chunk);
               ReadableByteStreamControllerEnqueue(branch1._controller, clonedChunk);
             }
             if (canceled2 === true) {
@@ -569,7 +569,7 @@ function ReadableByteStreamTee(stream) {
             }
           } else {
             if (canceled2 === false) {
-              const clonedChunk = new chunk.constructor(chunk);
+              const clonedChunk = CloneArrayBufferView(chunk);
               ReadableByteStreamControllerEnqueue(branch2._controller, clonedChunk);
             }
             if (canceled1 === true) {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -23,6 +23,7 @@ const WritableStream = require('../../generated/WritableStream.js');
 Object.assign(exports, {
   AcquireReadableStreamBYOBReader,
   AcquireReadableStreamDefaultReader,
+  CreateReadableByteStream,
   CreateReadableStream,
   InitializeReadableStream,
   IsReadableStreamLocked,
@@ -90,7 +91,24 @@ function CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, hi
   return stream;
 }
 
-// CreateReadableByteStream is not implemented since it is only meant for external specs.
+function CreateReadableByteStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark = 0,
+                                  autoAllocateChunkSize = undefined) {
+  assert(IsNonNegativeNumber(highWaterMark) === true);
+  if (autoAllocateChunkSize !== undefined) {
+    assert(Number.isInteger(autoAllocateChunkSize) === true);
+    assert(autoAllocateChunkSize > 0);
+  }
+
+  const stream = ReadableStream.new(globalThis);
+  InitializeReadableStream(stream);
+
+  const controller = ReadableByteStreamController.new(globalThis);
+  SetUpReadableByteStreamController(
+    stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, autoAllocateChunkSize
+  );
+
+  return stream;
+}
 
 function InitializeReadableStream(stream) {
   stream._state = 'readable';

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -561,19 +561,17 @@ function ReadableByteStreamTee(stream) {
               const clonedChunk = CloneAsUint8Array(chunk);
               ReadableByteStreamControllerEnqueue(branch1._controller, clonedChunk);
             }
-            if (canceled2 === true) {
-              chunk = new Uint8Array(chunk.buffer, chunk.byteOffset, 0);
+            if (canceled2 === false) {
+              ReadableByteStreamControllerRespondWithNewView(branch2._controller, chunk);
             }
-            ReadableByteStreamControllerRespondWithNewView(branch2._controller, chunk);
           } else {
             if (canceled2 === false) {
               const clonedChunk = CloneAsUint8Array(chunk);
               ReadableByteStreamControllerEnqueue(branch2._controller, clonedChunk);
             }
-            if (canceled1 === true) {
-              chunk = new Uint8Array(chunk.buffer, chunk.byteOffset, 0);
+            if (canceled1 === false) {
+              ReadableByteStreamControllerRespondWithNewView(branch1._controller, chunk);
             }
-            ReadableByteStreamControllerRespondWithNewView(branch1._controller, chunk);
           }
         });
       },

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -548,6 +548,9 @@ function ReadableByteStreamTee(stream) {
       forwardReaderError(reader);
     }
 
+    const byobBranch = forBranch2 ? branch2 : branch1;
+    const otherBranch = forBranch2 ? branch1 : branch2;
+
     const readIntoRequest = {
       chunkSteps: chunk => {
         // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
@@ -556,8 +559,6 @@ function ReadableByteStreamTee(stream) {
         queueMicrotask(() => {
           reading = false;
 
-          const byobBranch = forBranch2 ? branch2 : branch1;
-          const otherBranch = forBranch2 ? branch1 : branch2;
           const byobCanceled = forBranch2 ? canceled2 : canceled1;
           const otherCanceled = forBranch2 ? canceled1 : canceled2;
 
@@ -573,8 +574,6 @@ function ReadableByteStreamTee(stream) {
       closeSteps: chunk => {
         reading = false;
 
-        const byobBranch = forBranch2 ? branch2 : branch1;
-        const otherBranch = forBranch2 ? branch1 : branch2;
         const byobCanceled = forBranch2 ? canceled2 : canceled1;
         const otherCanceled = forBranch2 ? canceled1 : canceled2;
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -377,7 +377,7 @@ function ReadableStreamDefaultTee(stream, cloneForBranch2) {
           // There is no way to access the cloning code right now in the reference implementation.
           // If we add one then we'll need an implementation for serializable objects.
           // if (canceled2 === false && cloneForBranch2 === true) {
-          //   chunk2 = StructuredDeserialize(StructuredSerialize(chunk2));
+          //   chunk2 = StructuredClone(chunk2);
           // }
 
           if (canceled1 === false) {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -557,9 +557,11 @@ function ReadableByteStreamTee(stream) {
 
           if (otherCanceled === false) {
             const clonedChunk = CloneAsUint8Array(chunk);
+            if (byobCanceled === false) {
+              ReadableByteStreamControllerRespondWithNewView(byobBranch._controller, chunk);
+            }
             ReadableByteStreamControllerEnqueue(otherBranch._controller, clonedChunk);
-          }
-          if (byobCanceled === false) {
+          } else if (byobCanceled === false) {
             ReadableByteStreamControllerRespondWithNewView(byobBranch._controller, chunk);
           }
         });

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -6,7 +6,7 @@ const { promiseResolvedWith, promiseRejectedWith, newPromise, resolvePromise, re
   require('../helpers/webidl.js');
 const { CanTransferArrayBuffer, CopyDataBlockBytes, CreateArrayFromList, IsDetachedBuffer, TransferArrayBuffer } =
   require('./ecmascript.js');
-const { CloneArrayBufferView, IsNonNegativeNumber } = require('./miscellaneous.js');
+const { CloneAsUint8Array, IsNonNegativeNumber } = require('./miscellaneous.js');
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
         WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterRelease,
@@ -503,7 +503,7 @@ function ReadableByteStreamTee(stream) {
           const chunk1 = chunk;
           let chunk2 = chunk;
           if (canceled1 === false && canceled2 === false) {
-            chunk2 = CloneArrayBufferView(chunk);
+            chunk2 = CloneAsUint8Array(chunk);
           }
 
           if (canceled1 === false) {
@@ -558,7 +558,7 @@ function ReadableByteStreamTee(stream) {
 
           if (forBranch2 === true) {
             if (canceled1 === false) {
-              const clonedChunk = CloneArrayBufferView(chunk);
+              const clonedChunk = CloneAsUint8Array(chunk);
               ReadableByteStreamControllerEnqueue(branch1._controller, clonedChunk);
             }
             if (canceled2 === true) {
@@ -567,7 +567,7 @@ function ReadableByteStreamTee(stream) {
             ReadableByteStreamControllerRespondWithNewView(branch2._controller, chunk);
           } else {
             if (canceled2 === false) {
-              const clonedChunk = CloneArrayBufferView(chunk);
+              const clonedChunk = CloneAsUint8Array(chunk);
               ReadableByteStreamControllerEnqueue(branch2._controller, clonedChunk);
             }
             if (canceled1 === true) {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -520,14 +520,17 @@ function ReadableByteStreamTee(stream) {
         queueMicrotask(() => {
           reading = false;
 
+          const chunk1 = chunk;
+          let chunk2 = chunk;
           if (canceled1 === false && canceled2 === false) {
-            const clonedChunk = new chunk.constructor(chunk);
-            ReadableByteStreamControllerEnqueue(branch1._controller, chunk);
-            ReadableByteStreamControllerEnqueue(branch2._controller, clonedChunk);
-          } else if (canceled1 === false) {
-            ReadableByteStreamControllerEnqueue(branch1._controller, chunk);
-          } else if (canceled2 === false) {
-            ReadableByteStreamControllerEnqueue(branch2._controller, chunk);
+            chunk2 = new chunk.constructor(chunk);
+          }
+
+          if (canceled1 === false) {
+            ReadableByteStreamControllerEnqueue(branch1._controller, chunk1);
+          }
+          if (canceled2 === false) {
+            ReadableByteStreamControllerEnqueue(branch2._controller, chunk2);
           }
         });
       },

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -576,7 +576,6 @@ function ReadableByteStreamTee(stream) {
         });
       },
       closeSteps: chunk => {
-        assert(chunk.byteLength === 0);
         reading = false;
 
         if (canceled1 === false) {
@@ -586,15 +585,18 @@ function ReadableByteStreamTee(stream) {
           ReadableByteStreamControllerClose(branch2._controller);
         }
 
-        if (forBranch2 === true) {
-          ReadableByteStreamControllerRespondWithNewView(branch2._controller, chunk);
-          if (branch1._controller._pendingPullIntos.length > 0) {
-            ReadableByteStreamControllerRespond(branch1._controller, 0);
-          }
-        } else {
-          ReadableByteStreamControllerRespondWithNewView(branch1._controller, chunk);
-          if (branch2._controller._pendingPullIntos.length > 0) {
-            ReadableByteStreamControllerRespond(branch2._controller, 0);
+        if (chunk !== undefined) {
+          assert(chunk.byteLength === 0);
+          if (forBranch2 === true) {
+            ReadableByteStreamControllerRespondWithNewView(branch2._controller, chunk);
+            if (branch1._controller._pendingPullIntos.length > 0) {
+              ReadableByteStreamControllerRespond(branch1._controller, 0);
+            }
+          } else {
+            ReadableByteStreamControllerRespondWithNewView(branch1._controller, chunk);
+            if (branch2._controller._pendingPullIntos.length > 0) {
+              ReadableByteStreamControllerRespond(branch2._controller, 0);
+            }
           }
         }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -562,22 +562,18 @@ function ReadableByteStreamTee(stream) {
               ReadableByteStreamControllerEnqueue(branch1._controller, clonedChunk);
             }
             if (canceled2 === true) {
-              const emptyChunk = new Uint8Array(chunk.buffer, chunk.byteOffset, 0);
-              ReadableByteStreamControllerRespondWithNewView(branch2._controller, emptyChunk);
-            } else {
-              ReadableByteStreamControllerRespond(branch2._controller, chunk.byteLength);
+              chunk = new Uint8Array(chunk.buffer, chunk.byteOffset, 0);
             }
+            ReadableByteStreamControllerRespondWithNewView(branch2._controller, chunk);
           } else {
             if (canceled2 === false) {
               const clonedChunk = CloneArrayBufferView(chunk);
               ReadableByteStreamControllerEnqueue(branch2._controller, clonedChunk);
             }
             if (canceled1 === true) {
-              const emptyChunk = new Uint8Array(chunk.buffer, chunk.byteOffset, 0);
-              ReadableByteStreamControllerRespondWithNewView(branch1._controller, emptyChunk);
-            } else {
-              ReadableByteStreamControllerRespondWithNewView(branch1._controller, chunk);
+              chunk = new Uint8Array(chunk.buffer, chunk.byteOffset, 0);
             }
+            ReadableByteStreamControllerRespondWithNewView(branch1._controller, chunk);
           }
         });
       },

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -93,20 +93,13 @@ function CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, hi
   return stream;
 }
 
-function CreateReadableByteStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark = 0,
-                                  autoAllocateChunkSize = undefined) {
-  assert(IsNonNegativeNumber(highWaterMark) === true);
-  if (autoAllocateChunkSize !== undefined) {
-    assert(Number.isInteger(autoAllocateChunkSize) === true);
-    assert(autoAllocateChunkSize > 0);
-  }
-
+function CreateReadableByteStream(startAlgorithm, pullAlgorithm, cancelAlgorithm) {
   const stream = ReadableStream.new(globalThis);
   InitializeReadableStream(stream);
 
   const controller = ReadableByteStreamController.new(globalThis);
   SetUpReadableByteStreamController(
-    stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, autoAllocateChunkSize
+    stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, 0, undefined
   );
 
   return stream;

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -648,9 +648,6 @@ function ReadableByteStreamTee(stream) {
   function cancel1Algorithm(reason) {
     canceled1 = true;
     reason1 = reason;
-    if (reading === false && branch1._controller._pendingPullIntos.length > 0) {
-      ReadableByteStreamControllerRespond(branch1._controller, 0);
-    }
     if (canceled2 === true) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);
@@ -662,9 +659,6 @@ function ReadableByteStreamTee(stream) {
   function cancel2Algorithm(reason) {
     canceled2 = true;
     reason2 = reason;
-    if (reading === false && branch2._controller._pendingPullIntos.length > 0) {
-      ReadableByteStreamControllerRespond(branch2._controller, 0);
-    }
     if (canceled1 === true) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -342,6 +342,15 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
 function ReadableStreamTee(stream, cloneForBranch2) {
   assert(ReadableStream.isImpl(stream));
   assert(typeof cloneForBranch2 === 'boolean');
+  if (ReadableByteStreamController.isImpl(stream._controller)) {
+    return ReadableByteStreamTee(stream);
+  }
+  return ReadableStreamDefaultTee(stream, cloneForBranch2);
+}
+
+function ReadableStreamDefaultTee(stream, cloneForBranch2) {
+  assert(ReadableStream.isImpl(stream));
+  assert(typeof cloneForBranch2 === 'boolean');
 
   const reader = AcquireReadableStreamDefaultReader(stream);
 
@@ -446,9 +455,9 @@ function ReadableStreamTee(stream, cloneForBranch2) {
   return [branch1, branch2];
 }
 
-function ReadableStreamTee2(stream, cloneForBranch2) {
+function ReadableByteStreamTee(stream) {
   assert(ReadableStream.isImpl(stream));
-  assert(typeof cloneForBranch2 === 'boolean');
+  assert(ReadableByteStreamController.isImpl(stream._controller));
 
   const reader = AcquireReadableStreamDefaultReader(stream);
 
@@ -470,37 +479,37 @@ function ReadableStreamTee2(stream, cloneForBranch2) {
     reading = true;
 
     const readRequest = {
-      chunkSteps: value => {
+      chunkSteps: chunk => {
         // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
         // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let
         // successful synchronously-available reads get ahead of asynchronously-available errors.
         queueMicrotask(() => {
           reading = false;
-          const value1 = value;
-          const value2 = value;
 
-          // There is no way to access the cloning code right now in the reference implementation.
-          // If we add one then we'll need an implementation for serializable objects.
-          // if (canceled2 === false && cloneForBranch2 === true) {
-          //   value2 = StructuredDeserialize(StructuredSerialize(value2));
-          // }
-
-          if (canceled1 === false) {
-            ReadableStreamDefaultControllerEnqueue(branch1._controller, value1);
-          }
-
-          if (canceled2 === false) {
-            ReadableStreamDefaultControllerEnqueue(branch2._controller, value2);
+          if (canceled1 === false && canceled2 === false) {
+            const clonedChunk = new chunk.constructor(chunk);
+            ReadableByteStreamControllerEnqueue(branch1._controller, chunk);
+            ReadableByteStreamControllerEnqueue(branch2._controller, clonedChunk);
+          } else if (canceled1 === false) {
+            ReadableByteStreamControllerEnqueue(branch1._controller, chunk);
+          } else if (canceled2 === false) {
+            ReadableByteStreamControllerEnqueue(branch2._controller, chunk);
           }
         });
       },
       closeSteps: () => {
         reading = false;
         if (canceled1 === false) {
-          ReadableStreamDefaultControllerClose(branch1._controller);
+          ReadableByteStreamControllerClose(branch1._controller);
+          if (branch1._controller._pendingPullIntos.length > 0) {
+            ReadableByteStreamControllerRespond(branch1._controller, 0);
+          }
         }
         if (canceled2 === false) {
-          ReadableStreamDefaultControllerClose(branch2._controller);
+          ReadableByteStreamControllerClose(branch2._controller);
+          if (branch2._controller._pendingPullIntos.length > 0) {
+            ReadableByteStreamControllerRespond(branch2._controller, 0);
+          }
         }
         if (canceled1 === false || canceled2 === false) {
           resolvePromise(cancelPromise, undefined);
@@ -518,6 +527,9 @@ function ReadableStreamTee2(stream, cloneForBranch2) {
   function cancel1Algorithm(reason) {
     canceled1 = true;
     reason1 = reason;
+    if (branch1._controller._pendingPullIntos.length > 0) {
+      ReadableByteStreamControllerRespond(branch1._controller, 0);
+    }
     if (canceled2 === true) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);
@@ -529,6 +541,9 @@ function ReadableStreamTee2(stream, cloneForBranch2) {
   function cancel2Algorithm(reason) {
     canceled2 = true;
     reason2 = reason;
+    if (branch2._controller._pendingPullIntos.length > 0) {
+      ReadableByteStreamControllerRespond(branch2._controller, 0);
+    }
     if (canceled1 === true) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);
@@ -539,12 +554,12 @@ function ReadableStreamTee2(stream, cloneForBranch2) {
 
   function startAlgorithm() {}
 
-  branch1 = CreateReadableStream(startAlgorithm, pullAlgorithm, cancel1Algorithm);
-  branch2 = CreateReadableStream(startAlgorithm, pullAlgorithm, cancel2Algorithm);
+  branch1 = CreateReadableByteStream(startAlgorithm, pullAlgorithm, cancel1Algorithm);
+  branch2 = CreateReadableByteStream(startAlgorithm, pullAlgorithm, cancel2Algorithm);
 
   uponRejection(reader._closedPromise, r => {
-    ReadableStreamDefaultControllerError(branch1._controller, r);
-    ReadableStreamDefaultControllerError(branch2._controller, r);
+    ReadableByteStreamControllerError(branch1._controller, r);
+    ReadableByteStreamControllerError(branch2._controller, r);
     if (canceled1 === false || canceled2 === false) {
       resolvePromise(cancelPromise, undefined);
     }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -365,27 +365,27 @@ function ReadableStreamDefaultTee(stream, cloneForBranch2) {
     reading = true;
 
     const readRequest = {
-      chunkSteps: value => {
+      chunkSteps: chunk => {
         // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
         // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let
         // successful synchronously-available reads get ahead of asynchronously-available errors.
         queueMicrotask(() => {
           reading = false;
-          const value1 = value;
-          const value2 = value;
+          const chunk1 = chunk;
+          const chunk2 = chunk;
 
           // There is no way to access the cloning code right now in the reference implementation.
           // If we add one then we'll need an implementation for serializable objects.
           // if (canceled2 === false && cloneForBranch2 === true) {
-          //   value2 = StructuredDeserialize(StructuredSerialize(value2));
+          //   chunk2 = StructuredDeserialize(StructuredSerialize(chunk2));
           // }
 
           if (canceled1 === false) {
-            ReadableStreamDefaultControllerEnqueue(branch1._controller, value1);
+            ReadableStreamDefaultControllerEnqueue(branch1._controller, chunk1);
           }
 
           if (canceled2 === false) {
-            ReadableStreamDefaultControllerEnqueue(branch2._controller, value2);
+            ReadableStreamDefaultControllerEnqueue(branch2._controller, chunk2);
           }
         });
       },


### PR DESCRIPTION
With this PR, teeing a readable byte stream will now create two *readable byte streams* (instead of two "default" readable streams). See #1111 for context.

This implements the "hard" solution: when a branch is being read using a BYOB reader, the view of that read request is forwarded to the original stream, so it can read directly into that view. After the view is filled, an identical copy is created and enqueued on the other branch, so they both see the same data.

To do:
* [x] Write tests
* [x] Update specification text to match new reference implementation

---

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * web-platform-tests/wpt#29190
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1114.html" title="Last updated on Jul 8, 2021, 8:45 PM UTC (75a80a8)">Preview</a> | <a href="https://whatpr.org/streams/1114/c46742f...75a80a8.html" title="Last updated on Jul 8, 2021, 8:45 PM UTC (75a80a8)">Diff</a>