### PR TITLE
Reject pending reads when releasing reader

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1231,9 +1231,10 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
   when the lock is released, the reader will appear errored in the same way from now on; otherwise,
   the reader will appear closed.
 
-  <p>A reader's lock cannot be released while it still has a pending read request, i.e., if a
-  promise returned by the reader's {{ReadableStreamDefaultReader/read()}} method has not yet been
-  settled. Attempting to do so will throw a {{TypeError}} and leave the reader locked to the stream.
+  <p>If the reader's lock is released while it still has pending read requests, then the
+  promises returned by the reader's {{ReadableStreamDefaultReader/read()}} method are immediately
+  rejected with a {{TypeError}}. Any unread chunks remain in the stream's [=internal queue=] and can
+  be read later by acquiring a new reader.
 </dl>
 
 <div algorithm>
@@ -1390,9 +1391,10 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
   when the lock is released, the reader will appear errored in the same way from now on; otherwise,
   the reader will appear closed.
 
-  <p>A reader's lock cannot be released while it still has a pending read request, i.e., if a
-  promise returned by the reader's {{ReadableStreamBYOBReader/read()}} method has not yet been
-  settled. Attempting to do so will throw a {{TypeError}} and leave the reader locked to the stream.
+  <p>If the reader's lock is released while it still has pending read requests, then the
+  promises returned by the reader's {{ReadableStreamBYOBReader/read()}} method are immediately
+  rejected with a {{TypeError}}. Any unread chunks remain in the stream's [=internal queue=] and can
+  be read later by acquiring a new reader.
 </dl>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -2773,7 +2773,8 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
+ <dfn abstract-op
+ lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
  1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
@@ -2806,7 +2807,8 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
+ <dfn abstract-op
+ lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
  1. Let |readRequests| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
@@ -3250,7 +3252,8 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerEnqueueClonedChunkToQueue">ReadableByteStreamControllerEnqueueClonedChunkToQueue(|controller|,
+ <dfn abstract-op
+ lt="ReadableByteStreamControllerEnqueueClonedChunkToQueue">ReadableByteStreamControllerEnqueueClonedChunkToQueue(|controller|,
  |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
 
  1. Let |cloneResult| be [$CloneArrayBuffer$](|buffer|, |byteOffset|, |byteLength|, {{%ArrayBuffer%}}).
@@ -3262,7 +3265,8 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
+ <dfn abstract-op
+ lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
  1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`none`".
@@ -3449,7 +3453,8 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerProcessReadRequestsUsingQueue">ReadableByteStreamControllerProcessReadRequestsUsingQueue(|controller|)</dfn>
+ <dfn abstract-op
+ lt="ReadableByteStreamControllerProcessReadRequestsUsingQueue">ReadableByteStreamControllerProcessReadRequestsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
  1. Let |reader| be |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[reader]]=].

--- a/index.bs
+++ b/index.bs
@@ -3254,16 +3254,26 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
+ <dfn abstract-op lt="ReadableByteStreamControllerEnqueueClonedChunkToQueue">ReadableByteStreamControllerEnqueueClonedChunkToQueue(|controller|,
+ |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
+
+ 1. Let |cloneResult| be [$CloneArrayBuffer$](|buffer|, |byteOffset|, |byteLength|, {{%ArrayBuffer%}}).
+ 1. If |cloneResult| is an abrupt completion,
+  1. Perform ! [$ReadableByteStreamControllerError$](|cloneResult|.\[[Value]]).
+  1. Return |cloneResult|.
+ 1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
+    |cloneResult|.\[[Value]], 0, |byteLength|).
+</div>
+
+<div algorithm>
  <dfn abstract-op lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
  |firstDescriptor|)</dfn> performs the following steps:
 
  1. Assert: |firstDescriptor|'s [=pull-into descriptor/reader type=] is "`none`".
- 1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] > 0,
-  1. Let |chunk| be ? [$CloneArrayBuffer$](|pullIntoDescriptor|'s [=pull-into
-     descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=],
-     |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=], {{%ArrayBuffer%}}).
-  1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|, |chunk|, 0,
-     |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=]).
+ 1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] > 0, perform ?
+    [$ReadableByteStreamControllerEnqueueClonedChunkToQueue$](|controller|, |pullIntoDescriptor|'s
+    [=pull-into descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into  descriptor/byte offset=],
+    |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=]).
  1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
 </div>
 
@@ -3570,10 +3580,9 @@ The following abstract operations support the implementation of the
  1. If |remainderSize| > 0,
    1. Let |end| be |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=] +
       |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=].
-   1. Let |remainder| be ? [$CloneArrayBuffer$](|pullIntoDescriptor|'s [=pull-into
-      descriptor/buffer=], |end| − |remainderSize|, |remainderSize|, {{%ArrayBuffer%}}).
-   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|, |remainder|, 0,
-      |remainder|.\[[ByteLength]]).
+   1. Perform ? [$ReadableByteStreamControllerEnqueueClonedChunkToQueue$](|controller|,
+      |pullIntoDescriptor|'s [=pull-into descriptor/buffer=], |end| − |remainderSize|,
+      |remainderSize|).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] − |remainderSize|.
  1. Perform !

--- a/index.bs
+++ b/index.bs
@@ -3202,13 +3202,9 @@ The following abstract operations support the implementation of the
      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If ! [$IsDetachedBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
      is true, throw a {{TypeError}} exception.
+  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
      [$TransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=]).
- 1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
- 1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
-    [=list/is empty|empty=],
-  1. Let |firstPendingPullInto| be
-     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If |firstPendingPullInto|'s [=pull-into descriptor/reader type=] is "`none`",
      perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
      |firstPendingPullInto|).

--- a/index.bs
+++ b/index.bs
@@ -1619,6 +1619,14 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
   1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$]([=this=]).
 </div>
 
+<div algorithm>
+ <dfn abstract-op lt="[[ReleaseSteps]]" for="ReadableStreamDefaultController">\[[ReleaseSteps]]()</dfn>
+ implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract. It performs the following
+ steps:
+
+ 1. Return.
+</div>
+
 <h3 id="rbs-controller-class">The {{ReadableByteStreamController}} class</h3>
 
 The {{ReadableByteStreamController}} class has methods that allow control of a {{ReadableStream}}'s
@@ -1758,7 +1766,8 @@ has the following [=struct/items=]:
    used for constructing a view with which to write into the [=pull-into descriptor/buffer=]
 : <dfn for="pull-into descriptor">reader type</dfn>
 :: Either "`default`" or "`byob`", indicating what type of [=readable stream reader=] initiated this
-   request
+   request, or "`none`" if the initiating [=readable stream reader|reader=] was [=release a read
+   lock|released=]
 
 <h4 id="rbs-controller-prototype">Methods and properties</h4>
 
