### PR TITLE
Various fixes for readable byte streams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1992,7 +1992,6 @@ following table:
  The <dfn id="rs-byob-request-respond-with-new-view" method
  for="ReadableStreamBYOBRequest">respondWithNewView(|view|)</dfn> method steps are:
 
- 1. If |view|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
@@ -3203,6 +3202,7 @@ The following abstract operations support the implementation of the
      |firstDescriptor|).
  1. Otherwise,
   1. Assert: |state| is "`readable`".
+  1. If |bytesWritten| is 0, throw a {{TypeError}} exception.
   1. Perform ? [$ReadableByteStreamControllerRespondInReadableState$](|controller|, |bytesWritten|,
      |firstDescriptor|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -2922,6 +2922,8 @@ The following abstract operations support the implementation of the
       |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
    1. If ! [$CanTransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
       is false, throw a {{TypeError}} exception.
+   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
+      [$TransferArrayBuffer$]([=pull-into descriptor/buffer=]).
   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
      |transferredBuffer|, |byteOffset|, |byteLength|).
   1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
@@ -3150,6 +3152,8 @@ The following abstract operations support the implementation of the
   1. If |bytesWritten| is 0, throw a {{TypeError}} exception.
   1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| >
      |firstDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
+ 1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to !
+    [$TransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |bytesWritten|).
 </div>
 
@@ -3158,8 +3162,6 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-respond-in-closed-state">ReadableByteStreamControllerRespondInClosedState(|controller|,
  |firstDescriptor|)</dfn> performs the following steps:
 
- 1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to !
-    [$TransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Assert: |firstDescriptor|'s [=pull-into descriptor/bytes filled=] is 0.
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
@@ -3242,7 +3244,8 @@ The following abstract operations support the implementation of the
     |view|.\[[ViewedArrayBuffer]].\[[ByteLength]], throw a {{RangeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] + |view|.\[[ByteLength]] >
     |firstDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
- 1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to |view|.\[[ViewedArrayBuffer]].
+ 1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to !
+    [$TransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]).
  1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |view|.\[[ByteLength]]).
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3220,7 +3220,7 @@ The following abstract operations support the implementation of the
     descriptor/bytes filled=] is not |view|.\[[ByteOffset]], throw a {{RangeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/buffer byte length=] is not
     |view|.\[[ViewedArrayBuffer]].\[[ByteLength]], throw a {{RangeError}} exception.
- 1. If |firstDescriptor|'s [=pull-into descriptor/byte length=] is not |view|.\[[ByteLength]], throw
+ 1. If |firstDescriptor|'s [=pull-into descriptor/byte length=] < |view|.\[[ByteLength]], throw
     a {{RangeError}} exception.
  1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to |view|.\[[ViewedArrayBuffer]].
  1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |view|.\[[ByteLength]]).

--- a/index.bs
+++ b/index.bs
@@ -2914,8 +2914,8 @@ The following abstract operations support the implementation of the
     [=list/is empty|empty=],
   1. Let |firstPendingPullInto| be
      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If ! [$CanTransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
-     is false, throw a {{TypeError}} exception.
+  1. If ! [$IsDetachedBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
+     is true, throw a {{TypeError}} exception.
   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
      [$TransferArrayBuffer$]([=pull-into descriptor/buffer=]).
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -2918,10 +2918,7 @@ The following abstract operations support the implementation of the
    1. Let |firstPendingPullInto| be
       |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
    1. If ! [$CanTransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
-      is false,
-    1. Let |e| be a new {{TypeError}} exception.
-    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
-    1. Throw |e|.
+      is false, throw a {{TypeError}} exception.
   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
      |transferredBuffer|, |byteOffset|, |byteLength|).
   1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -1986,6 +1986,8 @@ following table:
 
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
+ 1. If ! [$CanTransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]) is false,
+    throw a {{TypeError}} exception.
  1. Return ?
     [$ReadableByteStreamControllerRespondWithNewView$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
     |view|).
@@ -3215,6 +3217,7 @@ The following abstract operations support the implementation of the
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is
     empty|empty=].
+ 1. Assert: ! [$CanTransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]) is true.
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. If |firstDescriptor|'s [=pull-into descriptor/byte offset=] + |firstDescriptor|' [=pull-into
     descriptor/bytes filled=] is not |view|.\[[ByteOffset]], throw a {{RangeError}} exception.

--- a/index.bs
+++ b/index.bs
@@ -2902,6 +2902,14 @@ The following abstract operations support the implementation of the
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or
     |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
+ 1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
+    [=list/is empty|empty=],
+  1. Let |firstPendingPullInto| be
+     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. If ! [$CanTransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
+     is false, throw a {{TypeError}} exception.
+  1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
+     [$TransferArrayBuffer$]([=pull-into descriptor/buffer=]).
  1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
  1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
  1. Let |byteLength| be |chunk|.\[[ByteLength]].
@@ -2916,14 +2924,6 @@ The following abstract operations support the implementation of the
       |byteOffset|, |byteLength| »).
    1. Perform ! [$ReadableStreamFulfillReadRequest$](|stream|, |transferredView|, false).
  1. Otherwise, if ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
-  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
-     [=list/is empty|empty=],
-   1. Let |firstPendingPullInto| be
-      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-   1. If ! [$CanTransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
-      is false, throw a {{TypeError}} exception.
-   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
-      [$TransferArrayBuffer$]([=pull-into descriptor/buffer=]).
   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
      |transferredBuffer|, |byteOffset|, |byteLength|).
   1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -1817,6 +1817,8 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
  1. If |chunk|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |chunk|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
+ 1. If ! [$CanTransferArrayBuffer$](|chunk|.\[[ViewedArrayBuffer]]) is false,
+    throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}}
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
@@ -2894,6 +2896,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-enqueue">ReadableByteStreamControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
+ 1. Assert: ! [$CanTransferArrayBuffer$](|chunk|.\[[ViewedArrayBuffer]]) is true.
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or
     |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.

--- a/index.bs
+++ b/index.bs
@@ -1824,8 +1824,6 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
  1. If |chunk|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |chunk|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
     exception.
- 1. If ! [$CanTransferArrayBuffer$](|chunk|.\[[ViewedArrayBuffer]]) is false,
-    throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}}
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
@@ -2907,6 +2905,11 @@ The following abstract operations support the implementation of the
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or
     |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
+ 1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
+ 1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
+ 1. Let |byteLength| be |chunk|.\[[ByteLength]].
+ 1. If ! [$IsDetachedBuffer$](|buffer|) is true, throw a {{TypeError}} exception.
+ 1. Let |transferredBuffer| be ? [$TransferArrayBuffer$](|buffer|).
  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
     [=list/is empty|empty=],
   1. Let |firstPendingPullInto| be
@@ -2916,10 +2919,6 @@ The following abstract operations support the implementation of the
   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
      [$TransferArrayBuffer$]([=pull-into descriptor/buffer=]).
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
- 1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
- 1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
- 1. Let |byteLength| be |chunk|.\[[ByteLength]].
- 1. Let |transferredBuffer| be ! [$TransferArrayBuffer$](|buffer|).
  1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true
   1. If ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0,
    1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,

--- a/index.bs
+++ b/index.bs
@@ -61,6 +61,11 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMASCRIPT
   text: Type; url: #sec-ecmascript-data-types-and-values
  text: TypeError; url: #sec-native-error-types-used-in-this-standard-typeerror; type: exception
  text: map; url: #sec-array.prototype.map; type: method; for: Array.prototype
