### PR TITLE
Editorial: Linkify WritableStreamDealWithRejection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4363,7 +4363,7 @@ the {{WritableStream}}'s public API.
   1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort
      request/promise=] with |error|.
   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
- 1. Perform ! WritableStreamDealWithRejection(|stream|, |error|).
+ 1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |error|).
 </div>
 
 <div algorithm>


### PR DESCRIPTION
One use of WritableStreamDefaultDealWithRejection was not linkified. Fix
it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1133.html" title="Last updated on Jun 4, 2021, 6:55 AM UTC (8303aae)">Preview</a> | <a href="https://whatpr.org/streams/1133/cc29ed3...8303aae.html" title="Last updated on Jun 4, 2021, 6:55 AM UTC (8303aae)">Diff</a>