### PR TITLE
Remove unused parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4294,7 +4294,7 @@ the {{WritableStream}}'s public API.
 
 <div algorithm>
  <dfn abstract-op lt="WritableStreamFinishErroring"
- id="writable-stream-finish-erroring">WritableStreamFinishErroring(|stream|, |reason|)</dfn>
+ id="writable-stream-finish-erroring">WritableStreamFinishErroring(|stream|)</dfn>
  performs the following steps:
 
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`erroring`".


### PR DESCRIPTION
``WritableStreamFinishErroring`` is only invoked with one parameter, but it has signature with two parameters, the second one seems unused. It seems ``reason`` was added by mistake due to similarly named ``WritableStreamStartErroring``, while it actually should exists only as an argument to ``Upon promise rejection`` step.

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