+urlPrefix: https://webassembly.github.io/spec/js-api/; spec: WASM-JS-API-1
+ type: interface
+  text: WebAssembly.Memory; url: #memory
+ type: attribute
+  text: buffer; for: WebAssembly.Memory; url: #dom-memory-buffer
 url: https://wicg.github.io/compression/#compressionstream; spec: COMPRESSION; type: interface; text: CompressionStream
 </pre>
 
@@ -6136,6 +6141,9 @@ The following abstract operations are a grab-bag of utilities.
  1. Let |arrayBufferData| be |O|.\[[ArrayBufferData]].
  1. Let |arrayBufferByteLength| be |O|.\[[ArrayBufferByteLength]].
  1. Perform ? [$DetachArrayBuffer$](|O|).
+    <p class="note">This will throw an exception if |O| has an \[[ArrayBufferDetachKey]]
+    that is not undefined, such as a {{WebAssembly.Memory}}'s {{WebAssembly.Memory/buffer}}.
+    [[WASM-JS-API-1]]</p>
  1. Return a new {{ArrayBuffer}} object, created in [=the current Realm=], whose
     \[[ArrayBufferData]] internal slot value is |arrayBufferData| and whose
     \[[ArrayBufferByteLength]] internal slot value is |arrayBufferByteLength|.

--- a/index.bs
+++ b/index.bs
@@ -1721,6 +1721,8 @@ has the following [=struct/items=]:
 
 : <dfn for="pull-into descriptor">buffer</dfn>
 :: An {{ArrayBuffer}}
+: <dfn for="pull-into descriptor">buffer byte length</dfn>
+:: A positive integer representing the initial byte length of [=pull-into descriptor/buffer=]
 : <dfn for="pull-into descriptor">byte offset</dfn>
 :: A nonnegative integer byte offset into the [=pull-into descriptor/buffer=] where the
    [=underlying byte source=] will start writing
@@ -1887,8 +1889,9 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
    1. Perform |readRequest|'s [=read request/error steps=], given |buffer|.\[[Value]].
    1. Return.
   1. Let |pullIntoDescriptor| be a new [=pull-into descriptor=] with [=pull-into descriptor/buffer=]
-     |buffer|.\[[Value]], [=pull-into descriptor/byte offset=] 0, [=pull-into descriptor/byte
-     length=] |autoAllocateChunkSize|, [=pull-into descriptor/bytes filled=] 0, [=pull-into
+     |buffer|.\[[Value]], [=pull-into descriptor/buffer byte length=] |autoAllocateChunkSize|,
+     [=pull-into descriptor/byte offset=] 0, [=pull-into descriptor/byte length=]
+     |autoAllocateChunkSize|, [=pull-into descriptor/bytes filled=] 0, [=pull-into
      descriptor/element size=] 1, [=pull-into descriptor/view constructor=] {{%Uint8Array%}}, and
      [=pull-into descriptor/reader type=] "`default`".
   1. [=list/Append=] |pullIntoDescriptor| to
@@ -3095,9 +3098,10 @@ The following abstract operations support the implementation of the
  1. Let |byteLength| be |view|.\[[ByteLength]].
  1. Let |buffer| be ! [$TransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]).
  1. Let |pullIntoDescriptor| be a new [=pull-into descriptor=] with [=pull-into descriptor/buffer=]
-    |buffer|, [=pull-into descriptor/byte offset=] |byteOffset|, [=pull-into descriptor/byte
-    length=] |byteLength|, [=pull-into descriptor/bytes filled=] 0, [=pull-into descriptor/element
-    size=] |elementSize|, [=pull-into descriptor/view constructor=] |ctor|, and [=pull-into
+    |buffer|, [=pull-into descriptor/buffer byte length=] |buffer|.\[[ArrayBufferByteLength]],
+    [=pull-into descriptor/byte offset=] |byteOffset|, [=pull-into descriptor/byte length=]
+    |byteLength|, [=pull-into descriptor/bytes filled=] 0, [=pull-into descriptor/element size=]
+    |elementSize|, [=pull-into descriptor/view constructor=] |ctor|, and [=pull-into
     descriptor/reader type=] "`byob`".
  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty,
   1. [=list/Append=] |pullIntoDescriptor| to
@@ -3214,6 +3218,8 @@ The following abstract operations support the implementation of the
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. If |firstDescriptor|'s [=pull-into descriptor/byte offset=] + |firstDescriptor|' [=pull-into
     descriptor/bytes filled=] is not |view|.\[[ByteOffset]], throw a {{RangeError}} exception.
+ 1. If |firstDescriptor|'s [=pull-into descriptor/buffer byte length=] is not
+    |view|.\[[ViewedArrayBuffer]].\[[ByteLength]], throw a {{RangeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/byte length=] is not |view|.\[[ByteLength]], throw
     a {{RangeError}} exception.
  1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to |view|.\[[ViewedArrayBuffer]].

--- a/index.bs
+++ b/index.bs
@@ -2896,7 +2896,6 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-enqueue">ReadableByteStreamControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. Assert: ! [$CanTransferArrayBuffer$](|chunk|.\[[ViewedArrayBuffer]]) is true.
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true or
     |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.

--- a/index.bs
+++ b/index.bs
@@ -1807,10 +1807,6 @@ has the following [=struct/items=]:
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
- 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
-  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If ! [$CanTransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is false,
-     throw a {{TypeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1991,8 +1991,6 @@ following table:
  The <dfn id="rs-byob-request-respond-with-new-view" method
  for="ReadableStreamBYOBRequest">respondWithNewView(|view|)</dfn> method steps are:
 
- 1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
-    exception.
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
  1. Return ?

--- a/index.bs
+++ b/index.bs
@@ -3140,6 +3140,16 @@ The following abstract operations support the implementation of the
  |bytesWritten|)</dfn> performs the following steps:
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty.
+ 1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+ 1. Let |state| be
+    |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
+ 1. If |state| is "`closed`",
+  1. If |bytesWritten| is not 0, throw a {{TypeError}} exception.
+ 1. Otherwise,
+  1. Assert: |state| is "`readable`".
+  1. If |bytesWritten| is 0, throw a {{TypeError}} exception.
+  1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| >
+     |firstDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |bytesWritten|).
 </div>
 
@@ -3165,8 +3175,8 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-respond-in-readable-state">ReadableByteStreamControllerRespondInReadableState(|controller|,
  |bytesWritten|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
- 1. If |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| >
-    |pullIntoDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
+ 1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| <=
+    |pullIntoDescriptor|'s [=pull-into descriptor/byte length=].
  1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
     |bytesWritten|, |pullIntoDescriptor|).
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] &lt; |pullIntoDescriptor|'s
@@ -3201,12 +3211,12 @@ The following abstract operations support the implementation of the
  1. Let |state| be
     |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`closed`",
-  1. If |bytesWritten| is not 0, throw a {{TypeError}} exception.
+  1. Assert: |bytesWritten| is 0.
   1. Perform ! [$ReadableByteStreamControllerRespondInClosedState$](|controller|,
      |firstDescriptor|).
  1. Otherwise,
   1. Assert: |state| is "`readable`".
-  1. If |bytesWritten| is 0, throw a {{TypeError}} exception.
+  1. Assert: |bytesWritten| > 0.
   1. Perform ? [$ReadableByteStreamControllerRespondInReadableState$](|controller|, |bytesWritten|,
      |firstDescriptor|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
@@ -3221,6 +3231,13 @@ The following abstract operations support the implementation of the
     empty|empty=].
  1. Assert: ! [$CanTransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]) is true.
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+ 1. Let |state| be
+    |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
+ 1. If |state| is "`closed`",
+  1. If |view|.\[[ByteLength]] is not 0, throw a {{TypeError}} exception.
+ 1. Otherwise,
+  1. Assert: |state| is "`readable`".
+  1. If |view|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/byte offset=] + |firstDescriptor|' [=pull-into
     descriptor/bytes filled=] is not |view|.\[[ByteOffset]], throw a {{RangeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/buffer byte length=] is not

--- a/index.bs
+++ b/index.bs
@@ -1821,11 +1821,7 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
- 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
-  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If ! [$CanTransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is false,
-     throw a {{TypeError}} exception.
- 1. Return ! [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
+ 1. Return ? [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
 </div>
 
 <div algorithm>
@@ -2913,6 +2909,15 @@ The following abstract operations support the implementation of the
       |byteOffset|, |byteLength| »).
    1. Perform ! [$ReadableStreamFulfillReadRequest$](|stream|, |transferredView|, false).
  1. Otherwise, if ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
+  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
+     [=list/is empty|empty=],
+   1. Let |firstPendingPullInto| be
+      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+   1. If ! [$CanTransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
+      is false,
+    1. Let |e| be a new {{TypeError}} exception.
+    1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
+    1. Throw |e|.
   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
      |transferredBuffer|, |byteOffset|, |byteLength|).
   1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -2910,6 +2910,7 @@ The following abstract operations support the implementation of the
      is false, throw a {{TypeError}} exception.
   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
      [$TransferArrayBuffer$]([=pull-into descriptor/buffer=]).
+ 1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. Let |buffer| be |chunk|.\[[ViewedArrayBuffer]].
  1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
  1. Let |byteLength| be |chunk|.\[[ByteLength]].
@@ -2968,7 +2969,7 @@ The following abstract operations support the implementation of the
  1. Assert: either |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=]
     [=list/is empty=], or |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0]
     is |pullIntoDescriptor|.
- 1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null.
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to [=pull-into
     descriptor/bytes filled=] + |size|.
 </div>
@@ -3208,6 +3209,7 @@ The following abstract operations support the implementation of the
 
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. Assert: ! [$CanTransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true.
+ 1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. Let |state| be
     |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`closed`",
@@ -3254,10 +3256,10 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-shift-pending-pull-into">ReadableByteStreamControllerShiftPendingPullInto(|controller|)</dfn>
  performs the following steps:
 
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null.
  1. Let |descriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. [=list/Remove=] |descriptor| from
     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
- 1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. Return |descriptor|.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1993,7 +1993,7 @@ following table:
 
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
- 1. If ! [$CanTransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]) is false,
+ 1. If ! [$IsDetachedBuffer$](|view|.\[[ViewedArrayBuffer]]) is true,
     throw a {{TypeError}} exception.
  1. Return ?
     [$ReadableByteStreamControllerRespondWithNewView$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
@@ -3235,7 +3235,7 @@ The following abstract operations support the implementation of the
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is
     empty|empty=].
- 1. Assert: ! [$CanTransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]) is true.
+ 1. Assert: ! [$IsDetachedBuffer$](|view|.\[[ViewedArrayBuffer]]) is false.
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
  1. Let |state| be
     |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
