### PR TITLE
Resolve BYOB reads immediately on cancel

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1322,8 +1322,8 @@ the following [=struct/items=]:
 : <dfn export for="read-into request">chunk steps</dfn>
 :: An algorithm taking a [=chunk=], called when a chunk is available for reading
 : <dfn export for="read-into request">close steps</dfn>
-:: An algorithm taking a [=chunk=], called when no chunks are available because the stream is
-   closed
+:: An algorithm taking a [=chunk=] or undefined, called when no chunks are available because
+   the stream is closed
 : <dfn export for="read-into request">error steps</dfn>
 :: An algorithm taking a JavaScript value, called when no [=chunks=] are available because the
    stream is errored
@@ -1331,8 +1331,10 @@ the following [=struct/items=]:
 <p class="note">The [=read-into request/close steps=] take a [=chunk=] so that it can return the
 backing memory to the caller if possible. For example,
 {{ReadableStreamBYOBReader/read()|byobReader.read(chunk)}} will fulfill with <code highlight="js">{
-value: newViewOnSameMemory, done: true }</code> for closed streams, instead of the more traditional
-<code highlight="js">{ value: undefined, done: true }</code>.
+value: newViewOnSameMemory, done: true }</code> for closed streams. If the stream is
+[=cancel a readable stream|canceled=], the backing memory is discarded and
+{{ReadableStreamBYOBReader/read()|byobReader.read(chunk)}} fulfills with the more traditional
+<code highlight="js">{ value: undefined, done: true }</code> instead.
 
 <h4 id="byob-reader-prototype">Constructor, methods, and properties</h4>
 
@@ -1368,6 +1370,10 @@ value: newViewOnSameMemory, done: true }</code> for closed streams, instead of t
    [=ArrayBuffer/detached=] and no longer usable, but <code>theChunk</code> will be a new view (of
    the same type) onto the same backing memory region, with no modifications, to ensure the memory
    is returned to the caller.
+
+   <li>If the reader is [=cancel a readable stream|canceled=], the promise will be fulfilled with
+   an object of the form <code highlight="js">{ value: undefined, done: true }</code>. In this case,
+   the backing memory region of |view| is discarded and not returned to the caller.
 
    <li>If the stream becomes errored, the promise will be rejected with the relevant error.
   </ul>
@@ -1849,10 +1855,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  id="rbs-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
- 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is
-    empty|empty=],
-  1. Let |firstDescriptor| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. Set |firstDescriptor|'s [=pull-into descriptor/bytes filled=] to 0.
+ 1. Perform ! [$ReadableByteStreamControllerClearPendingPullIntos$]([=this=]).
  1. Perform ! [$ResetQueue$]([=this=]).
  1. Let |result| be the result of performing
     [=this=].[=ReadableByteStreamController/[[cancelAlgorithm]]=], passing in |reason|.
@@ -2361,6 +2364,11 @@ the {{ReadableStream}}'s public API.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", return [=a promise rejected with=]
     |stream|.[=ReadableStream/[[storedError]]=].
  1. Perform ! [$ReadableStreamClose$](|stream|).
+ 1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
+ 1. If |reader| is not undefined and |reader| [=implements=] {{ReadableStreamBYOBReader}},
+  1. [=list/For each=] |readIntoRequest| of |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=],
+   1. Perform |readIntoRequest|'s [=read-into request/close steps=], given undefined.
+  1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to an empty [=list=].
  1. Let |sourceCancelPromise| be !
     |stream|.[=ReadableStream/[[controller]]=].[$ReadableStreamController/[[CancelSteps]]$](|reason|).
  1. Return the result of [=reacting=] to |sourceCancelPromise| with a fulfillment step that returns

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -66,10 +66,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
   }
 
   [CancelSteps](reason) {
-    if (this._pendingPullIntos.length > 0) {
-      const firstDescriptor = this._pendingPullIntos[0];
-      firstDescriptor.bytesFilled = 0;
-    }
+    aos.ReadableByteStreamControllerClearPendingPullIntos(this);
 
     ResetQueue(this);
 


### PR DESCRIPTION
Right now, if you cancel the stream while a BYOB read is pending, the stream has to wait for the underlying byte source to call `respond(0)` before it can return the BYOB request's buffer to the caller. Effectively, every single underlying byte source would need to look like this:
```javascript
const readable = new ReadableStream({
  type: 'bytes',
  autoAllocateChunkSize: 1024,
  start(controller) {
    this._controller = controller;
  },
  async pull(controller) {
    const bytesWritten = await readBytesIntoViewSomehow(controller.byobRequest.view);
    controller.byobRequest.respond(bytesWritten);
  },
  cancel(reason) {
    this._controller.byobRequest?.respond(0); // must not forget this!
  }
});
```
This is a footgun: we *have* to rely on the underlying byte source to do this correctly. We are unable to do this automatically, since we don't know if or how the source might be using the BYOB request (for example, it might have transferred the buffer). If the source fails to call `respond(0)`, then the BYOB read never resolves and the reader gets stuck. If you forget to implement `cancel()` altogether, then the default implementation will not help either, since it is specified to do nothing.

In [#1114 (comment)](https://github.com/whatwg/streams/pull/1114#discussion_r605259271) and [#1123 (comment)](https://github.com/whatwg/streams/pull/1123#issuecomment-841413902), @domenic suggested that if you cancel the stream while a BYOB read is pending, the stream should simply not give you back your buffer. This means that `cancel()` can immediately resolve all pending BYOB reads with the classic `{ done: true, value: undefined }`, without having to wait for the underlying byte source. This solves the problem, and would make it easier to implement an underlying byte source.

This PR implements this suggestion. To make it work, I also had to change one other thing: when the stream is cancelled, any pending BYOB request is now *immediately invalidated*, so the underlying byte source doesn't erroneously think that it still needs to provide a response. (This aligns with the behavior of `controller.enqueue()`, which throws if the stream is already closed.)

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * web-platform-tests/wpt#29128
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1129.html" title="Last updated on Jun 1, 2021, 10:11 PM UTC (1b0a482)">Preview</a> | <a href="https://whatpr.org/streams/1129/033c6d9...1b0a482.html" title="Last updated on Jun 1, 2021, 10:11 PM UTC (1b0a482)">Diff</a>