### PR TITLE
Editorial: move informative pointers to a note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6963,7 +6963,7 @@ each instance's [=GenericTransformStream/transform=] to a [=new=] {{TransformStr
 <var>[=TransformStream/set up/transformAlgorithm=]</var> and optionally
 <var>[=TransformStream/set up/flushAlgorithm=]</var> arguments.
 
-Existing examples of this pattern on the web platform include {{CompressionStream}} and
+Note: Existing examples of this pattern on the web platform include {{CompressionStream}} and
 {{TextDecoderStream}}. [[COMPRESSION]] [[ENCODING]]
 
 <p class="note">There's no need to create a wrapper class if you don't need any API beyond what the


### PR DESCRIPTION
This ensures the references end up in the 'Informative' rather than 'Normative' section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1179.html" title="Last updated on Oct 20, 2021, 9:50 AM UTC (06eca0c)">Preview</a> | <a href="https://whatpr.org/streams/1179/ea03a24...06eca0c.html" title="Last updated on Oct 20, 2021, 9:50 AM UTC (06eca0c)">Diff</a>