@@ -3250,7 +3250,7 @@ The following abstract operations support the implementation of the
     |view|.\[[ViewedArrayBuffer]].\[[ByteLength]], throw a {{RangeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] + |view|.\[[ByteLength]] >
     |firstDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
- 1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to !
+ 1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to ?
     [$TransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]).
  1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |view|.\[[ByteLength]]).
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1960,6 +1960,13 @@ following table:
   {{ReadableStreamBYOBRequest/view}}, the [=underlying byte source=] is providing a new
   {{ArrayBufferView}}, which will be given to the [=consumer=] of the [=readable byte stream=].
 
+  <p>The new |view| has to be a view onto the same backing memory region as
+  {{ReadableStreamBYOBRequest/view}}, i.e. its buffer has to equal (or be a
+  <a href="#transfer-array-buffer">transferred</a> version of) {{ReadableStreamBYOBRequest/view}}'s
+  buffer. Its <code>byteOffset</code> has to equal {{ReadableStreamBYOBRequest/view}}'s
+  <code>byteOffset</code>, and its <code>byteLength</code> (representing the number of bytes written)
+  has to be less than or equal to that of {{ReadableStreamBYOBRequest/view}}.
+
   <p>After this method is called, <var ignore>view</var> will be <a
   href="#transfer-array-buffer">transferred</a> and no longer modifiable.
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -1587,7 +1587,7 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  id="rs-default-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
- 1. Let |stream| be [=this=].[=ReadableStreamGenericReader/[[stream]]=].
+ 1. Let |stream| be [=this=].[=ReadableStreamDefaultController/[[stream]]=].
  1. If [=this=].[=ReadableStreamDefaultController/[[queue]]=] is not [=list/is empty|empty=],
   1. Let |chunk| be ! [$DequeueValue$]([=this=]).
   1. If [=this=].[=ReadableStreamDefaultController/[[closeRequested]]=] is true and
@@ -1803,7 +1803,7 @@ has the following [=struct/items=]:
 
  1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}}
     exception.
- 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not
+ 1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
@@ -1821,7 +1821,7 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}}
     exception.
- 1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not
+ 1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].

--- a/index.bs
+++ b/index.bs
@@ -2888,9 +2888,10 @@ The following abstract operations support the implementation of the
  1. Let |elementSize| be |pullIntoDescriptor|'s [=pull-into descriptor/element size=].
  1. Assert: |bytesFilled| ≤ |pullIntoDescriptor|'s [=pull-into descriptor/byte length=].
  1. Assert: |bytesFilled| mod |elementSize| is 0.
+ 1. Let |buffer| be ! [$TransferArrayBuffer$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Return ! [$Construct$](|pullIntoDescriptor|'s [=pull-into descriptor/view constructor=], «
-    |pullIntoDescriptor|'s [=pull-into descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into
-    descriptor/byte offset=], |bytesFilled| ÷ |elementSize| »).
+    |buffer|, |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=],
+    |bytesFilled| ÷ |elementSize| »).
 </div>
 
 <div algorithm>
@@ -3190,8 +3191,6 @@ The following abstract operations support the implementation of the
       descriptor/buffer=], |end| − |remainderSize|, |remainderSize|, {{%ArrayBuffer%}}).
    1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|, |remainder|, 0,
       |remainder|.\[[ByteLength]]).
- 1. Set |pullIntoDescriptor|'s [=pull-into descriptor/buffer=] to !
-    [$TransferArrayBuffer$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] − |remainderSize|.
  1. Perform !

--- a/index.bs
+++ b/index.bs
@@ -6132,10 +6132,10 @@ The following abstract operations are a grab-bag of utilities.
  <dfn abstract-op lt="TransferArrayBuffer"
  id="transfer-array-buffer">TransferArrayBuffer(|O|)</dfn> performs the following steps:
 
- 1. Assert: ! [$CanTransferArrayBuffer$](|O|) is true.
+ 1. Assert: ! [$IsDetachedBuffer$](|O|) is false.
  1. Let |arrayBufferData| be |O|.\[[ArrayBufferData]].
  1. Let |arrayBufferByteLength| be |O|.\[[ArrayBufferByteLength]].
