### PR TITLE
Allow other specifications to respond with fewer bytes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6575,10 +6575,11 @@ mark=] is greater than zero.
 
 <div algorithm>
  To <dfn export for="ReadableStream">enqueue</dfn> the JavaScript value |chunk| into a
- {{ReadableStream}} |stream|:
+ {{ReadableStream}} |stream| and an optional nonnegative integer |bytesWritten|:
 
  1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=]
     {{ReadableStreamDefaultController}},
+  1. Assert: |bytesWritten| was not given.
   1. Perform ! [$ReadableStreamDefaultControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=],
      |chunk|).
  1. Otherwise,
@@ -6592,11 +6593,16 @@ mark=] is greater than zero.
    1. Assert: |chunk|.\[[ByteLength]] ≤ |byobView|.\[[ByteLength]].
       <p class="note">These asserts ensure that the caller does not write outside the requested
       range in the [=ReadableStream/current BYOB request view=].
+   1. Let |bytesToRespondWith| be |bytesWritten| if it was given, or |chunk|.\[[ByteLength]]
+      otherwise.
    1. Perform ?
       [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
-      |chunk|.\[[ByteLength]]).
-  1. Otherwise, perform ?
-     [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=], |chunk|).
+      |bytesToRespondWith|).
+  1. Otherwise,
+   1. Assert: if |bytesWritten| was given, it's equal to |chunk|.\[[ByteLength]]. (Anything else
+      indicates a logic error in the calling specification.)
+   1. Perform ? [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=],
+      |chunk|).
 </div>
 
 <hr>


### PR DESCRIPTION
See https://github.com/w3c/webtransport/pull/297#discussion_r671494543.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1146.html" title="Last updated on Jul 16, 2021, 8:15 PM UTC (1b1bf6c)">Preview</a> | <a href="https://whatpr.org/streams/1146/109f1d4...1b1bf6c.html" title="Last updated on Jul 16, 2021, 8:15 PM UTC (1b1bf6c)">Diff</a>