### PR TITLE
Define WritableStreamDefaultController.signal

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4105,7 +4105,7 @@ closed. It is only used internally, and is never exposed to web developers.
 <h4 id="ws-default-controller-prototype">Methods and properties</h4>
 
 <dl class="domintro non-normative">
- <dt><code><var ignore>controller</var>.signal</code>
+ <dt><code><var ignore>controller</var>.{{WritableStreamDefaultController/signal}}</code>
  <dd>
   <p>An AbortSignal that can be used to abort the pending write or close operation when the stream is
   [=abort a writable stream|aborted=].

--- a/index.bs
+++ b/index.bs
@@ -4274,6 +4274,10 @@ The following abstract operations operate on {{WritableStream}} instances at a h
     |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[signal]]=].
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`closed`" or "`errored`", return [=a promise resolved with=] undefined.
+
+ <p class="note">We re-check the state because [=signaling abort=] runs author code and that might
+ have changed the state.
+
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined, return
     |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=].
  1. Assert: |state| is "`writable`" or "`erroring`".
@@ -4441,8 +4445,7 @@ the {{WritableStream}}'s public API.
  1. [=Reject=] |stream|.[=WritableStream/[[inFlightCloseRequest]]=] with |error|.
  1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
- 1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined and |error| is not an
-    "{{AbortError}}" {{DOMException}},
+ 1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
   1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort
      request/promise=] with |error|.
   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.

--- a/index.bs
+++ b/index.bs
@@ -4442,7 +4442,7 @@ the {{WritableStream}}'s public API.
  1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined and |error| is not an
-    {{AbortError}},
+    "{{AbortError}}" {{DOMException}},
   1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort
      request/promise=] with |error|.
   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.

--- a/index.bs
+++ b/index.bs
@@ -4716,6 +4716,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=WritableStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
+ 1. Set |controller|.[=WritableStreamDefaultController/[[abortReason]]=] to undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[signal]]=] to a new {{AbortSignal}}.
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to

--- a/index.bs
+++ b/index.bs
@@ -4041,6 +4041,7 @@ The Web IDL definition for the {{WritableStreamDefaultController}} class is give
 <xmp class="idl">
 [Exposed=(Window,Worker,Worklet)]
 interface WritableStreamDefaultController {
+  readonly attribute any abortReason;
   readonly attribute AbortSignal signal;
   undefined error(optional any e);
 };
@@ -4061,6 +4062,9 @@ the following table:
    <td><dfn>\[[abortAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm, taking one argument (the abort reason),
    which communicates a requested abort to the [=underlying sink=]
+  <tr>
+   <td><dfn>\[[abortReason]]</dfn>
+   <td class="non-normative">The argument given to [$WritableStreamAbort$], or undefined.
   <tr>
    <td><dfn>\[[closeAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
@@ -4119,6 +4123,13 @@ closed. It is only used internally, and is never exposed to web developers.
   in response to an event outside the normal lifecycle of interactions with the [=underlying
   sink=].
 </dl>
+
+<div algorithm>
+ The <dfn id="ws-default-controller-abort-reason" attribute
+ for="WritableStreamDefaultController">abortReason</dfn> getter steps are:
+
+ 1. Return [=this=].[=WritableStreamDefaultController/[[abortReason]]=].
+</div>
 
 <div algorithm>
  The <dfn id="ws-default-controller-signal" attribute
@@ -4270,6 +4281,9 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 
  1. If |stream|.[=WritableStream/[[state]]=] is "`closed`" or "`errored`", return
     [=a promise resolved with=] undefined.
+ 1. Set
+    |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[abortReason]]=]
+    to |reason|.
  1. [=Signal abort=] on
     |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[signal]]=].
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].

--- a/index.bs
+++ b/index.bs
@@ -4041,6 +4041,7 @@ The Web IDL definition for the {{WritableStreamDefaultController}} class is give
 <xmp class="idl">
 [Exposed=(Window,Worker,Worklet)]
 interface WritableStreamDefaultController {
+  readonly attribute AbortSignal signal;
   undefined error(optional any e);
 };
 </xmp>
