### PR TITLE
Fix cancelPromise in ReadableStreamTee being resolved twice (again)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2240,7 +2240,7 @@ create them does not matter.
        [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
     1. If |canceled2| is false, perform !
        [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
-    1. [=Resolve=] |cancelPromise| with undefined.
+    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read request/error steps=]
    ::

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -373,7 +373,9 @@ function ReadableStreamTee(stream, cloneForBranch2) {
         if (canceled2 === false) {
           ReadableStreamDefaultControllerClose(branch2._controller);
         }
-        resolvePromise(cancelPromise, undefined);
+        if (canceled1 === false || canceled2 === false) {
+          resolvePromise(cancelPromise, undefined);
+        }
       },
       errorSteps: () => {
         reading = false;


### PR DESCRIPTION
I liked #1112 so much that I wanted to fix it twice! 😛

The following test case throws an `AssertionError`:
```javascript
const rs = new ReadableStream({});

const [branch1, branch2] = rs.tee();

const cancel1 = branch1.cancel();
await flushAsyncEvents();
const cancel2 = branch2.cancel();

await Promise.all([cancel1, cancel2]);
```

This time, the error comes from [this line](https://github.com/whatwg/streams/blob/dd76a17a3738d78708a8dfd8f0508e717d6a1988/reference-implementation/lib/abstract-ops/readable-streams.js#L376):
```
promise_test: Unhandled rejection with value: object "AssertionError: false == true"
Error
    at AssertionError.get_stack (http://127.0.0.1:51551/resources/testharness.js:3553:21)
    at new AssertionError (http://127.0.0.1:51551/resources/testharness.js:3546:27)
    at assert (http://127.0.0.1:51551/resources/testharness.js:3539:19)
    at Test.<anonymous> (http://127.0.0.1:51551/resources/testharness.js:618:29)
    at Test.step (http://127.0.0.1:51551/resources/testharness.js:1977:25)
    at http://127.0.0.1:51551/resources/testharness.js:2002:35
```

- [x] At least two implementers are interested (and none opposed):
   * Chome (@ricea)
   * Firefox (@evilpie)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * web-platform-tests/wpt#28266
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1194266
   * Firefox: …
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=223962

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1118.html" title="Last updated on Mar 30, 2021, 11:21 PM UTC (9a5bcc7)">Preview</a> | <a href="https://whatpr.org/streams/1118/03bd01a...9a5bcc7.html" title="Last updated on Mar 30, 2021, 11:21 PM UTC (9a5bcc7)">Diff</a>