@@ -1884,6 +1893,18 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
      [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=].
  1. Perform ! [$ReadableStreamAddReadRequest$](|stream|, |readRequest|).
  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$]([=this=]).
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="[[ReleaseSteps]]" for="ReadableByteStreamController">\[[ReleaseSteps]]()</dfn>
+ implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract. It performs the following
+ steps:
+
+ 1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
+  1. Let |firstPendingPullInto| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. Set |firstPendingPullInto|'s [=pull-into descriptor/reader type=] to "`none`".
+  1. Set [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] to the [=list=]
+     « |firstPendingPullInto| ».
 </div>
 
 <h3 id="rs-byob-request-class">The {{ReadableStreamBYOBRequest}} class</h3>
@@ -2517,7 +2538,7 @@ centralizing most of the potentially-varying logic inside the two controller cla
 of the stateful internal slots and abstract operations for how a stream's [=internal queue=] is
 managed and how it interfaces with its [=underlying source=] or [=underlying byte source=].
 
-Each controller class defines two internal methods, which are called by the {{ReadableStream}}
+Each controller class defines three internal methods, which are called by the {{ReadableStream}}
 algorithms:
 
 <dl>
@@ -2531,6 +2552,10 @@ algorithms:
   ignore>readRequest</var>)</dfn>
   <dd>The controller's steps that run when a [=default reader=] is read from, used to pull from the
   controller any queued [=chunks=], or pull from the [=underlying source=] to get more chunks.
+
+  <dt><dfn abstract-op lt="[[ReleaseSteps]]" for="ReadableStreamController">\[[ReleaseSteps]]()</dfn>
+  <dd>The controller's steps that run when a [=readable stream reader|reader=] is
+  [=release a read lock|released=], used to clean up reader-specific resources stored in the controller.
 </dl>
 
 (These are defined as internal methods, instead of as abstract operations, so that they can be
@@ -2748,6 +2773,7 @@ The following abstract operations support the implementation and manipulation of
  1. Otherwise, set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise
     rejected with=] a {{TypeError}} exception.
  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
+ 1. Perform ! |stream|.[=ReadableStream/[[controller]]=].[$ReadableStreamController/[[ReleaseSteps]]$]().
  1. Set |stream|.[=ReadableStream/[[reader]]=] to undefined.
  1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=] to undefined.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1272,8 +1272,6 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  for="ReadableStreamDefaultReader">releaseLock()</dfn> method steps are:
 
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
- 1. If [=this=].[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is empty|empty=],
-    throw a {{TypeError}} exception.
  1. Perform ! [$ReadableStreamDefaultReaderRelease$]([=this=]).
 </div>
 
@@ -1438,8 +1436,6 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
  for="ReadableStreamBYOBReader">releaseLock()</dfn> method steps are:
 
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
- 1. If [=this=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is empty|empty=],
-    throw a {{TypeError}} exception.
  1. Perform ! [$ReadableStreamBYOBReaderRelease$]([=this=]).
 </div>
 
@@ -2791,8 +2787,10 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-byob-reader-release">ReadableStreamBYOBReaderRelease(|reader|)</dfn>
  performs the following steps:
 
- 1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+ 1. Let |e| be a new {{TypeError}} exception.
+ 1. Perform ! [$ReadableStreamBYOBReaderErrorReadIntoRequests$](|reader|, |e|).
+</div>
 
 <div algorithm>
  <dfn abstract-op lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
@@ -2827,8 +2825,10 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-default-reader-release">ReadableStreamDefaultReaderRelease(|reader|)</dfn>
  performs the following steps:
 
- 1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+ 1. Let |e| be a new {{TypeError}} exception.
+ 1. Perform ! [$ReadableStreamDefaultReaderErrorReadRequests$](|reader|, |e|).
+</div>
 
 <div algorithm>
  <dfn abstract-op lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