- 1. Perform ! [$DetachArrayBuffer$](|O|).
+ 1. Perform ? [$DetachArrayBuffer$](|O|).
  1. Return a new {{ArrayBuffer}} object, created in [=the current Realm=], whose
     \[[ArrayBufferData]] internal slot value is |arrayBufferData| and whose
     \[[ArrayBufferByteLength]] internal slot value is |arrayBufferByteLength|.

--- a/index.bs
+++ b/index.bs
@@ -55,6 +55,7 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMASCRIPT
   text: IsDetachedBuffer; url: #sec-isdetachedbuffer
   text: IsInteger; url: #sec-isinteger
   text: OrdinaryObjectCreate; url: #sec-ordinaryobjectcreate
+  text: SameValue; url: #sec-samevalue
   text: SetFunctionLength; url: #sec-setfunctionlength
   text: SetFunctionName; url: #sec-setfunctionname
   text: Type; url: #sec-ecmascript-data-types-and-values
@@ -6086,6 +6087,7 @@ The following abstract operations are a grab-bag of utilities.
  1. Assert: [$Type$](|O|) is Object.
  1. Assert: |O| has an \[[ArrayBufferData]] internal slot.
  1. If ! [$IsDetachedBuffer$](|O|) is true, return false.
+ 1. If [$SameValue$](|O|.\[[ArrayBufferDetachKey]], undefined) is false, return false.
  1. Return true.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1402,7 +1402,7 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
  1. If |view|.\[[ByteLength]] is 0, return [=a promise rejected with=] a {{TypeError}} exception.
  1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. If ! [$CanTransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]) is false, return
+ 1. If ! [$IsDetachedBuffer$](|view|.\[[ViewedArrayBuffer]]) is true, return
     [=a promise rejected with=] a {{TypeError}} exception.
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected
     with=] a {{TypeError}} exception.
@@ -3105,7 +3105,11 @@ The following abstract operations support the implementation of the
      |view|.\[[TypedArrayName]].
  1. Let |byteOffset| be |view|.\[[ByteOffset]].
  1. Let |byteLength| be |view|.\[[ByteLength]].
- 1. Let |buffer| be ! [$TransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]).
+ 1. Let |bufferResult| be [$TransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]).
+ 1. If |bufferResult| is an abrupt completion,
+  1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |bufferResult|.\[[Value]].
+  1. Return.
+ 1. Let |buffer| be |bufferResult|.\[[Value]].
  1. Let |pullIntoDescriptor| be a new [=pull-into descriptor=] with [=pull-into descriptor/buffer=]
     |buffer|, [=pull-into descriptor/buffer byte length=] |buffer|.\[[ArrayBufferByteLength]],
     [=pull-into descriptor/byte offset=] |byteOffset|, [=pull-into descriptor/byte length=]

--- a/index.bs
+++ b/index.bs
@@ -1808,7 +1808,7 @@ has the following [=struct/items=]:
     "`readable`", throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If ! [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
+  1. If ! [$CanTransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is false,
      throw a {{TypeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
 </div>
@@ -1826,7 +1826,7 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
     "`readable`", throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If ! [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
+  1. If ! [$CanTransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is false,
      throw a {{TypeError}} exception.
  1. Return ! [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
 </div>
@@ -1977,8 +1977,8 @@ following table:
 
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
- 1. If ! [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]]) is
-    true, throw a {{TypeError}} exception.
+ 1. If ! [$CanTransferArrayBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]])
+    is false, throw a {{TypeError}} exception.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ByteLength]] &gt; 0.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByteLength]]
     &gt; 0.
@@ -6080,6 +6080,16 @@ abstract operations are used to implement these "cross-realm transforms".
 The following abstract operations are a grab-bag of utilities.
 
 <div algorithm>
+ <dfn abstract-op lt="CanTransferArrayBuffer"
+ id="can-transfer-array-buffer">CanTransferArrayBuffer(|O|)</dfn> performs the following steps:
+
+ 1. Assert: [$Type$](|O|) is Object.
+ 1. Assert: |O| has an \[[ArrayBufferData]] internal slot.
+ 1. If ! [$IsDetachedBuffer$](|O|) is true, return false.
+ 1. Return true.
+</div>
+
+<div algorithm>
  <dfn abstract-op lt="IsNonNegativeNumber"
  id="is-non-negative-number">IsNonNegativeNumber(|v|)</dfn> performs the following steps:
 
@@ -6093,9 +6103,7 @@ The following abstract operations are a grab-bag of utilities.
  <dfn abstract-op lt="TransferArrayBuffer"
  id="transfer-array-buffer">TransferArrayBuffer(|O|)</dfn> performs the following steps:
 
- 1. Assert: [$Type$](|O|) is Object.
- 1. Assert: |O| has an \[[ArrayBufferData]] internal slot.
- 1. Assert: ! [$IsDetachedBuffer$](|O|) is false.
+ 1. Assert: ! [$CanTransferArrayBuffer$](|O|) is true.
  1. Let |arrayBufferData| be |O|.\[[ArrayBufferData]].
  1. Let |arrayBufferByteLength| be |O|.\[[ArrayBufferByteLength]].
  1. Perform ! [$DetachArrayBuffer$](|O|).

--- a/index.bs
+++ b/index.bs
@@ -63,9 +63,9 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMASCRIPT
  text: map; url: #sec-array.prototype.map; type: method; for: Array.prototype
 urlPrefix: https://webassembly.github.io/spec/js-api/; spec: WASM-JS-API-1
  type: interface
-  text: WebAssembly.Memory; url: #memory
+  text: Memory; url: #memory
  type: attribute
-  text: buffer; for: WebAssembly.Memory; url: #dom-memory-buffer
+  text: buffer; for: Memory; url: #dom-memory-buffer
 url: https://wicg.github.io/compression/#compressionstream; spec: COMPRESSION; type: interface; text: CompressionStream
 </pre>
 
@@ -6145,7 +6145,7 @@ The following abstract operations are a grab-bag of utilities.
  1. Let |arrayBufferByteLength| be |O|.\[[ArrayBufferByteLength]].
  1. Perform ? [$DetachArrayBuffer$](|O|).
     <p class="note">This will throw an exception if |O| has an \[[ArrayBufferDetachKey]]
-    that is not undefined, such as a {{WebAssembly.Memory}}'s {{WebAssembly.Memory/buffer}}.
+    that is not undefined, such as a {{Memory|WebAssembly.Memory}}'s {{Memory/buffer}}.
     [[WASM-JS-API-1]]</p>
  1. Return a new {{ArrayBuffer}} object, created in [=the current Realm=], whose
     \[[ArrayBufferData]] internal slot value is |arrayBufferData| and whose

--- a/index.bs
+++ b/index.bs
@@ -1977,8 +1977,8 @@ following table:
 
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
- 1. If ! [$CanTransferArrayBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]])
-    is false, throw a {{TypeError}} exception.
+ 1. If ! [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]])
+    is true, throw a {{TypeError}} exception.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ByteLength]] &gt; 0.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByteLength]]
     &gt; 0.

