### PR TITLE
Fix dfn refs for arguments of "TransformStream/set up"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6407,7 +6407,7 @@ reason.
 
  1. Let |transformStream| be a [=new=] {{TransformStream}}.
  1. [=TransformStream/Set up=] |transformStream| with <var
-    ignore>[=TransformStream/create/transformAlgorithm=]</var> set to an algorithm which, given
+    ignore>[=TransformStream/set up/transformAlgorithm=]</var> set to an algorithm which, given
     |chunk|, [=TransformStream/enqueues=] |chunk| in |transformStream|.
  1. Return |transformStream|.
 </div>
@@ -6416,8 +6416,8 @@ reason.
 
 The following algorithms must only be used on {{TransformStream}} instances initialized via the
 above [=TransformStream/set up=] algorithm. Usually they are called as part of
-<var>[=TransformStream/create/transformAlgorithm=]</var> or
-<var>[=TransformStream/create/flushAlgorithm=]</var>.
+<var>[=TransformStream/set up/transformAlgorithm=]</var> or
+<var>[=TransformStream/set up/flushAlgorithm=]</var>.
 
 <p algorithm>To <dfn export for="TransformStream">enqueue</dfn> the JavaScript value |chunk| into a
 {{TransformStream}} |stream|, perform !
@@ -6460,8 +6460,8 @@ Including the {{GenericTransformStream}} mixin will give an IDL interface the ap
 the behavior of the resulting interface, its constructor (or other initialization code) must set
 each instance's [=GenericTransformStream/transform=] to a [=new=] {{TransformStream}}, and then
 [=TransformStream/set up|set it up=] with appropriate customizations via the
-<var>[=TransformStream/create/transformAlgorithm=]</var> and optionally
-<var>[=TransformStream/create/flushAlgorithm=]</var> arguments.
+<var>[=TransformStream/set up/transformAlgorithm=]</var> and optionally
+<var>[=TransformStream/set up/flushAlgorithm=]</var> arguments.
 
 Existing examples of this pattern on the web platform include {{CompressionStream}} and
 {{TextDecoderStream}}. [[COMPRESSION]] [[ENCODING]]


### PR DESCRIPTION
The references for the _transformAlgorithm_ and _flushAlgorithm_ arguments of "set up TransformStream" were incorrect in #1110. This fixes it.

Not sure how/why [`make deploy` succeeded](https://github.com/whatwg/streams/runs/2230655379) for 8c215873d9c720b76878638e1c0ee235dc08164a, but it failed on my PR #1118. 🤷


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1119.html" title="Last updated on Mar 30, 2021, 10:47 PM UTC (a6b7f4f)">Preview</a> | <a href="https://whatpr.org/streams/1119/8c21587...a6b7f4f.html" title="Last updated on Mar 30, 2021, 10:47 PM UTC (a6b7f4f)">Diff</a>