### PR TITLE
Reference impl: Use arrow functions for `size` functions

### DIFF
--- a/reference-implementation/lib/ByteLengthQueuingStrategy-impl.js
+++ b/reference-implementation/lib/ByteLengthQueuingStrategy-impl.js
@@ -19,8 +19,7 @@ function initializeSizeFunction(globalObject) {
   }
 
   // We need to set the 'name' property:
-  // eslint-disable-next-line prefer-arrow-callback
-  sizeFunctionWeakMap.set(globalObject, function size(chunk) {
-    return chunk.byteLength;
-  });
+  // The size function must not have a prototype property nor be a constructor
+  const size = chunk => chunk.byteLength;
+  sizeFunctionWeakMap.set(globalObject, size);
 }

--- a/reference-implementation/lib/CountQueuingStrategy-impl.js
+++ b/reference-implementation/lib/CountQueuingStrategy-impl.js
@@ -19,8 +19,7 @@ function initializeSizeFunction(globalObject) {
   }
 
   // We need to set the 'name' property:
-  // eslint-disable-next-line prefer-arrow-callback
-  sizeFunctionWeakMap.set(globalObject, function size() {
-    return 1;
-  });
+  // The size function must not have a prototype property nor be a constructor
+  const size = () => 1;
+  sizeFunctionWeakMap.set(globalObject, size);
 }


### PR DESCRIPTION
The reference implementation uses `function` expressions to create the `size()` functions for `CountQueuingStrategy` and `ByteLengthQueuingStrategy`, which results in them being constructible and having `prototype` properties. This PR changes to using arrow functions to better conform to the spec; see original discussion below:

> Printing
> 
> ```js
> new ByteLengthQueuingStrategy({ highWaterMark: 100 }).size.prototype
> ```
>
> gives undefined in Chrome and Firefox. The Streams spec calls CreateBuiltinFunction without calling MakeConstructor, which is the abstract op that adds the `prototype` property. So it would appear that we should in fact use arrow functions after all
>
> _Originally posted by @TimothyGu in https://github.com/jsdom/jsdom/pull/3200#discussion_r661008480_