### PR TITLE
Remove optional from chunk parameter in QueuingStrategySize

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5861,7 +5861,7 @@ dictionary QueuingStrategy {
   QueuingStrategySize size;
 };
 
-callback QueuingStrategySize = unrestricted double (optional any chunk);
+callback QueuingStrategySize = unrestricted double (any chunk);
 </xmp>
 
 <dl>

--- a/reference-implementation/lib/QueuingStrategy.webidl
+++ b/reference-implementation/lib/QueuingStrategy.webidl
@@ -3,4 +3,4 @@ dictionary QueuingStrategy {
   QueuingStrategySize size;
 };
 
-callback QueuingStrategySize = unrestricted double (optional any chunk);
+callback QueuingStrategySize = unrestricted double (any chunk);


### PR DESCRIPTION
The `QueuingStrategySize` callback type is currently defined as:
```
callback QueuingStrategySize = unrestricted double (optional any chunk);
```

I don't think the `optional` should be there? The stream implementation must always pass a value for `chunk` (although the chunk itself *could* still be `undefined` if the user did `controller.enqueue(undefined)` or `writer.write(undefined)`).

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1164.html" title="Last updated on Sep 4, 2021, 11:11 PM UTC (05898d3)">Preview</a> | <a href="https://whatpr.org/streams/1164/361897c...05898d3.html" title="Last updated on Sep 4, 2021, 11:11 PM UTC (05898d3)">Diff</a>