@@ -4072,6 +4073,10 @@ the following table:
    <td class="non-normative">The total size of all the chunks stored in
    [=WritableStreamDefaultController/[[queue]]=] (see [[#queue-with-sizes]])
   <tr>
+   <td><dfn>\[[signal]]</dfn>
+   <td class="non-normative">An {{AbortSignal}} that can be used to abort the pending write or
+   close operation when the stream is [=abort a writable stream|aborted=].
+  <tr>
    <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying sink=] has finished
    starting
@@ -4097,9 +4102,13 @@ The <dfn>close sentinel</dfn> is a unique value enqueued into
 [=WritableStreamDefaultController/[[queue]]=], in lieu of a [=chunk=], to signal that the stream is
 closed. It is only used internally, and is never exposed to web developers.
 
-<h4 id="ws-default-controller-prototype">Methods</h4>
+<h4 id="ws-default-controller-prototype">Methods and properties</h4>
 
 <dl class="domintro non-normative">
+ <dt><code><var ignore>controller</var>.signal</code>
+ <dd>
+  <p>An AbortSignal that can be used to abort the pending write or close operation when the stream is
+  [=abort a writable stream|aborted=].
  <dt><code><var ignore>controller</var>.{{WritableStreamDefaultController/error()|error}}(<var ignore>e</var>)</code>
  <dd>
   <p>Closes the controlled writable stream, making all future interactions with it fail with the
@@ -4110,6 +4119,13 @@ closed. It is only used internally, and is never exposed to web developers.
   in response to an event outside the normal lifecycle of interactions with the [=underlying
   sink=].
 </dl>
+
+<div algorithm>
+ The <dfn id="ws-default-controller-signal" attribute
+ for="WritableStreamDefaultController">signal</dfn> getter steps are:
+
+ 1. Return [=this=].[=WritableStreamDefaultController/[[signal]]=].
+</div>
 
 <div algorithm>
  The <dfn id="ws-default-controller-error" method
@@ -4252,6 +4268,10 @@ The following abstract operations operate on {{WritableStream}} instances at a h
  id="writable-stream-abort">WritableStreamAbort(|stream|, |reason|)</dfn> performs the following
  steps:
 
+ 1. If |stream|.[=WritableStream/[[state]]=] is "`closed`" or "`errored`", return
+    [=a promise resolved with=] undefined.
+ 1. [=Signal abort=] on
+    |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[signal]]=].
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`closed`" or "`errored`", return [=a promise resolved with=] undefined.
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined, return
@@ -4421,7 +4441,8 @@ the {{WritableStream}}'s public API.
  1. [=Reject=] |stream|.[=WritableStream/[[inFlightCloseRequest]]=] with |error|.
  1. Set |stream|.[=WritableStream/[[inFlightCloseRequest]]=] to undefined.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
- 1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined,
+ 1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined and |error| is not an
+    {{AbortError}},
   1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort
      request/promise=] with |error|.
   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
@@ -4678,6 +4699,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=WritableStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
+ 1. Set |controller|.[=WritableStreamDefaultController/[[signal]]=] to a new {{AbortSignal}}.
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to
     |sizeAlgorithm|.

