### PR TITLE
Editorial: align .webidl files with WebIDL from spec text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1150,8 +1150,8 @@ interface ReadableStreamDefaultReader {
 ReadableStreamDefaultReader includes ReadableStreamGenericReader;
 
 dictionary ReadableStreamDefaultReadResult {
- any value;
- boolean done;
+  any value;
+  boolean done;
 };
 </xmp>
 
@@ -1294,8 +1294,8 @@ interface ReadableStreamBYOBReader {
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;
 
 dictionary ReadableStreamBYOBReadResult {
- ArrayBufferView value;
- boolean done;
+  ArrayBufferView value;
+  boolean done;
 };
 </xmp>
 

--- a/reference-implementation/lib/ReadableByteStreamController.webidl
+++ b/reference-implementation/lib/ReadableByteStreamController.webidl
@@ -3,7 +3,7 @@ interface ReadableByteStreamController {
   readonly attribute ReadableStreamBYOBRequest? byobRequest;
   readonly attribute unrestricted double? desiredSize;
 
-  void close();
-  void enqueue(ArrayBufferView chunk);
-  void error(optional any e);
+  undefined close();
+  undefined enqueue(ArrayBufferView chunk);
+  undefined error(optional any e);
 };

--- a/reference-implementation/lib/ReadableStream.webidl
+++ b/reference-implementation/lib/ReadableStream.webidl
@@ -1,13 +1,13 @@
-[Exposed=(Window,Worker,Worklet)]
+[Exposed=(Window,Worker,Worklet), Transferable]
 interface ReadableStream {
   constructor(optional object underlyingSource, optional QueuingStrategy strategy = {});
 
   readonly attribute boolean locked;
 
-  Promise<void> cancel(optional any reason);
+  Promise<undefined> cancel(optional any reason);
   ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
   ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
-  Promise<void> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
+  Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
   sequence<ReadableStream> tee();
 
   [WebIDL2JSHasReturnSteps] async iterable<any>(optional ReadableStreamIteratorOptions options = {});

--- a/reference-implementation/lib/ReadableStreamBYOBReader.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBReader.webidl
@@ -3,6 +3,6 @@ interface ReadableStreamBYOBReader {
   constructor(ReadableStream stream);
 
   Promise<ReadableStreamBYOBReadResult> read(ArrayBufferView view);
-  void releaseLock();
+  undefined releaseLock();
 };
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;

--- a/reference-implementation/lib/ReadableStreamBYOBRequest.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest.webidl
@@ -2,6 +2,6 @@
 interface ReadableStreamBYOBRequest {
   readonly attribute ArrayBufferView? view;
 
-  void respond([EnforceRange] unsigned long long bytesWritten);
-  void respondWithNewView(ArrayBufferView view);
+  undefined respond([EnforceRange] unsigned long long bytesWritten);
+  undefined respondWithNewView(ArrayBufferView view);
 };

--- a/reference-implementation/lib/ReadableStreamDefaultController.webidl
+++ b/reference-implementation/lib/ReadableStreamDefaultController.webidl
@@ -2,7 +2,7 @@
 interface ReadableStreamDefaultController {
   readonly attribute unrestricted double? desiredSize;
 
-  void close();
-  void enqueue(optional any chunk);
-  void error(optional any e);
+  undefined close();
+  undefined enqueue(optional any chunk);
+  undefined error(optional any e);
 };

--- a/reference-implementation/lib/ReadableStreamDefaultReader.webidl
+++ b/reference-implementation/lib/ReadableStreamDefaultReader.webidl
@@ -3,6 +3,6 @@ interface ReadableStreamDefaultReader {
   constructor(ReadableStream stream);
 
   Promise<ReadableStreamDefaultReadResult> read();
-  void releaseLock();
+  undefined releaseLock();
 };
 ReadableStreamDefaultReader includes ReadableStreamGenericReader;

--- a/reference-implementation/lib/ReadableStreamGenericReader.webidl
+++ b/reference-implementation/lib/ReadableStreamGenericReader.webidl
@@ -1,5 +1,5 @@
 interface mixin ReadableStreamGenericReader {
-  readonly attribute Promise<void> closed;
+  readonly attribute Promise<undefined> closed;
 
-  Promise<void> cancel(optional any reason);
+  Promise<undefined> cancel(optional any reason);
 };

--- a/reference-implementation/lib/TransformStream.webidl
+++ b/reference-implementation/lib/TransformStream.webidl
@@ -1,4 +1,4 @@
-[Exposed=(Window,Worker,Worklet)]
+[Exposed=(Window,Worker,Worklet), Transferable]
 interface TransformStream {
   constructor(optional object transformer,
               optional QueuingStrategy writableStrategy = {},

--- a/reference-implementation/lib/TransformStreamDefaultController.webidl
+++ b/reference-implementation/lib/TransformStreamDefaultController.webidl
@@ -2,7 +2,7 @@
 interface TransformStreamDefaultController {
   readonly attribute unrestricted double? desiredSize;
 
-  void enqueue(optional any chunk);
-  void error(optional any reason);
-  void terminate();
+  undefined enqueue(optional any chunk);
+  undefined error(optional any reason);
+  undefined terminate();
 };

--- a/reference-implementation/lib/Transformer.webidl
+++ b/reference-implementation/lib/Transformer.webidl
@@ -7,5 +7,5 @@ dictionary Transformer {
 };
 
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
-callback TransformerFlushCallback = Promise<void> (TransformStreamDefaultController controller);
-callback TransformerTransformCallback = Promise<void> (any chunk, TransformStreamDefaultController controller);
+callback TransformerFlushCallback = Promise<undefined> (TransformStreamDefaultController controller);
+callback TransformerTransformCallback = Promise<undefined> (any chunk, TransformStreamDefaultController controller);

--- a/reference-implementation/lib/UnderlyingSink.webidl
+++ b/reference-implementation/lib/UnderlyingSink.webidl
@@ -7,6 +7,6 @@ dictionary UnderlyingSink {
 };
 
 callback UnderlyingSinkStartCallback = any (WritableStreamDefaultController controller);
-callback UnderlyingSinkWriteCallback = Promise<void> (any chunk, WritableStreamDefaultController controller);
-callback UnderlyingSinkCloseCallback = Promise<void> ();
-callback UnderlyingSinkAbortCallback = Promise<void> (optional any reason);
+callback UnderlyingSinkWriteCallback = Promise<undefined> (any chunk, WritableStreamDefaultController controller);
+callback UnderlyingSinkCloseCallback = Promise<undefined> ();
+callback UnderlyingSinkAbortCallback = Promise<undefined> (optional any reason);

--- a/reference-implementation/lib/UnderlyingSource.webidl
+++ b/reference-implementation/lib/UnderlyingSource.webidl
@@ -9,7 +9,7 @@ dictionary UnderlyingSource {
 typedef (ReadableStreamDefaultController or ReadableByteStreamController) ReadableStreamController;
 
 callback UnderlyingSourceStartCallback = any (ReadableStreamController controller);
-callback UnderlyingSourcePullCallback = Promise<void> (ReadableStreamController controller);
-callback UnderlyingSourceCancelCallback = Promise<void> (optional any reason);
+callback UnderlyingSourcePullCallback = Promise<undefined> (ReadableStreamController controller);
+callback UnderlyingSourceCancelCallback = Promise<undefined> (optional any reason);
 
 enum ReadableStreamType { "bytes" };

--- a/reference-implementation/lib/WritableStream.webidl
+++ b/reference-implementation/lib/WritableStream.webidl
@@ -1,10 +1,10 @@
-[Exposed=(Window,Worker,Worklet)]
+[Exposed=(Window,Worker,Worklet), Transferable]
 interface WritableStream {
   constructor(optional object underlyingSink, optional QueuingStrategy strategy = {});
 
   readonly attribute boolean locked;
 
-  Promise<void> abort(optional any reason);
-  Promise<void> close();
+  Promise<undefined> abort(optional any reason);
+  Promise<undefined> close();
   WritableStreamDefaultWriter getWriter();
 };

--- a/reference-implementation/lib/WritableStreamDefaultController.webidl
+++ b/reference-implementation/lib/WritableStreamDefaultController.webidl
@@ -1,5 +1,5 @@
 [Exposed=(Window,Worker,Worklet)]
 interface WritableStreamDefaultController {
   readonly attribute AbortSignal signal;
-  void error(optional any e);
+  undefined error(optional any e);
 };

--- a/reference-implementation/lib/WritableStreamDefaultWriter.webidl
+++ b/reference-implementation/lib/WritableStreamDefaultWriter.webidl
@@ -2,12 +2,12 @@
 interface WritableStreamDefaultWriter {
   constructor(WritableStream stream);
 
-  readonly attribute Promise<void> closed;
+  readonly attribute Promise<undefined> closed;
   readonly attribute unrestricted double? desiredSize;
-  readonly attribute Promise<void> ready;
+  readonly attribute Promise<undefined> ready;
 
-  Promise<void> abort(optional any reason);
-  Promise<void> close();
-  void releaseLock();
-  Promise<void> write(optional any chunk);
+  Promise<undefined> abort(optional any reason);
+  Promise<undefined> close();
+  undefined releaseLock();
+  Promise<undefined> write(optional any chunk);
 };


### PR DESCRIPTION
Some of the recent changes to the WebIDL were only applied to the spec text, and not to the `.webidl` files of the reference implementation. Although these changes don't affect code generation, it's still better to keep them in sync.
* `void` and `Promise<void>` were replaced with `undefined` and `Promise<undefined>` (#1068)
* `ReadableStream`, `WritableStream` and `TransformStream` were marked `[Transferable]` (#1053)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1192.html" title="Last updated on Dec 1, 2021, 9:43 PM UTC (a4a26ac)">Preview</a> | <a href="https://whatpr.org/streams/1192/44190d1...a4a26ac.html" title="Last updated on Dec 1, 2021, 9:43 PM UTC (a4a26ac)">Diff</a>