--- a/index.bs
+++ b/index.bs
@@ -1805,6 +1805,10 @@ has the following [=struct/items=]:
     exception.
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
+  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. If [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
+     throw a {{TypeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
 </div>
 
@@ -1819,6 +1823,10 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
     exception.
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
+ 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
+  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. If [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
+     throw a {{TypeError}} exception.
  1. Return ! [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1808,7 +1808,7 @@ has the following [=struct/items=]:
     "`readable`", throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
+  1. If ! [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
      throw a {{TypeError}} exception.
  1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
 </div>
@@ -1826,7 +1826,7 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
     "`readable`", throw a {{TypeError}} exception.
  1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
+  1. If ! [$IsDetachedBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true,
      throw a {{TypeError}} exception.
  1. Return ! [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
 </div>
@@ -1977,7 +1977,7 @@ following table:
 
  1. If [=this=].[=ReadableStreamBYOBRequest/[[controller]]=] is undefined, throw a {{TypeError}}
     exception.
- 1. If [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]]) is
+ 1. If ! [$IsDetachedBuffer$]([=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ArrayBuffer]]) is
     true, throw a {{TypeError}} exception.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ByteLength]] &gt; 0.
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByteLength]]

--- a/index.bs
+++ b/index.bs
@@ -1397,6 +1397,8 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
  1. If |view|.\[[ByteLength]] is 0, return [=a promise rejected with=] a {{TypeError}} exception.
  1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, return [=a promise rejected
     with=] a {{TypeError}} exception.
+ 1. If ! [$CanTransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]) is false, return
+    [=a promise rejected with=] a {{TypeError}} exception.
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected
     with=] a {{TypeError}} exception.
  1. Let |promise| be [=a new promise=].

--- a/index.bs
+++ b/index.bs
@@ -2917,7 +2917,7 @@ The following abstract operations support the implementation of the
   1. If ! [$IsDetachedBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
      is true, throw a {{TypeError}} exception.
   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
-     [$TransferArrayBuffer$]([=pull-into descriptor/buffer=]).
+     [$TransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=]).
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
  1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true
   1. If ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0,

--- a/index.bs
+++ b/index.bs
@@ -3219,8 +3219,8 @@ The following abstract operations support the implementation of the
     descriptor/bytes filled=] is not |view|.\[[ByteOffset]], throw a {{RangeError}} exception.
  1. If |firstDescriptor|'s [=pull-into descriptor/buffer byte length=] is not
     |view|.\[[ViewedArrayBuffer]].\[[ByteLength]], throw a {{RangeError}} exception.
- 1. If |firstDescriptor|'s [=pull-into descriptor/byte length=] < |view|.\[[ByteLength]], throw
-    a {{RangeError}} exception.
+ 1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] + |view|.\[[ByteLength]] >
+    |firstDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
  1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to |view|.\[[ViewedArrayBuffer]].
  1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |view|.\[[ByteLength]]).
 </div>