--- a/reference-implementation/lib/WritableStreamDefaultController-impl.js
+++ b/reference-implementation/lib/WritableStreamDefaultController-impl.js
@@ -5,6 +5,10 @@ const { AbortSteps, ErrorSteps } = require('./abstract-ops/internal-methods.js')
 const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
 
 exports.implementation = class WritableStreamDefaultControllerImpl {
+  get signal() {
+    return this._abortController.signal;
+  }
+
   error(e) {
     const state = this._stream._state;
 

--- a/reference-implementation/lib/WritableStreamDefaultController-impl.js
+++ b/reference-implementation/lib/WritableStreamDefaultController-impl.js
@@ -5,6 +5,9 @@ const { AbortSteps, ErrorSteps } = require('./abstract-ops/internal-methods.js')
 const { ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
 
 exports.implementation = class WritableStreamDefaultControllerImpl {
+  get abortReason() {
+    return this._abortReason;
+  }
   get signal() {
     return this._abortController.signal;
   }

--- a/reference-implementation/lib/WritableStreamDefaultController.webidl
+++ b/reference-implementation/lib/WritableStreamDefaultController.webidl
@@ -1,5 +1,6 @@
 [Exposed=(Window,Worker,Worklet)]
 interface WritableStreamDefaultController {
+  readonly attribute any abortReason;
   readonly attribute AbortSignal signal;
   void error(optional any e);
 };

--- a/reference-implementation/lib/WritableStreamDefaultController.webidl
+++ b/reference-implementation/lib/WritableStreamDefaultController.webidl
@@ -1,4 +1,5 @@
 [Exposed=(Window,Worker,Worklet)]
 interface WritableStreamDefaultController {
+  readonly attribute AbortSignal signal;
   void error(optional any e);
 };

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -303,7 +303,7 @@ function WritableStreamFinishInFlightCloseWithError(stream, error) {
   assert(stream._state === 'writable' || stream._state === 'erroring');
 
   // Never execute sink abort() after sink close().
-  if (stream._pendingAbortRequest !== undefined && !(error instanceof DOMException && error.name === 'AbortError')) {
+  if (stream._pendingAbortRequest !== undefined) {
     rejectPromise(stream._pendingAbortRequest.promise, error);
     stream._pendingAbortRequest = undefined;
   }

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -303,7 +303,7 @@ function WritableStreamFinishInFlightCloseWithError(stream, error) {
   assert(stream._state === 'writable' || stream._state === 'erroring');
 
   // Never execute sink abort() after sink close().
-  if (stream._pendingAbortRequest !== undefined && !(error instanceof AbortError)) {
+  if (stream._pendingAbortRequest !== undefined && !(error instanceof DOMException && error.name == "AbortError")) {
     rejectPromise(stream._pendingAbortRequest.promise, error);
     stream._pendingAbortRequest = undefined;
   }

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -107,6 +107,7 @@ function WritableStreamAbort(stream, reason) {
   if (stream._state === 'closed' || stream._state === 'errored') {
     return promiseResolvedWith(undefined);
   }
+  stream._controller._abortReason = reason;
   stream._controller._abortController.abort();
   const state = stream._state;
   if (state === 'closed' || state === 'errored') {
@@ -541,6 +542,7 @@ function SetUpWritableStreamDefaultController(stream, controller, startAlgorithm
   controller._queueTotalSize = undefined;
   ResetQueue(controller);
 
+  controller._abortReason = undefined;
   controller._abortController = new AbortController();
   controller._started = false;
 

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -303,7 +303,7 @@ function WritableStreamFinishInFlightCloseWithError(stream, error) {
   assert(stream._state === 'writable' || stream._state === 'erroring');
 
   // Never execute sink abort() after sink close().
-  if (stream._pendingAbortRequest !== undefined && !(error instanceof DOMException && error.name == "AbortError")) {
+  if (stream._pendingAbortRequest !== undefined && !(error instanceof DOMException && error.name === 'AbortError')) {
     rejectPromise(stream._pendingAbortRequest.promise, error);
     stream._pendingAbortRequest = undefined;
   }


### PR DESCRIPTION
Define the property to signal abort to UnderlyingSink even
when it has a pending write or close operation.

Fixes #1015.
<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/29310
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1215992
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1714341
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=226575

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1132.html" title="Last updated on Jun 24, 2021, 5:57 PM UTC (dde2430)">Preview</a> | <a href="https://whatpr.org/streams/1132/8a7d92b...dde2430.html" title="Last updated on Jun 24, 2021, 5:57 PM UTC (dde2430)">Diff</a>