### PR TITLE
Fix coverage script for reference implementation

### DIFF
--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -12,8 +12,10 @@
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "license": "(CC0-1.0 OR MIT)",
   "devDependencies": {
+    "@babel/core": "^7.14.3",
+    "babel-plugin-istanbul": "^6.0.0",
+    "babelify": "^10.0.0",
     "browserify": "^16.5.1",
-    "browserify-istanbul": "^3.0.1",
     "debug": "^4.1.1",
     "eslint": "^6.8.0",
     "minimatch": "^3.0.4",

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -13,6 +13,7 @@
   "license": "(CC0-1.0 OR MIT)",
   "devDependencies": {
     "browserify": "^16.5.1",
+    "browserify-istanbul": "^3.0.1",
     "debug": "^4.1.1",
     "eslint": "^6.8.0",
     "minimatch": "^3.0.4",

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const { promisify } = require('util');
 const browserify = require('browserify');
-const istanbul = require('browserify-istanbul');
+const babelify = require('babelify');
 const wptRunner = require('wpt-runner');
 const minimatch = require('minimatch');
 const readFileAsync = promisify(fs.readFile);
@@ -93,7 +93,7 @@ async function main() {
 
 async function bundle(entryPath) {
   const b = browserify([entryPath]);
-  b.transform(istanbul);
+  b.transform(babelify, { plugins: ['istanbul'] });
   const buffer = await promisify(b.bundle.bind(b))();
   return buffer.toString();
 }


### PR DESCRIPTION
As noted in [my comment on web-platform-tests/wpt#29190](https://github.com/web-platform-tests/wpt/pull/29190#issuecomment-855036997), it looks like `npm run coverage` has been broken for a while on the reference implementation. 😬

[Previously](https://github.com/whatwg/streams/blob/99ffba7a632c261566c12da60bb35800a42e3b3f/reference-implementation/run-web-platform-tests.js), we would use `require()` to load the reference implementation, which Istanbul can instrument. [Nowadays](https://github.com/whatwg/streams/blob/9beefc2ac041a1a848088962d56eb03e89a8bf07/reference-implementation/run-web-platform-tests.js) however, we first bundle the reference implementation with Browserify and then `eval()` that inside the test's `window`. As a result, Istanbul is unable to instrument our code and cannot report any coverage.

This PR fixes this by instrumenting the bundle with `babel-plugin-istanbul`. (There's also a `browserify-istanbul` plugin, but it uses an old version of Istanbul which doesn't support all the latest JavaScript syntax. The Babel plugin seems to be the recommended approach.) We also need to make sure that coverage results are kept between tests, so we inject the `__coverage__` variable from Node's global scope into each test's `window`.

To do:
* [ ] Only enable Istanbul transform if we're running the tests with coverage reporting enabled? However I don't know how we could detect that... (`global.__coverage__` is initially still `undefined` even with coverage reporting enabled.)