--- a/index.bs
+++ b/index.bs
@@ -3193,6 +3193,7 @@ The following abstract operations support the implementation of the
  |bytesWritten|)</dfn> performs the following steps:
 
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+ 1. Assert: ! [$CanTransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true.
  1. Let |state| be
     |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`closed`",

--- a/index.bs
+++ b/index.bs
@@ -3186,7 +3186,7 @@ The following abstract operations support the implementation of the
  id="readable-byte-stream-controller-respond-in-readable-state">ReadableByteStreamControllerRespondInReadableState(|controller|,
  |bytesWritten|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
- 1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| <=
+ 1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| ≤
     |pullIntoDescriptor|'s [=pull-into descriptor/byte length=].
  1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
     |bytesWritten|, |pullIntoDescriptor|).

--- a/index.bs
+++ b/index.bs
@@ -1727,8 +1727,7 @@ has the following [=struct/items=]:
 :: A nonnegative integer byte offset into the [=pull-into descriptor/buffer=] where the
    [=underlying byte source=] will start writing
 : <dfn for="pull-into descriptor">byte length</dfn>
-:: A nonnegative integer number of bytes which can be written into the [=pull-into
-   descriptor/buffer=]
+:: A positive integer number of bytes which can be written into the [=pull-into descriptor/buffer=]
 : <dfn for="pull-into descriptor">bytes filled</dfn>
 :: A nonnegative integer number of bytes that have been written into the [=pull-into
    descriptor/buffer=] so far

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -3,7 +3,6 @@ const assert = require('assert');
 
 const { CancelSteps, PullSteps } = require('./abstract-ops/internal-methods.js');
 const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
-const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
 const aos = require('./abstract-ops/readable-streams.js');
 
 const ReadableStreamBYOBRequest = require('../generated/ReadableStreamBYOBRequest.js');
@@ -57,13 +56,6 @@ exports.implementation = class ReadableByteStreamControllerImpl {
     const state = this._stream._state;
     if (state !== 'readable') {
       throw new TypeError(`The stream (in ${state} state) is not in the readable state and cannot be enqueued to`);
-    }
-
-    if (this._pendingPullIntos.length > 0) {
-      const firstDescriptor = this._pendingPullIntos[0];
-      if (CanTransferArrayBuffer(firstDescriptor.buffer) === false) {
-        throw new TypeError('The BYOB request\'s buffer has been detached');
-      }
     }
 
     aos.ReadableByteStreamControllerEnqueue(this, chunk);

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -1,6 +1,7 @@
 'use strict';
 const assert = require('assert');
 
+const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
 const { CancelSteps, PullSteps } = require('./abstract-ops/internal-methods.js');
 const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
 const aos = require('./abstract-ops/readable-streams.js');
@@ -47,6 +48,9 @@ exports.implementation = class ReadableByteStreamControllerImpl {
     }
     if (chunk.buffer.byteLength === 0) {
       throw new TypeError('chunk\'s buffer must have non-zero byteLength');
+    }
+    if (CanTransferArrayBuffer(chunk.buffer) === false) {
+      throw new TypeError('The given view\'s buffer is not transferable and so cannot be enqueued');
     }
 
     if (this._closeRequested === true) {

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -1,7 +1,6 @@
 'use strict';
 const assert = require('assert');
 
-const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
 const { CancelSteps, PullSteps } = require('./abstract-ops/internal-methods.js');
 const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
 const aos = require('./abstract-ops/readable-streams.js');
@@ -48,9 +47,6 @@ exports.implementation = class ReadableByteStreamControllerImpl {
     }
     if (chunk.buffer.byteLength === 0) {
       throw new TypeError('chunk\'s buffer must have non-zero byteLength');
-    }
-    if (CanTransferArrayBuffer(chunk.buffer) === false) {
-      throw new TypeError('chunk\'s buffer is not transferable and so cannot be enqueued');
     }
 
     if (this._closeRequested === true) {

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 
 const { CancelSteps, PullSteps } = require('./abstract-ops/internal-methods.js');
 const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
-const { IsDetachedBuffer } = require('./abstract-ops/ecmascript.js');
+const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
 const aos = require('./abstract-ops/readable-streams.js');
 
 const ReadableStreamBYOBRequest = require('../generated/ReadableStreamBYOBRequest.js');
@@ -41,7 +41,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
 
     if (this._pendingPullIntos.length > 0) {
       const firstDescriptor = this._pendingPullIntos[0];
-      if (IsDetachedBuffer(firstDescriptor.buffer) === true) {
+      if (CanTransferArrayBuffer(firstDescriptor.buffer) === false) {
         throw new TypeError('The BYOB request\'s buffer has been detached');
       }
     }
@@ -68,7 +68,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
 
     if (this._pendingPullIntos.length > 0) {
       const firstDescriptor = this._pendingPullIntos[0];
-      if (IsDetachedBuffer(firstDescriptor.buffer) === true) {
+      if (CanTransferArrayBuffer(firstDescriptor.buffer) === false) {
         throw new TypeError('The BYOB request\'s buffer has been detached');
       }
     }

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -39,13 +39,6 @@ exports.implementation = class ReadableByteStreamControllerImpl {
       throw new TypeError(`The stream (in ${state} state) is not in the readable state and cannot be closed`);
     }
 
-    if (this._pendingPullIntos.length > 0) {
-      const firstDescriptor = this._pendingPullIntos[0];
-      if (CanTransferArrayBuffer(firstDescriptor.buffer) === false) {
-        throw new TypeError('The BYOB request\'s buffer has been detached');
-      }
-    }
-
     aos.ReadableByteStreamControllerClose(this);
   }
 

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -123,6 +123,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
 
       const pullIntoDescriptor = {
         buffer,
+        bufferByteLength: autoAllocateChunkSize,
         byteOffset: 0,
         byteLength: autoAllocateChunkSize,
         bytesFilled: 0,

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -50,7 +50,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
       throw new TypeError('chunk\'s buffer must have non-zero byteLength');
     }
     if (CanTransferArrayBuffer(chunk.buffer) === false) {
-      throw new TypeError('The given view\'s buffer is not transferable and so cannot be enqueued');
+      throw new TypeError('chunk\'s buffer is not transferable and so cannot be enqueued');
     }
 
     if (this._closeRequested === true) {

--- a/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { newPromise, resolvePromise, rejectPromise, promiseRejectedWith } = require('./helpers/webidl.js');
+const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
 const aos = require('./abstract-ops/readable-streams.js');
 const { mixin } = require('./helpers/miscellaneous.js');
 const ReadableStreamGenericReaderImpl = require('./ReadableStreamGenericReader-impl.js').implementation;
@@ -16,6 +17,9 @@ class ReadableStreamBYOBReaderImpl {
     }
     if (view.buffer.byteLength === 0) {
       return promiseRejectedWith(new TypeError('view\'s buffer must have non-zero byteLength'));
+    }
+    if (CanTransferArrayBuffer(view.buffer) === false) {
+      return promiseRejectedWith(new TypeError('view\'s buffer is not transferable'));
     }
 
     if (this._stream === undefined) {

--- a/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { newPromise, resolvePromise, rejectPromise, promiseRejectedWith } = require('./helpers/webidl.js');
-const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
+const { IsDetachedBuffer } = require('./abstract-ops/ecmascript.js');
 const aos = require('./abstract-ops/readable-streams.js');
 const { mixin } = require('./helpers/miscellaneous.js');
 const ReadableStreamGenericReaderImpl = require('./ReadableStreamGenericReader-impl.js').implementation;
@@ -18,8 +18,8 @@ class ReadableStreamBYOBReaderImpl {
     if (view.buffer.byteLength === 0) {
       return promiseRejectedWith(new TypeError('view\'s buffer must have non-zero byteLength'));
     }
-    if (CanTransferArrayBuffer(view.buffer) === false) {
-      return promiseRejectedWith(new TypeError('view\'s buffer is not transferable'));
+    if (IsDetachedBuffer(view.buffer) === true) {
+      return promiseRejectedWith(new TypeError('view\'s buffer has been detached'));
     }
 
     if (this._stream === undefined) {

--- a/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
@@ -25,9 +25,6 @@ exports.implementation = class ReadableStreamBYOBRequestImpl {
   }
 
   respondWithNewView(view) {
-    if (view.byteLength === 0) {
-      throw new TypeError('chunk must have non-zero byteLength');
-    }
     if (view.buffer.byteLength === 0) {
       throw new TypeError('chunk\'s buffer must have non-zero byteLength');
     }

--- a/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
@@ -25,10 +25,6 @@ exports.implementation = class ReadableStreamBYOBRequestImpl {
   }
 
   respondWithNewView(view) {
-    if (view.buffer.byteLength === 0) {
-      throw new TypeError('chunk\'s buffer must have non-zero byteLength');
-    }
-
     if (this._controller === undefined) {
       throw new TypeError('This BYOB request has been invalidated');
     }

--- a/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('assert');
 
-const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
+const { CanTransferArrayBuffer, IsDetachedBuffer } = require('./abstract-ops/ecmascript.js');
 const aos = require('./abstract-ops/readable-streams.js');
 
 exports.implementation = class ReadableStreamBYOBRequestImpl {
@@ -14,7 +14,7 @@ exports.implementation = class ReadableStreamBYOBRequestImpl {
       throw new TypeError('This BYOB request has been invalidated');
     }
 
-    if (CanTransferArrayBuffer(this._view.buffer) === false) {
+    if (IsDetachedBuffer(this._view.buffer) === true) {
       throw new TypeError('The BYOB request\'s buffer has been detached and so cannot be used as a response');
     }
 

--- a/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
@@ -29,6 +29,10 @@ exports.implementation = class ReadableStreamBYOBRequestImpl {
       throw new TypeError('This BYOB request has been invalidated');
     }
 
+    if (CanTransferArrayBuffer(view.buffer) === false) {
+      throw new TypeError('The given view\'s buffer is not transferable and so cannot be used as a response');
+    }
+
     aos.ReadableByteStreamControllerRespondWithNewView(this._controller, view);
   }
 };

--- a/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('assert');
 
-const { IsDetachedBuffer } = require('./abstract-ops/ecmascript.js');
+const { CanTransferArrayBuffer } = require('./abstract-ops/ecmascript.js');
 const aos = require('./abstract-ops/readable-streams.js');
 
 exports.implementation = class ReadableStreamBYOBRequestImpl {
@@ -14,7 +14,7 @@ exports.implementation = class ReadableStreamBYOBRequestImpl {
       throw new TypeError('This BYOB request has been invalidated');
     }
 
-    if (IsDetachedBuffer(this._view.buffer) === true) {
+    if (CanTransferArrayBuffer(this._view.buffer) === false) {
       throw new TypeError('The BYOB request\'s buffer has been detached and so cannot be used as a response');
     }
 

--- a/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest-impl.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('assert');
 
-const { CanTransferArrayBuffer, IsDetachedBuffer } = require('./abstract-ops/ecmascript.js');
+const { IsDetachedBuffer } = require('./abstract-ops/ecmascript.js');
 const aos = require('./abstract-ops/readable-streams.js');
 
 exports.implementation = class ReadableStreamBYOBRequestImpl {
@@ -29,8 +29,8 @@ exports.implementation = class ReadableStreamBYOBRequestImpl {
       throw new TypeError('This BYOB request has been invalidated');
     }
 
-    if (CanTransferArrayBuffer(view.buffer) === false) {
-      throw new TypeError('The given view\'s buffer is not transferable and so cannot be used as a response');
+    if (IsDetachedBuffer(view.buffer) === true) {
+      throw new TypeError('The given view\'s buffer has been detached and so cannot be used as a response');
     }
 
     aos.ReadableByteStreamControllerRespondWithNewView(this._controller, view);

--- a/reference-implementation/lib/abstract-ops/ecmascript.js
+++ b/reference-implementation/lib/abstract-ops/ecmascript.js
@@ -15,7 +15,7 @@ exports.CopyDataBlockBytes = (dest, destOffset, src, srcOffset, n) => {
 
 // Not implemented correctly
 exports.TransferArrayBuffer = O => {
-  assert(!exports.IsDetachedBuffer(O));
+  assert(exports.CanTransferArrayBuffer(O));
   const transferredIshVersion = O.slice();
 
   // This is specifically to fool tests that test "is transferred" by taking a non-zero-length
@@ -28,6 +28,11 @@ exports.TransferArrayBuffer = O => {
   O[isFakeDetached] = true;
 
   return transferredIshVersion;
+};
+
+// Not implemented correctly
+exports.CanTransferArrayBuffer = O => {
+  return !exports.IsDetachedBuffer(O);
 };
 
 // Not implemented correctly

--- a/reference-implementation/lib/abstract-ops/ecmascript.js
+++ b/reference-implementation/lib/abstract-ops/ecmascript.js
@@ -15,7 +15,7 @@ exports.CopyDataBlockBytes = (dest, destOffset, src, srcOffset, n) => {
 
 // Not implemented correctly
 exports.TransferArrayBuffer = O => {
-  assert(exports.CanTransferArrayBuffer(O));
+  assert(!exports.IsDetachedBuffer(O));
   const transferredIshVersion = O.slice();
 
   // This is specifically to fool tests that test "is transferred" by taking a non-zero-length

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -989,8 +989,6 @@ function ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescripto
 }
 
 function ReadableByteStreamControllerEnqueue(controller, chunk) {
-  assert(CanTransferArrayBuffer(chunk.buffer) === true);
-
   const stream = controller._stream;
 
   if (controller._closeRequested === true || stream._state !== 'readable') {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -989,6 +989,8 @@ function ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescripto
 }
 
 function ReadableByteStreamControllerEnqueue(controller, chunk) {
+  assert(CanTransferArrayBuffer(chunk.buffer) === true);
+
   const stream = controller._stream;
 
   if (controller._closeRequested === true || stream._state !== 'readable') {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1013,12 +1013,9 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
     if (controller._pendingPullIntos.length > 0) {
       const firstPendingPullInto = controller._pendingPullIntos[0];
       if (CanTransferArrayBuffer(firstPendingPullInto.buffer) === false) {
-        const e = new TypeError(
+        throw new TypeError(
           'The BYOB request\'s buffer has been detached and so cannot be filled with an enqueued chunk'
         );
-        ReadableByteStreamControllerError(controller, e);
-
-        throw e;
       }
     }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1163,6 +1163,7 @@ function ReadableByteStreamControllerPullInto(controller, view, readIntoRequest)
   const buffer = TransferArrayBuffer(view.buffer);
   const pullIntoDescriptor = {
     buffer,
+    bufferByteLength: buffer.byteLength,
     byteOffset: view.byteOffset,
     byteLength: view.byteLength,
     bytesFilled: 0,
@@ -1289,8 +1290,11 @@ function ReadableByteStreamControllerRespondWithNewView(controller, view) {
   if (firstDescriptor.byteOffset + firstDescriptor.bytesFilled !== view.byteOffset) {
     throw new RangeError('The region specified by view does not match byobRequest');
   }
-  if (firstDescriptor.byteLength !== view.byteLength) {
+  if (firstDescriptor.bufferByteLength !== view.buffer.byteLength) {
     throw new RangeError('The buffer of view has different capacity than byobRequest');
+  }
+  if (firstDescriptor.byteLength !== view.byteLength) {
+    throw new RangeError('The region specified by view has different length than byobRequest');
   }
 
   firstDescriptor.buffer = view.buffer;

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1175,7 +1175,14 @@ function ReadableByteStreamControllerPullInto(controller, view, readIntoRequest)
 
   const ctor = view.constructor;
 
-  const buffer = TransferArrayBuffer(view.buffer);
+  let buffer;
+  try {
+    buffer = TransferArrayBuffer(view.buffer);
+  } catch (e) {
+    readIntoRequest.errorSteps(e);
+    return;
+  }
+
   const pullIntoDescriptor = {
     buffer,
     bufferByteLength: buffer.byteLength,

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -984,8 +984,8 @@ function ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescripto
   assert(bytesFilled <= pullIntoDescriptor.byteLength);
   assert(bytesFilled % elementSize === 0);
 
-  return new pullIntoDescriptor.viewConstructor(
-    pullIntoDescriptor.buffer, pullIntoDescriptor.byteOffset, bytesFilled / elementSize);
+  const buffer = TransferArrayBuffer(pullIntoDescriptor.buffer);
+  return new pullIntoDescriptor.viewConstructor(buffer, pullIntoDescriptor.byteOffset, bytesFilled / elementSize);
 }
 
 function ReadableByteStreamControllerEnqueue(controller, chunk) {
@@ -1280,7 +1280,6 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, remainder, 0, remainder.byteLength);
   }
 
-  pullIntoDescriptor.buffer = TransferArrayBuffer(pullIntoDescriptor.buffer);
   pullIntoDescriptor.bytesFilled -= remainderSize;
   ReadableByteStreamControllerCommitPullIntoDescriptor(controller._stream, pullIntoDescriptor);
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1296,7 +1296,7 @@ function ReadableByteStreamControllerRespondWithNewView(controller, view) {
   if (firstDescriptor.bufferByteLength !== view.buffer.byteLength) {
     throw new RangeError('The buffer of view has different capacity than byobRequest');
   }
-  if (firstDescriptor.byteLength < view.byteLength) {
+  if (firstDescriptor.bytesFilled + view.byteLength > firstDescriptor.byteLength) {
     throw new RangeError('The region specified by view is larger than byobRequest');
   }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1301,6 +1301,7 @@ function ReadableByteStreamControllerRespondInternal(controller, bytesWritten) {
 
 function ReadableByteStreamControllerRespondWithNewView(controller, view) {
   assert(controller._pendingPullIntos.length > 0);
+  assert(CanTransferArrayBuffer(view.buffer) === true);
 
   const firstDescriptor = controller._pendingPullIntos[0];
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1293,8 +1293,8 @@ function ReadableByteStreamControllerRespondWithNewView(controller, view) {
   if (firstDescriptor.bufferByteLength !== view.buffer.byteLength) {
     throw new RangeError('The buffer of view has different capacity than byobRequest');
   }
-  if (firstDescriptor.byteLength !== view.byteLength) {
-    throw new RangeError('The region specified by view has different length than byobRequest');
+  if (firstDescriptor.byteLength < view.byteLength) {
+    throw new RangeError('The region specified by view is larger than byobRequest');
   }
 
   firstDescriptor.buffer = view.buffer;

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1275,6 +1275,9 @@ function ReadableByteStreamControllerRespondInternal(controller, bytesWritten) {
     ReadableByteStreamControllerRespondInClosedState(controller, firstDescriptor);
   } else {
     assert(state === 'readable');
+    if (bytesWritten === 0) {
+      throw new TypeError('bytesWritten must be greater than 0 when calling respond() on a readable stream');
+    }
 
     ReadableByteStreamControllerRespondInReadableState(controller, bytesWritten, firstDescriptor);
   }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1277,6 +1277,7 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
 
 function ReadableByteStreamControllerRespondInternal(controller, bytesWritten) {
   const firstDescriptor = controller._pendingPullIntos[0];
+  assert(CanTransferArrayBuffer(firstDescriptor.buffer) === true);
 
   const state = controller._stream._state;
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1311,7 +1311,7 @@ function ReadableByteStreamControllerRespondInternal(controller, bytesWritten) {
 
 function ReadableByteStreamControllerRespondWithNewView(controller, view) {
   assert(controller._pendingPullIntos.length > 0);
-  assert(CanTransferArrayBuffer(view.buffer) === true);
+  assert(IsDetachedBuffer(view.buffer) === false);
 
   const firstDescriptor = controller._pendingPullIntos[0];
   const state = controller._stream._state;

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1005,7 +1005,7 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
 
   if (controller._pendingPullIntos.length > 0) {
     const firstPendingPullInto = controller._pendingPullIntos[0];
-    if (CanTransferArrayBuffer(firstPendingPullInto.buffer) === false) {
+    if (IsDetachedBuffer(firstPendingPullInto.buffer) === true) {
       throw new TypeError(
         'The BYOB request\'s buffer has been detached and so cannot be filled with an enqueued chunk'
       );

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1017,6 +1017,7 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
           'The BYOB request\'s buffer has been detached and so cannot be filled with an enqueued chunk'
         );
       }
+      firstPendingPullInto.buffer = TransferArrayBuffer(firstPendingPullInto.buffer);
     }
 
     // TODO: Ideally in this branch detaching should happen only if the buffer is not consumed fully.
@@ -1244,12 +1245,12 @@ function ReadableByteStreamControllerRespond(controller, bytesWritten) {
     }
   }
 
+  firstDescriptor.buffer = TransferArrayBuffer(firstDescriptor.buffer);
+
   ReadableByteStreamControllerRespondInternal(controller, bytesWritten);
 }
 
 function ReadableByteStreamControllerRespondInClosedState(controller, firstDescriptor) {
-  firstDescriptor.buffer = TransferArrayBuffer(firstDescriptor.buffer);
-
   assert(firstDescriptor.bytesFilled === 0);
 
   const stream = controller._stream;
@@ -1267,7 +1268,6 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
   ReadableByteStreamControllerFillHeadPullIntoDescriptor(controller, bytesWritten, pullIntoDescriptor);
 
   if (pullIntoDescriptor.bytesFilled < pullIntoDescriptor.elementSize) {
-    // TODO: Figure out whether we should detach the buffer or not here.
     return;
   }
 
@@ -1334,7 +1334,7 @@ function ReadableByteStreamControllerRespondWithNewView(controller, view) {
     throw new RangeError('The region specified by view is larger than byobRequest');
   }
 
-  firstDescriptor.buffer = view.buffer;
+  firstDescriptor.buffer = TransferArrayBuffer(view.buffer);
 
   ReadableByteStreamControllerRespondInternal(controller, view.byteLength);
 }

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -33,6 +33,11 @@ async function main() {
   const testsPath = path.resolve(wptPath, 'streams');
 
   const filterGlobs = process.argv.length >= 3 ? process.argv.slice(2) : ['**/*.html'];
+  const excludeGlobs = [
+    // These tests use ArrayBuffers backed by WebAssembly.Memory objects, which *should* be non-transferable.
+    // However, our TransferArrayBuffer implementation cannot detect these, and will incorrectly "transfer" them anyway.
+    'readable-byte-streams/non-transferable-buffers.any.html'
+  ];
   const anyTestPattern = /\.any\.html$/;
 
   const bundledJS = await bundle(entryPath);
@@ -61,7 +66,8 @@ async function main() {
         return false;
       }
 
-      return filterGlobs.some(glob => minimatch(testPath, glob));
+      return filterGlobs.some(glob => minimatch(testPath, glob)) &&
+        !excludeGlobs.some(glob => minimatch(testPath, glob));
     }
   });
 


### PR DESCRIPTION
This started as a few fixes that we encountered while working on #1114, but it ended up being... a lot of fixes. 😅

* `.respondWithNewView(newView)` can now be called with a `newView` that is *smaller than* the BYOB request's view. This aligns it with `.respond(bytesWritten)`, which also allows `bytesWritten <= byobRequest.view.byteLength`.
* `.respondWithNewView()` must now be called with an empty view when the stream is closed. This aligns it with `.respond(bytesWritten)`, which requires `bytesWritten` to be 0 when closed.
* `.respondWithNewView(newView)` must now be called with a view whose `view.buffer.byteLength` matches that of the BYOB request. Ideally, we would like to assert that the new view's buffer is the "transferred version" of the BYOB request's buffer, but that's not possible yet with the tools currently provided by the ECMAScript specification.
* `.enqueue(chunk)` and `.respondWithNewView(newView)` now check that the given view's buffer is actually *transferable*. Previously, we only checked whether the buffer is *not yet detached*, but this is insufficient: a `WebAssembly.Memory`'s buffer is *never* transferable. We also make sure to not transfer the given buffer until *after* we've checked all other preconditions, so the buffer is still intact if these methods were to throw an error.
* `.enqueue()` and `.respond()` now check that the BYOB request's view has *not* been transferred, since otherwise it's not possible to copy bytes into its buffer and/or transfer the buffer when committing. This could crash Chrome, but has already been fixed in https://crbug.com/1200302. The reproduction case (see below) is now covered by a WPT test.
* `.enqueue()`, `.respond()` and `.respondWithNewView()` immediately invalidate the BYOB request. Previously, we only did this if we actually filled the first pull-into descriptor, which doesn't *always* happen. (For example: if the pull-into descriptor's element size is 4, but we only have filled 1 or 2 bytes.)
* We now always transfer the pull-into descriptor's buffer when committing it (to fulfill a read request or read-into request). This is mainly a sanity check: the stream should never use this buffer after it has been committed.

<details>
<summary>Original description</summary>

While working on #1114, we found that `byobRequest.respondWithNewView(newView)` didn't support all the same use cases as a regular `.respond(bytesWritten)` call. In particular:
* `newView` was required to be the same length as the BYOB request's view. This would have required the underlying byte source to always fill *the entire view*. On the other hand, `.respond()` allows responding with fewer bytes *up to the view's length*, which is the desired behavior.
* When the stream is closed, `.respond()` can only be called with `bytesWritten` set to 0. To match this, `.respondWithNewView()` should only be called with an empty view in the closed state.

We now also require the view passed to `.respondWithNewView(newView)` to have the same capacity as the BYOB request's original buffer. Ideally, we would like to assert that the new view's buffer is the "transferred version" of the BYOB request's buffer, but that's not possible yet with the tools currently provided by the ECMAScript specification.

I also found cases where the stream would try to transfer an already transferred buffer. For example, this code crashes the tab in Chrome 92 (error code: `STATUS_ACCESS_VIOLATION`):
```javascript
let rs = new ReadableStream({
    type: 'bytes',
    pull(c) {
        let buffer = c.byobRequest.view.buffer;
        // Detach the buffer.
        postMessage(buffer, '*', [buffer]);
        // Try to enqueue with a new buffer.
        // The stream will try to copy to the pull-into request's view, but it can't because it has lost the buffer.
        c.enqueue(new Uint8Array([42]));
    }
});
let reader = rs.getReader({ mode: 'byob' });
await reader.read(new Uint8Array(1));
```
I fixed this by requiring the BYOB request's buffer to not be detached when calling `byteStreamController.enqueue()` or `.close()`.

</details>

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * web-platform-tests/wpt#28557
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1123.html" title="Last updated on May 26, 2021, 4:23 PM UTC (b22d61f)">Preview</a> | <a href="https://whatpr.org/streams/1123/cc29ed3...b22d61f.html" title="Last updated on May 26, 2021, 4:23 PM UTC (b22d61f)">Diff</a>