### PR TITLE
Fix reference implementation's ReadableStream{Default,BYOB}ReadResult.webidl

### DIFF
--- a/reference-implementation/lib/ReadableStreamBYOBReadResult.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBReadResult.webidl
@@ -1,4 +1,4 @@
 dictionary ReadableStreamBYOBReadResult {
-  ArrayBufferView chunk;
+  ArrayBufferView value;
   boolean done;
 };

--- a/reference-implementation/lib/ReadableStreamDefaultReadResult.webidl
+++ b/reference-implementation/lib/ReadableStreamDefaultReadResult.webidl
@@ -1,4 +1,4 @@
 dictionary ReadableStreamDefaultReadResult {
-  any chunk;
+  any value;
   boolean done;
 };


### PR DESCRIPTION
The [spec](https://streams.spec.whatwg.org/#default-reader-class-definition) says this should be `{value: any, done: boolean}`, not `{chunk: any, done: boolean}`.

The code generated by this webidl file is never run, because `ReadableStreamDefaultReadResult`s are only ever used wrapped in `Promise`s, which `webidl2js` currently doesn't unwrap.