### PR TITLE
Remove controller argument in SetUpReadableStreamDefaultControllerFromUnderlyingSource

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2982,7 +2982,7 @@ The following abstract operations support the implementation of the
 <div algorithm>
  <dfn abstract-op lt="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
  id="set-up-readable-stream-default-controller-from-underlying-source">SetUpReadableStreamDefaultControllerFromUnderlyingSource(|stream|,
- |controller|, |underlyingSource|, |underlyingSourceDict|, |highWaterMark|, |sizeAlgorithm|)</dfn>
+ |underlyingSource|, |underlyingSourceDict|, |highWaterMark|, |sizeAlgorithm|)</dfn>
  performs the following steps:
 
  1. Let |controller| be a [=new=] {{ReadableStreamDefaultController}}.
@@ -7806,6 +7806,7 @@ Brian di Palma,
 Calvin Metcalf,
 Dominic Tarr,
 Ed Hager,
+Eric Skoglund,
 Forbes Lindesay,
 Forrest Norvell,
 Gary Blackwood,


### PR DESCRIPTION
This fixes #1151 and removes the unnecessary controller argument
in SetUpReadableStreamDefaultControllerFromUnderlyingSource.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1152.html" title="Last updated on Jul 29, 2021, 8:19 PM UTC (41aae69)">Preview</a> | <a href="https://whatpr.org/streams/1152/109f1d4...41aae69.html" title="Last updated on Jul 29, 2021, 8:19 PM UTC (41aae69)">Diff</a>