@@ -3152,6 +3152,7 @@ The following abstract operations support the implementation of the
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is not "`errored`".
+ 1. Assert: |pullIntoDescriptor|.[=pull-into descriptor/reader type=] is not "`none`".
  1. Let |done| be false.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`",
   1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] is 0.
@@ -3202,7 +3203,15 @@ The following abstract operations support the implementation of the
   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
      [$TransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=]).
  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
- 1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true
+ 1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
+    [=list/is empty|empty=],
+  1. Let |firstPendingPullInto| be
+     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
+  1. If |firstPendingPullInto|'s [=pull-into descriptor/reader type=] is "`none`",
+   1. Perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
+      |firstPendingPullInto|).
+ 1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true,
+  1. Perform ! [$ReadableByteStreamControllerProcessReadRequestsUsingQueue$](|controller|).
   1. If ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0,
    1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is
       [=list/is empty|empty=].
@@ -3240,6 +3249,20 @@ The following abstract operations support the implementation of the
     |controller|.[=ReadableByteStreamController/[[queue]]=].
  1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to
     |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] + |byteLength|.
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
+ |firstDescriptor|)</dfn> performs the following steps:
+
+ 1. Assert: |firstDescriptor|'s [=pull-into descriptor/reader type=] is "`none`".
+ 1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] > 0,
+  1. Let |chunk| be ? [$CloneArrayBuffer$](|pullIntoDescriptor|'s [=pull-into
+     descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=],
+     |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=], {{%ArrayBuffer%}}).
+  1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|, |chunk|, 0,
+     |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=]).
+ 1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
 </div>
 
 <div algorithm>
@@ -3418,6 +3441,19 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
+ <dfn abstract-op lt="ReadableByteStreamControllerProcessReadRequestsUsingQueue">ReadableByteStreamControllerProcessReadRequestsUsingQueue(|controller|)</dfn>
+ performs the following steps:
+
+ 1. Let |reader| be |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[reader]]=].
+ 1. Assert: |reader| [=implements=] {{ReadableStreamDefaultReader}}.
+ 1. While |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is empty|empty=],
+  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, return.
+  1. Let |readRequest| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=][0].
+  1. [=list/Remove=] |readRequest| from |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
+  1. Perform ! [$ReadableByteStreamControllerFillReadRequestFromQueue$](|controller|, |readRequest|).
+</div>
+
+<div algorithm>
  <dfn abstract-op lt="ReadableByteStreamControllerPullInto"
  id="readable-byte-stream-controller-pull-into">ReadableByteStreamControllerPullInto(|controller|,
  |view|, |readIntoRequest|)</dfn> performs the following steps:
@@ -3499,6 +3535,8 @@ The following abstract operations support the implementation of the
  |firstDescriptor|)</dfn> performs the following steps:
 
  1. Assert: |firstDescriptor|'s [=pull-into descriptor/bytes filled=] is 0.
+ 1. If |firstDescriptor|'s [=pull-into descriptor/reader type=] is "`none`",
+  1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
   1. [=While=] ! [$ReadableStreamGetNumReadIntoRequests$](|stream|) > 0,
@@ -3517,6 +3555,11 @@ The following abstract operations support the implementation of the
     |pullIntoDescriptor|'s [=pull-into descriptor/byte length=].
  1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
     |bytesWritten|, |pullIntoDescriptor|).
+ 1. If |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`none`",
+  1. Perform ! [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
+     |pullIntoDescriptor|).
+  1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+  1. Return.
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] &lt; |pullIntoDescriptor|'s
     [=pull-into descriptor/element size=], return.
  1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).

--- a/index.bs
+++ b/index.bs
@@ -1865,16 +1865,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
  1. If [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
   1. Assert: ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0.
-  1. Let |entry| be [=this=].[=ReadableByteStreamController/[[queue]]=][0].
-  1. [=list/Remove=] |entry| from [=this=].[=ReadableByteStreamController/[[queue]]=].
-  1. Set [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] to
-     [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] − |entry|'s [=readable byte stream
-     queue entry/byte length=].
-  1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$]([=this=]).
-  1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |entry|'s [=readable byte stream queue
-     entry/buffer=], |entry|'s [=readable byte stream queue entry/byte offset=], |entry|'s
-     [=readable byte stream queue entry/byte length=] »).
-  1. Perform |readRequest|'s [=read request/chunk steps=], given |view|.
+  1. Perform ! [$ReadableByteStreamControllerFillReadRequestFromQueue$]([=this=], |readRequest|).
   1. Return.
  1. Let |autoAllocateChunkSize| be
     [=this=].[=ReadableByteStreamController/[[autoAllocateChunkSize]]=].
@@ -3290,6 +3281,24 @@ The following abstract operations support the implementation of the
   1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] &lt;
      |pullIntoDescriptor|'s [=pull-into descriptor/element size=].
  1. Return |ready|.
+</div>
+
+<div algorithm>
+ <dfn abstract-op
+ lt="ReadableByteStreamControllerFillReadRequestFromQueue">ReadableByteStreamControllerFillReadRequestFromQueue(|controller|,
+ |readRequest|)</dfn> performs the following steps:
+
+ 1. Assert: |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] > 0.
+ 1. Let |entry| be |controller|.[=ReadableByteStreamController/[[queue]]=][0].
+ 1. [=list/Remove=] |entry| from |controller|.[=ReadableByteStreamController/[[queue]]=].
+ 1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to
+    |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] − |entry|'s [=readable byte stream
+    queue entry/byte length=].
+ 1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$](|controller|).
+ 1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |entry|'s [=readable byte stream queue
+    entry/buffer=], |entry|'s [=readable byte stream queue entry/byte offset=], |entry|'s
+    [=readable byte stream queue entry/byte length=] »).
+ 1. Perform |readRequest|'s [=read request/chunk steps=], given |view|.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -2586,9 +2586,10 @@ the {{ReadableStream}}'s public API.
  1. Perform ! [$ReadableStreamClose$](|stream|).
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. If |reader| is not undefined and |reader| [=implements=] {{ReadableStreamBYOBReader}},
-  1. [=list/For each=] |readIntoRequest| of |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=],
-   1. Perform |readIntoRequest|'s [=read-into request/close steps=], given undefined.
+  1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
   1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to an empty [=list=].
+  1. [=list/For each=] |readIntoRequest| of |readIntoRequests|,
+   1. Perform |readIntoRequest|'s [=read-into request/close steps=], given undefined.
  1. Let |sourceCancelPromise| be !
     |stream|.[=ReadableStream/[[controller]]=].[$ReadableStreamController/[[CancelSteps]]$](|reason|).
  1. Return the result of [=reacting=] to |sourceCancelPromise| with a fulfillment step that returns
@@ -2605,9 +2606,10 @@ the {{ReadableStream}}'s public API.
  1. If |reader| is undefined, return.
  1. [=Resolve=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with undefined.
  1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
-  1. [=list/For each=] |readRequest| of |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=],
-   1. Perform |readRequest|'s [=read request/close steps=].
+  1. Let |readRequests| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
   1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to an empty [=list=].
+  1. [=list/For each=] |readRequest| of |readRequests|,
+   1. Perform |readRequest|'s [=read request/close steps=].
 </div>
 
 <div algorithm>
@@ -2622,15 +2624,16 @@ the {{ReadableStream}}'s public API.
  1. [=Reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with |e|.
  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
  1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
-  1. [=list/For each=] |readRequest| of |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=],
-    1. Perform |readRequest|'s [=read request/error steps=], given |e|.
+  1. Let |readRequests| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
   1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to a new empty [=list=].
+  1. [=list/For each=] |readRequest| of |readRequests|,
+    1. Perform |readRequest|'s [=read request/error steps=], given |e|.
  1. Otherwise,
    1. Assert: |reader| [=implements=] {{ReadableStreamBYOBReader}}.
-   1. [=list/For each=] |readIntoRequest| of
-      |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=],
-    1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
+   1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
    1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
+   1. [=list/For each=] |readIntoRequest| of |readIntoRequests|,
+    1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -2366,6 +2366,7 @@ create them does not matter.
    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
  1. Let |pullWithDefaultReader| be the following steps:
   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}},
+   1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
    1. Perform ! [$ReadableStreamBYOBReaderRelease$](|reader|).
    1. Set |reader| to ! [$AcquireReadableStreamDefaultReader$](|stream|).
    1. Perform |forwardReaderError|, given |reader|.
@@ -2420,6 +2421,7 @@ create them does not matter.
   1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
  1. Let |pullWithBYOBReader| be the following steps, given |view| and |forBranch2|:
   1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
+   1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
    1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. Set |reader| to ! [$AcquireReadableStreamBYOBReader$](|stream|).
    1. Perform |forwardReaderError|, given |reader|.

--- a/index.bs
+++ b/index.bs
@@ -1011,11 +1011,11 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
    1. [=Resolve=] |promise| with |chunk|.
   : [=read request/close steps=]
   ::
-   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. [=Resolve=] |promise| with [=end of iteration=].
   : [=read request/error steps=], given |e|
   ::
-   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. [=Reject=] |promise| with |e|.
  1. Perform ! [$ReadableStreamDefaultReaderRead$]([=this=], |readRequest|).
  1. Return |promise|.
@@ -1033,9 +1033,9 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
     before this is called.
  1. If |iterator|'s [=ReadableStream async iterator/prevent cancel=] is false:
   1. Let |result| be ! [$ReadableStreamReaderGenericCancel$](|reader|, |arg|).
-  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+  1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
   1. Return |result|.
- 1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+ 1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
  1. Return [=a promise resolved with=] undefined.
 </div>
 
@@ -1274,7 +1274,7 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
  1. If [=this=].[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is empty|empty=],
     throw a {{TypeError}} exception.
- 1. Perform ! [$ReadableStreamReaderGenericRelease$]([=this=]).
+ 1. Perform ! [$ReadableStreamDefaultReaderRelease$]([=this=]).
 </div>
 
 <h3 id="byob-reader-class">The {{ReadableStreamBYOBReader}} class</h3>
@@ -1440,7 +1440,7 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
  1. If [=this=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is empty|empty=],
     throw a {{TypeError}} exception.
- 1. Perform ! [$ReadableStreamReaderGenericRelease$]([=this=]).
+ 1. Perform ! [$ReadableStreamBYOBReaderRelease$]([=this=]).
 </div>
 
 <h3 id="rs-default-controller-class">The {{ReadableStreamDefaultController}} class</h3>
@@ -2197,7 +2197,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
   * <dfn id="rs-pipeTo-finalize"><i>Finalize</i></dfn>: both forms of shutdown will eventually ask
     to finalize, optionally with an error |error|, which means to perform the following steps:
    1. Perform ! [$WritableStreamDefaultWriterRelease$](|writer|).
-   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. If |signal| is not undefined, [=AbortSignal/remove=] |abortAlgorithm| from |signal|.
    1. If |error| was given, [=reject=] |promise| with |error|.
    1. Otherwise, [=resolve=] |promise| with undefined.
@@ -2358,8 +2358,7 @@ create them does not matter.
    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
  1. Let |pullWithDefaultReader| be the following steps:
   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}},
-   1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
-   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+   1. Perform ! [$ReadableStreamBYOBReaderRelease$](|reader|).
    1. Set |reader| to ! [$AcquireReadableStreamDefaultReader$](|stream|).
    1. Perform |forwardReaderError|, given |reader|.
   1. Let |readRequest| be a [=read request=] with the following [=struct/items=]:
@@ -2413,8 +2412,7 @@ create them does not matter.
   1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
  1. Let |pullWithBYOBReader| be the following steps, given |view| and |forBranch2|:
   1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
-   1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
-   1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. Set |reader| to ! [$AcquireReadableStreamBYOBReader$](|stream|).
    1. Perform |forwardReaderError|, given |reader|.
   1. Let |byobBranch| be |branch2| if |forBranch2| is true, and |branch1| otherwise.
@@ -2777,6 +2775,15 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
+ <dfn abstract-op lt="ReadableStreamBYOBReaderRelease"
+ id="readable-stream-byob-reader-release">ReadableStreamBYOBReaderRelease(|reader|)</dfn>
+ performs the following steps:
+
+ 1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
+ 1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+</div>
+
+<div algorithm>
  <dfn abstract-op lt="ReadableStreamDefaultReaderRead"
  id="readable-stream-default-reader-read">ReadableStreamDefaultReaderRead(|reader|,
  |readRequest|)</dfn> performs the following steps:
@@ -2792,6 +2799,15 @@ The following abstract operations support the implementation and manipulation of
   1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
   1. Perform !
      |stream|.[=ReadableStream/[[controller]]=].[$ReadableStreamController/[[PullSteps]]$](|readRequest|).
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="ReadableStreamDefaultReaderRelease"
+ id="readable-stream-default-reader-release">ReadableStreamDefaultReaderRelease(|reader|)</dfn>
+ performs the following steps:
+
+ 1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
+ 1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
 </div>
 
 <div algorithm>
@@ -6710,7 +6726,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
 <p algorithm>To <dfn export for="ReadableStreamDefaultReader">release</dfn> a
 {{ReadableStreamDefaultReader}} |reader|, perform !
-[$ReadableStreamReaderGenericRelease$](|reader|).
+[$ReadableStreamDefaultReaderRelease$](|reader|).
 
 <p algorithm>To <dfn export for="ReadableStreamDefaultReader">cancel</dfn> a
 {{ReadableStreamDefaultReader}} |reader| with |reason|, perform !

--- a/index.bs
+++ b/index.bs
@@ -2640,16 +2640,10 @@ the {{ReadableStream}}'s public API.
  1. [=Reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with |e|.
  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
  1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
-  1. Let |readRequests| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
-  1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to a new empty [=list=].
-  1. [=list/For each=] |readRequest| of |readRequests|,
-    1. Perform |readRequest|'s [=read request/error steps=], given |e|.
+  1. Perform ! [$ReadableStreamDefaultReaderErrorReadRequests$](|reader|, |e|).
  1. Otherwise,
-   1. Assert: |reader| [=implements=] {{ReadableStreamBYOBReader}}.
-   1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
-   1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
-   1. [=list/For each=] |readIntoRequest| of |readIntoRequests|,
-    1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
+  1. Assert: |reader| [=implements=] {{ReadableStreamBYOBReader}}.
+  1. Perform ! [$ReadableStreamBYOBReaderErrorReadIntoRequests$](|reader|, |e|).
 </div>
 
 <div algorithm>
@@ -2799,6 +2793,15 @@ The following abstract operations support the implementation and manipulation of
 
  1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+
+<div algorithm>
+ <dfn abstract-op lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
+ performs the following steps:
+
+ 1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
+ 1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
+ 1. [=list/For each=] |readIntoRequest| of |readIntoRequests|,
+  1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
 </div>
 
 <div algorithm>
@@ -2826,6 +2829,15 @@ The following abstract operations support the implementation and manipulation of
 
  1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+
+<div algorithm>
+ <dfn abstract-op lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
+ performs the following steps:
+
+ 1. Let |readRequests| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
+ 1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to a new empty [=list=].
+ 1. [=list/For each=] |readRequest| of |readRequests|,
+   1. Perform |readRequest|'s [=read request/error steps=], given |e|.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -3558,7 +3558,7 @@ The following abstract operations support the implementation of the
  1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
     |bytesWritten|, |pullIntoDescriptor|).
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`none`",
-  1. Perform ! [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
+  1. Perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
      |pullIntoDescriptor|).
   1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
   1. Return.

--- a/index.bs
+++ b/index.bs
@@ -2740,17 +2740,15 @@ The following abstract operations support the implementation and manipulation of
  id="readable-stream-reader-generic-release">ReadableStreamReaderGenericRelease(|reader|)</dfn>
  performs the following steps:
 
- 1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=] is not undefined.
- 1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[reader]]=] is
-    |reader|.
- 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[state]]=] is
-    "`readable`", [=reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with a
-    {{TypeError}} exception.
+ 1. Let |stream| be |reader|.[=ReadableStreamGenericReader/[[stream]]=].
+ 1. Assert: |stream| is not undefined.
+ 1. Assert: |stream|.[=ReadableStream/[[reader]]=] is |reader|.
+ 1. If |stream|.[=ReadableStream/[[state]]=] is "`readable`", [=reject=]
+    |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with a {{TypeError}} exception.
  1. Otherwise, set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] to [=a promise
     rejected with=] a {{TypeError}} exception.
  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
- 1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=].[=ReadableStream/[[reader]]=] to
-    undefined.
+ 1. Set |stream|.[=ReadableStream/[[reader]]=] to undefined.
  1. Set |reader|.[=ReadableStreamGenericReader/[[stream]]=] to undefined.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2773,6 +2773,16 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
+ <dfn abstract-op lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
+ performs the following steps:
+
+ 1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
+ 1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
+ 1. [=list/For each=] |readIntoRequest| of |readIntoRequests|,
+  1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
+</div>
+
+<div algorithm>
  <dfn abstract-op lt="ReadableStreamBYOBReaderRead"
  id="readable-stream-byob-reader-read">ReadableStreamBYOBReaderRead(|reader|, |view|,
  |readIntoRequest|)</dfn> performs the following steps:
@@ -2796,13 +2806,13 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
+ <dfn abstract-op lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
- 1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
- 1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
- 1. [=list/For each=] |readIntoRequest| of |readIntoRequests|,
-  1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
+ 1. Let |readRequests| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
+ 1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to a new empty [=list=].
+ 1. [=list/For each=] |readRequest| of |readRequests|,
+   1. Perform |readRequest|'s [=read request/error steps=], given |e|.
 </div>
 
 <div algorithm>
@@ -2830,16 +2840,6 @@ The following abstract operations support the implementation and manipulation of
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
  1. Let |e| be a new {{TypeError}} exception.
  1. Perform ! [$ReadableStreamDefaultReaderErrorReadRequests$](|reader|, |e|).
-</div>
-
-<div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
- performs the following steps:
-
- 1. Let |readRequests| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
- 1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to a new empty [=list=].
- 1. [=list/For each=] |readRequest| of |readRequests|,
-   1. Perform |readRequest|'s [=read request/error steps=], given |e|.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -3210,8 +3210,8 @@ The following abstract operations support the implementation of the
   1. Let |firstPendingPullInto| be
      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If |firstPendingPullInto|'s [=pull-into descriptor/reader type=] is "`none`",
-   1. Perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
-      |firstPendingPullInto|).
+     perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
+     |firstPendingPullInto|).
  1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true,
   1. Perform ! [$ReadableByteStreamControllerProcessReadRequestsUsingQueue$](|controller|).
   1. If ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0,
@@ -3538,7 +3538,7 @@ The following abstract operations support the implementation of the
 
  1. Assert: |firstDescriptor|'s [=pull-into descriptor/bytes filled=] is 0.
  1. If |firstDescriptor|'s [=pull-into descriptor/reader type=] is "`none`",
-  1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
+    perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
   1. [=While=] ! [$ReadableStreamGetNumReadIntoRequests$](|stream|) > 0,

--- a/index.bs
+++ b/index.bs
@@ -2787,8 +2787,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamBYOBReaderRelease"
- id="readable-stream-byob-reader-release">ReadableStreamBYOBReaderRelease(|reader|)</dfn>
+ <dfn abstract-op lt="ReadableStreamBYOBReaderRelease">ReadableStreamBYOBReaderRelease(|reader|)</dfn>
  performs the following steps:
 
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
@@ -2825,8 +2824,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultReaderRelease"
- id="readable-stream-default-reader-release">ReadableStreamDefaultReaderRelease(|reader|)</dfn>
+ <dfn abstract-op lt="ReadableStreamDefaultReaderRelease">ReadableStreamDefaultReaderRelease(|reader|)</dfn>
  performs the following steps:
 
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).

--- a/index.bs
+++ b/index.bs
@@ -3267,10 +3267,10 @@ The following abstract operations support the implementation of the
 
 <div algorithm>
  <dfn abstract-op lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
- |firstDescriptor|)</dfn> performs the following steps:
+ |pullIntoDescriptor|)</dfn> performs the following steps:
 
- 1. Assert: |firstDescriptor|'s [=pull-into descriptor/reader type=] is "`none`".
- 1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] > 0, perform ?
+ 1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`none`".
+ 1. If |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] > 0, perform ?
     [$ReadableByteStreamControllerEnqueueClonedChunkToQueue$](|controller|, |pullIntoDescriptor|'s
     [=pull-into descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into  descriptor/byte offset=],
     |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=]).

--- a/reference-implementation/lib/ReadableByteStreamController-impl.js
+++ b/reference-implementation/lib/ReadableByteStreamController-impl.js
@@ -104,7 +104,7 @@ exports.implementation = class ReadableByteStreamControllerImpl {
       const firstPullInto = this._pendingPullIntos[0];
       firstPullInto.readerType = 'none';
 
-      this._pendingPullIntos.splice(1);
+      this._pendingPullIntos = [firstPullInto];
     }
   }
 };

--- a/reference-implementation/lib/ReadableStream-impl.js
+++ b/reference-implementation/lib/ReadableStream-impl.js
@@ -129,11 +129,11 @@ exports.implementation = class ReadableStreamImpl {
     const readRequest = {
       chunkSteps: chunk => resolvePromise(promise, chunk),
       closeSteps: () => {
-        aos.ReadableStreamReaderGenericRelease(reader);
+        aos.ReadableStreamDefaultReaderRelease(reader);
         resolvePromise(promise, idlUtils.asyncIteratorEOI);
       },
       errorSteps: e => {
-        aos.ReadableStreamReaderGenericRelease(reader);
+        aos.ReadableStreamDefaultReaderRelease(reader);
         rejectPromise(promise, e);
       }
     };
@@ -151,11 +151,11 @@ exports.implementation = class ReadableStreamImpl {
 
     if (iterator._preventCancel === false) {
       const result = aos.ReadableStreamReaderGenericCancel(reader, arg);
-      aos.ReadableStreamReaderGenericRelease(reader);
+      aos.ReadableStreamDefaultReaderRelease(reader);
       return result;
     }
 
-    aos.ReadableStreamReaderGenericRelease(reader);
+    aos.ReadableStreamDefaultReaderRelease(reader);
     return promiseResolvedWith(undefined);
   }
 };

--- a/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
@@ -45,7 +45,7 @@ class ReadableStreamBYOBReaderImpl {
       throw new TypeError('Tried to release a reader lock when that reader has pending read() calls un-settled');
     }
 
-    aos.ReadableStreamReaderGenericRelease(this);
+    aos.ReadableStreamBYOBReaderRelease(this);
   }
 }
 

--- a/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamBYOBReader-impl.js
@@ -41,10 +41,6 @@ class ReadableStreamBYOBReaderImpl {
       return;
     }
 
-    if (this._readIntoRequests.length > 0) {
-      throw new TypeError('Tried to release a reader lock when that reader has pending read() calls un-settled');
-    }
-
     aos.ReadableStreamBYOBReaderRelease(this);
   }
 }

--- a/reference-implementation/lib/ReadableStreamDefaultController-impl.js
+++ b/reference-implementation/lib/ReadableStreamDefaultController-impl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { CancelSteps, PullSteps } = require('./abstract-ops/internal-methods.js');
+const { CancelSteps, PullSteps, ReleaseSteps } = require('./abstract-ops/internal-methods.js');
 const { DequeueValue, ResetQueue } = require('./abstract-ops/queue-with-sizes.js');
 const aos = require('./abstract-ops/readable-streams.js');
 
@@ -55,4 +55,6 @@ exports.implementation = class ReadableStreamDefaultControllerImpl {
       aos.ReadableStreamDefaultControllerCallPullIfNeeded(this);
     }
   }
+
+  [ReleaseSteps]() {}
 };

--- a/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
@@ -35,7 +35,7 @@ class ReadableStreamDefaultReaderImpl {
       throw new TypeError('Tried to release a reader lock when that reader has pending read() calls un-settled');
     }
 
-    aos.ReadableStreamReaderGenericRelease(this);
+    aos.ReadableStreamDefaultReaderRelease(this);
   }
 }
 

--- a/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
+++ b/reference-implementation/lib/ReadableStreamDefaultReader-impl.js
@@ -31,10 +31,6 @@ class ReadableStreamDefaultReaderImpl {
       return;
     }
 
-    if (this._readRequests.length > 0) {
-      throw new TypeError('Tried to release a reader lock when that reader has pending read() calls un-settled');
-    }
-
     aos.ReadableStreamDefaultReaderRelease(this);
   }
 }

--- a/reference-implementation/lib/abstract-ops/internal-methods.js
+++ b/reference-implementation/lib/abstract-ops/internal-methods.js
@@ -4,3 +4,4 @@ exports.AbortSteps = Symbol('[[AbortSteps]]');
 exports.ErrorSteps = Symbol('[[ErrorSteps]]');
 exports.CancelSteps = Symbol('[[CancelSteps]]');
 exports.PullSteps = Symbol('[[PullSteps]]');
+exports.ReleaseSteps = Symbol('[[ReleaseSteps]]');

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1343,7 +1343,7 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
   if (controller._pendingPullIntos.length > 0) {
     const firstPendingPullInto = controller._pendingPullIntos[0];
     if (firstPendingPullInto.readerType === 'none') {
-      ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller);
+      ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, firstPendingPullInto);
     }
   }
 
@@ -1674,7 +1674,7 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
   ReadableByteStreamControllerFillHeadPullIntoDescriptor(controller, bytesWritten, pullIntoDescriptor);
 
   if (pullIntoDescriptor.readerType === 'none') {
-    ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller);
+    ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, pullIntoDescriptor);
     ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
     return;
   }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1381,10 +1381,11 @@ function ReadableByteStreamControllerEnqueueChunkToQueue(controller, buffer, byt
 function ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, firstDescriptor) {
   assert(firstDescriptor.readerType === 'none');
   if (firstDescriptor.bytesFilled > 0) {
-    const byteOffset = firstDescriptor.byteOffset;
-    const bytesFilled = firstDescriptor.bytesFilled;
-    const chunk = firstDescriptor.buffer.slice(byteOffset, byteOffset + bytesFilled);
-    ReadableByteStreamControllerEnqueueChunkToQueue(controller, chunk, 0, bytesFilled);
+    const chunk = firstDescriptor.buffer.slice(
+      firstDescriptor.byteOffset,
+      firstDescriptor.byteOffset + firstDescriptor.bytesFilled
+    );
+    ReadableByteStreamControllerEnqueueChunkToQueue(controller, chunk, 0, firstDescriptor.bytesFilled);
   }
   ReadableByteStreamControllerShiftPendingPullInto(controller);
 }
@@ -1543,8 +1544,8 @@ function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(contro
 }
 
 function ReadableByteStreamControllerProcessReadRequestsUsingQueue(controller) {
-  assert(ReadableStreamHasDefaultReader(controller._stream));
   const reader = controller._stream._reader;
+  assert(ReadableStreamDefaultReader.isImpl(reader));
   while (reader._readRequests.length > 0) {
     if (controller._queueTotalSize === 0) {
       return;

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -58,7 +58,6 @@ Object.assign(exports, {
   ReadableStreamHasDefaultReader,
   ReadableStreamPipeTo,
   ReadableStreamReaderGenericCancel,
-  ReadableStreamReaderGenericRelease,
   ReadableStreamTee,
   SetUpReadableByteStreamControllerFromUnderlyingSource,
   SetUpReadableStreamBYOBReader,

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -890,10 +890,11 @@ function ReadableStreamReaderGenericInitialize(reader, stream) {
 }
 
 function ReadableStreamReaderGenericRelease(reader) {
-  assert(reader._stream !== undefined);
-  assert(reader._stream._reader === reader);
+  const stream = reader._stream;
+  assert(stream !== undefined);
+  assert(stream._reader === reader);
 
-  if (reader._stream._state === 'readable') {
+  if (stream._state === 'readable') {
     rejectPromise(
       reader._closedPromise,
       new TypeError('Reader was released and can no longer be used to monitor the stream\'s closedness')
@@ -905,9 +906,9 @@ function ReadableStreamReaderGenericRelease(reader) {
   }
   setPromiseIsHandledToTrue(reader._closedPromise);
 
-  reader._stream._controller[ReleaseSteps]();
+  stream._controller[ReleaseSteps]();
 
-  reader._stream._reader = undefined;
+  stream._reader = undefined;
   reader._stream = undefined;
 }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1335,13 +1335,8 @@ function ReadableByteStreamControllerEnqueue(controller, chunk) {
         'The BYOB request\'s buffer has been detached and so cannot be filled with an enqueued chunk'
       );
     }
+    ReadableByteStreamControllerInvalidateBYOBRequest(controller);
     firstPendingPullInto.buffer = TransferArrayBuffer(firstPendingPullInto.buffer);
-  }
-
-  ReadableByteStreamControllerInvalidateBYOBRequest(controller);
-
-  if (controller._pendingPullIntos.length > 0) {
-    const firstPendingPullInto = controller._pendingPullIntos[0];
     if (firstPendingPullInto.readerType === 'none') {
       ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, firstPendingPullInto);
     }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -796,19 +796,10 @@ function ReadableStreamError(stream, e) {
   setPromiseIsHandledToTrue(reader._closedPromise);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
-    const readRequests = reader._readRequests;
-    reader._readRequests = [];
-    for (const readRequest of readRequests) {
-      readRequest.errorSteps(e);
-    }
+    ReadableStreamDefaultReaderErrorReadRequests(reader, e);
   } else {
     assert(ReadableStreamBYOBReader.isImpl(reader));
-
-    const readIntoRequests = reader._readIntoRequests;
-    reader._readIntoRequests = [];
-    for (const readIntoRequest of readIntoRequests) {
-      readIntoRequest.errorSteps(e);
-    }
+    ReadableStreamBYOBReaderErrorReadIntoRequests(reader, e);
   }
 }
 
@@ -937,6 +928,10 @@ function ReadableStreamBYOBReaderRead(reader, view, readIntoRequest) {
 function ReadableStreamBYOBReaderRelease(reader) {
   ReadableStreamReaderGenericRelease(reader);
   const e = new TypeError('Reader was released');
+  ReadableStreamBYOBReaderErrorReadIntoRequests(reader, e);
+}
+
+function ReadableStreamBYOBReaderErrorReadIntoRequests(reader, e) {
   const readIntoRequests = reader._readIntoRequests;
   reader._readIntoRequests = [];
   for (const readRequest of readIntoRequests) {
@@ -964,6 +959,10 @@ function ReadableStreamDefaultReaderRead(reader, readRequest) {
 function ReadableStreamDefaultReaderRelease(reader) {
   ReadableStreamReaderGenericRelease(reader);
   const e = new TypeError('Reader was released');
+  ReadableStreamDefaultReaderErrorReadRequests(reader, e);
+}
+
+function ReadableStreamDefaultReaderErrorReadRequests(reader, e) {
   const readRequests = reader._readRequests;
   reader._readRequests = [];
   for (const readRequest of readRequests) {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -745,10 +745,11 @@ function ReadableStreamCancel(stream, reason) {
 
   const reader = stream._reader;
   if (reader !== undefined && ReadableStreamBYOBReader.isImpl(reader)) {
-    for (const readIntoRequest of reader._readIntoRequests) {
+    const readIntoRequests = reader._readIntoRequests;
+    reader._readIntoRequests = [];
+    for (const readIntoRequest of readIntoRequests) {
       readIntoRequest.closeSteps(undefined);
     }
-    reader._readIntoRequests = [];
   }
 
   const sourceCancelPromise = stream._controller[CancelSteps](reason);
@@ -769,10 +770,11 @@ function ReadableStreamClose(stream) {
   resolvePromise(reader._closedPromise, undefined);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
-    for (const readRequest of reader._readRequests) {
+    const readRequests = reader._readRequests;
+    reader._readRequests = [];
+    for (const readRequest of readRequests) {
       readRequest.closeSteps();
     }
-    reader._readRequests = [];
   }
 }
 
@@ -792,19 +794,19 @@ function ReadableStreamError(stream, e) {
   setPromiseIsHandledToTrue(reader._closedPromise);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
-    for (const readRequest of reader._readRequests) {
+    const readRequests = reader._readRequests;
+    reader._readRequests = [];
+    for (const readRequest of readRequests) {
       readRequest.errorSteps(e);
     }
-
-    reader._readRequests = [];
   } else {
     assert(ReadableStreamBYOBReader.isImpl(reader));
 
-    for (const readIntoRequest of reader._readIntoRequests) {
+    const readIntoRequests = reader._readIntoRequests;
+    reader._readIntoRequests = [];
+    for (const readIntoRequest of readIntoRequests) {
       readIntoRequest.errorSteps(e);
     }
-
-    reader._readIntoRequests = [];
   }
 }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -935,10 +935,10 @@ function ReadableStreamBYOBReaderRead(reader, view, readIntoRequest) {
 }
 
 function ReadableStreamBYOBReaderRelease(reader) {
+  ReadableStreamReaderGenericRelease(reader);
   const e = new TypeError('Reader was released');
   const readIntoRequests = reader._readIntoRequests;
   reader._readIntoRequests = [];
-  ReadableStreamReaderGenericRelease(reader);
   for (const readRequest of readIntoRequests) {
     readRequest.errorSteps(e);
   }
@@ -962,10 +962,10 @@ function ReadableStreamDefaultReaderRead(reader, readRequest) {
 }
 
 function ReadableStreamDefaultReaderRelease(reader) {
+  ReadableStreamReaderGenericRelease(reader);
   const e = new TypeError('Reader was released');
   const readRequests = reader._readRequests;
   reader._readRequests = [];
-  ReadableStreamReaderGenericRelease(reader);
   for (const readRequest of readRequests) {
     readRequest.errorSteps(e);
   }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1381,12 +1381,10 @@ function ReadableByteStreamControllerEnqueueChunkToQueue(controller, buffer, byt
 function ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, firstDescriptor) {
   assert(firstDescriptor.readerType === 'none');
   if (firstDescriptor.bytesFilled > 0) {
-    ReadableByteStreamControllerEnqueueChunkToQueue(
-      controller,
-      firstDescriptor.buffer,
-      firstDescriptor.byteOffset,
-      firstDescriptor.bytesFilled
-    );
+    const byteOffset = firstDescriptor.byteOffset;
+    const bytesFilled = firstDescriptor.bytesFilled;
+    const chunk = firstDescriptor.buffer.slice(byteOffset, byteOffset + bytesFilled);
+    ReadableByteStreamControllerEnqueueChunkToQueue(controller, chunk, 0, bytesFilled);
   }
   ReadableByteStreamControllerShiftPendingPullInto(controller);
 }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -931,7 +931,12 @@ function ReadableStreamBYOBReaderRead(reader, view, readIntoRequest) {
 }
 
 function ReadableStreamBYOBReaderRelease(reader) {
-  assert(reader._readIntoRequests.length === 0);
+  const e = new TypeError('Reader was released');
+  const readIntoRequests = reader._readIntoRequests;
+  reader._readIntoRequests = [];
+  for (const readRequest of readIntoRequests) {
+    readRequest.errorSteps(e);
+  }
   ReadableStreamReaderGenericRelease(reader);
 }
 
@@ -953,7 +958,12 @@ function ReadableStreamDefaultReaderRead(reader, readRequest) {
 }
 
 function ReadableStreamDefaultReaderRelease(reader) {
-  assert(reader._readRequests.length === 0);
+  const e = new TypeError('Reader was released');
+  const readRequests = reader._readRequests;
+  reader._readRequests = [];
+  for (const readRequest of readRequests) {
+    readRequest.errorSteps(e);
+  }
   ReadableStreamReaderGenericRelease(reader);
 }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -495,6 +495,7 @@ function ReadableByteStreamTee(stream) {
 
   function pullWithDefaultReader() {
     if (ReadableStreamBYOBReader.isImpl(reader)) {
+      assert(reader._readIntoRequests.length === 0);
       ReadableStreamBYOBReaderRelease(reader);
 
       reader = AcquireReadableStreamDefaultReader(stream);
@@ -565,6 +566,7 @@ function ReadableByteStreamTee(stream) {
 
   function pullWithBYOBReader(view, forBranch2) {
     if (ReadableStreamDefaultReader.isImpl(reader)) {
+      assert(reader._readRequests.length === 0);
       ReadableStreamDefaultReaderRelease(reader);
 
       reader = AcquireReadableStreamBYOBReader(stream);

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -938,10 +938,10 @@ function ReadableStreamBYOBReaderRelease(reader) {
   const e = new TypeError('Reader was released');
   const readIntoRequests = reader._readIntoRequests;
   reader._readIntoRequests = [];
+  ReadableStreamReaderGenericRelease(reader);
   for (const readRequest of readIntoRequests) {
     readRequest.errorSteps(e);
   }
-  ReadableStreamReaderGenericRelease(reader);
 }
 
 function ReadableStreamDefaultReaderRead(reader, readRequest) {
@@ -965,10 +965,10 @@ function ReadableStreamDefaultReaderRelease(reader) {
   const e = new TypeError('Reader was released');
   const readRequests = reader._readRequests;
   reader._readRequests = [];
+  ReadableStreamReaderGenericRelease(reader);
   for (const readRequest of readRequests) {
     readRequest.errorSteps(e);
   }
-  ReadableStreamReaderGenericRelease(reader);
 }
 
 function SetUpReadableStreamBYOBReader(reader, stream) {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -934,8 +934,8 @@ function ReadableStreamBYOBReaderRelease(reader) {
 function ReadableStreamBYOBReaderErrorReadIntoRequests(reader, e) {
   const readIntoRequests = reader._readIntoRequests;
   reader._readIntoRequests = [];
-  for (const readRequest of readIntoRequests) {
-    readRequest.errorSteps(e);
+  for (const readIntoRequest of readIntoRequests) {
+    readIntoRequest.errorSteps(e);
   }
 }
 


### PR DESCRIPTION
Currently, `ReadableStream(Default|BYOB)Reader.releaseLock()` throws an error if there are still pending read requests ([spec](https://streams.spec.whatwg.org/commit-snapshots/8bbfbf83ad06a8b9224bbe1cfbcbbbdbdd827a19/#default-reader-release-lock)):
> The releaseLock() method steps are:
> 
> 1. If this.\[[stream]] is undefined, return.
> 2. If this.\[[readRequests]] is not empty, throw a TypeError exception.
> 3. Perform ! ReadableStreamReaderGenericRelease(this).

However, in #1103 we realized that it would be more useful if we *allowed* releasing a reader while there are still pending reads, and to *reject* those reads instead. The user can then acquire a new reader to receive those chunks.

This PR implements that proposed change:
* `reader.releaseLock()` no longer throws an error when there are still pending reads. Instead, it immediately rejects all pending reads with a `TypeError`.
* For readable byte streams, we also discard pull-into descriptors corresponding to (now rejected) read-into requests. However, *we must retain the first pull-into descriptor*, since the underlying byte source may still be using it through `controller.byobRequest`. Instead, we mark this descriptor as "detached", such that when we invalidate this BYOB request (as a result of `controller.enqueue()` or `byobRequest.respond()`), the bytes from this descriptor are pushed into the stream's queue and used to fulfill read requests from a future reader.

This also allows expressing `pipeTo()`'s behavior more accurately. Currently, it "cheats" by calling `ReadableStreamReaderGenericRelease` directly without checking if `[[readRequests]]` is empty. (And yes, there's [a test](https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/piping/error-propagation-backward.any.js#L403-L419) that relies on this happening.) With the proposed changes, we can *safely* release the reader when the pipe finishes (even if there's a pending read), and be sure that any unread chunks can be read by a future reader or pipe.

To do:
* [x] Question: should pending reads be rejected with a `TypeError` or a `AbortError` `DOMException`?
  * Answer: `TypeError`, see [comment](https://github.com/whatwg/streams/pull/1168#issuecomment-1005156894)
* [x] Update spec text
* [ ] Write more tests

Originally, this PR proposed to only add some extra asserts to ensure that `[[readRequests]]` is empty before releasing the lock. However, as shown in the `pipeTo` case (above), this is not sufficient. For context, the original description of that proposal is attached below:
<details>
<summary>Original description</summary>

When using `ReadableStream(Default|BYOB)Reader.releaseLock()`, we throw an error if there are still pending read requests ([spec](https://streams.spec.whatwg.org/commit-snapshots/8bbfbf83ad06a8b9224bbe1cfbcbbbdbdd827a19/#default-reader-release-lock)):

> The releaseLock() method steps are:
> 
> 1. If this.\[[stream]] is undefined, return.
> 2. If this.\[[readRequests]] is not empty, throw a TypeError exception.
> 3. Perform ! ReadableStreamReaderGenericRelease(this).

However, when we use the abstract op `ReadableStreamReaderGenericRelease` directly, we do not assert this. Some places in the spec often have an extra assert specifically for this (e.g. async iterator's return steps or `ReadableByteStreamTee`), but other places fail to perform this check (e.g. async iterator's next steps or [`ReadableStreamPipeTo`](https://streams.spec.whatwg.org/commit-snapshots/8bbfbf83ad06a8b9224bbe1cfbcbbbdbdd827a19/#ref-for-readable-stream-reader-generic-release%E2%91%A5)).

I added this missing check, but now the following WPT tests start failing as a result:
* [piping/abort.any.js](https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/piping/abort.any.js#L375): abort should do nothing after the writable is errored
* [piping/error-propagation-backward.any.js](https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/piping/error-propagation-backward.any.js#L419): Errors must be propagated backward: becomes errored after piping; preventCancel = true
* [readable-streams/async-iterator.any.js](https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/readable-streams/async-iterator.any.js#L626): return() should unlock the stream synchronously when preventCancel = true *(also when preventCancel = false)*

The async iterator test fails because we [release the lock in the middle of the read request's close steps](https://streams.spec.whatwg.org/commit-snapshots/8bbfbf83ad06a8b9224bbe1cfbcbbbdbdd827a19/#ref-for-readable-stream-reader-generic-release), but [`ReadableStreamClose`](https://streams.spec.whatwg.org/commit-snapshots/8bbfbf83ad06a8b9224bbe1cfbcbbbdbdd827a19/#readable-stream-close) only clears the list of read requests *after* calling all the close steps. The fix is quite simple: empty the list *before* calling the close steps or error steps. I'll push a commit for that on this PR.

The pipe tests fail because the pipe loop actually *starts a read request*, but we don't wait for that read to complete before releasing the lock. I *think* it's possible you could lose a chunk this way, but I haven't yet figured out how. I'll keep trying though. 😛 I think we can solve this one by tracking both `currentWrite` *and* `currentRead`, but I'm not sure about the details yet.
</details>

- [x] At least two implementers are interested (and none opposed):
   * Chromium, as expressed below
   * Other implementations have not yet implemented readable byte streams. As such the editors are treating this as a bugfix to readable byte streams, that falls under their previously-expressed general interest in the feature. (Although, explicit review from other engines would be welcome.)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/32072
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: N/A, falls under general readable byte stream implementation work
   * Safari: N/A, falls under general readable byte stream implementation work

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1168.html" title="Last updated on Jan 13, 2022, 8:02 PM UTC (e9e78fe)">Preview</a> | <a href="https://whatpr.org/streams/1168/7f7d68b...e9e78fe.html" title="Last updated on Jan 13, 2022, 8:02 PM UTC (e9e78fe)">Diff</a>