### PR TITLE
Fix readable/writable file stream examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7302,7 +7302,7 @@ function makeReadableFileStream(filename) {
     },
 
     async pull(controller) {
-      const buffer = new ArrayBuffer(CHUNK_SIZE);
+      const buffer = new Uint8Array(CHUNK_SIZE);
 
       const { bytesRead } = await fileHandle.read(buffer, 0, CHUNK_SIZE, position);
       if (bytesRead === 0) {
@@ -7310,7 +7310,7 @@ function makeReadableFileStream(filename) {
         controller.close();
       } else {
         position += bytesRead;
-        controller.enqueue(new Uint8Array(buffer, 0, bytesRead));
+        controller.enqueue(buffer.subarray(0, bytesRead));
       }
     },
 

--- a/index.bs
+++ b/index.bs
@@ -7350,7 +7350,7 @@ function makeReadableByteFileStream(filename) {
       // feature allocates a buffer and passes it to us via byobRequest.
       const v = controller.byobRequest.view;
 
-      const { bytesRead } = await fileHandle.read(v.buffer, v.byteOffset, v.byteLength);
+      const { bytesRead } = await fileHandle.read(v, 0, v.byteLength, position);
       if (bytesRead === 0) {
         await fileHandle.close();
         controller.close();
@@ -7362,7 +7362,7 @@ function makeReadableByteFileStream(filename) {
     },
 
     cancel() {
-      return fs.close(fd);
+      return fileHandle.close();
     },
 
     autoAllocateChunkSize: DEFAULT_CHUNK_SIZE
@@ -7470,11 +7470,11 @@ function makeWritableFileStream(filename) {
     },
 
     close() {
-      return fs.close(fd);
+      return fileHandle.close();
     },
 
     abort() {
-      return fs.close(fd);
+      return fileHandle.close();
     }
   });
 }
@@ -7834,6 +7834,7 @@ Isaac Schlueter,
 isonmad,
 Jake Archibald,
 Jake Verbaten,
+James Pryor,
 Janessa Det,
 Jason Orendorff,
 Jeffrey Yasskin,


### PR DESCRIPTION
These examples weren't closing the filehandle correctly (they called `close` on a nonexistent `fd` variable, rather than calling the `fileHandle.close` method).

Also the ReadableStream example misused the `fileHandle.read` call: it was supplying an ArrayBuffer and v's byteOffset within the ArrayBuffer, but the API requires supplying v itself and an offset relative to v's start.

Also added the file offset `position` to that `fileHandle.read` call. There's no reason otherwise for the example to keep track of this. Alternatively, the argument could be supplied as null, and we just rely on implicit file positioning.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1191.html" title="Last updated on Nov 29, 2021, 1:06 PM UTC (0173abf)">Preview</a> | <a href="https://whatpr.org/streams/1191/5885d94...0173abf.html" title="Last updated on Nov 29, 2021, 1:06 PM UTC (0173abf)">Diff</a>