### PR TITLE
Editorial: disambiguate WebSocket references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,8 +19,9 @@ spec:infra; type:dfn; text:list
 spec:html; type:dfn; text:entangle
 spec:html; type:dfn; text:message port post message steps
 spec:html; type:dfn; text:port message queue
-spec:html; type:interface; text:WebSocket
-spec:html; type:attribute; text:bufferedAmount; for:WebSocket
+# TODO: remove these once whatwg/html#7414 is merged
+spec:websockets; type:interface; text:WebSocket
+spec:websockets; type:attribute; text:bufferedAmount; for:WebSocket
 </pre>
 
 <pre class="anchors">
@@ -7103,7 +7104,7 @@ constructors.
 <h3 id="example-rs-push-no-backpressure">A readable stream with an underlying push source (no
 backpressure support)</h3>
 
-The following function creates [=readable streams=] that wrap {{WebSocket}} instances [[HTML]],
+The following function creates [=readable streams=] that wrap {{WebSocket}} instances [[WEBSOCKETS]],
 which are [=push sources=] that do not support backpressure signals. It illustrates how, when
 adapting a push source, usually most of the work happens in the {{UnderlyingSource/start|start()}}
 method.
@@ -7382,7 +7383,7 @@ the manual branching in [[#example-rbs-push]].
 
 <h3 id="example-ws-no-backpressure">A writable stream with no backpressure or success signals</h3>
 
-The following function returns a [=writable stream=] that wraps a {{WebSocket}} [[HTML]]. Web
+The following function returns a [=writable stream=] that wraps a {{WebSocket}} [[WEBSOCKETS]]. Web
 sockets do not provide any way to tell when a given chunk of data has been successfully sent
 (without awkward polling of {{WebSocket/bufferedAmount}}, which we leave as an exercise to the
 reader). As such, this writable stream has no ability to communicate accurate [=backpressure=]

--- a/index.bs
+++ b/index.bs
@@ -19,6 +19,8 @@ spec:infra; type:dfn; text:list
 spec:html; type:dfn; text:entangle
 spec:html; type:dfn; text:message port post message steps
 spec:html; type:dfn; text:port message queue
+spec:html; type:interface; text:WebSocket
+spec:html; type:attribute; text:bufferedAmount; for:WebSocket
 </pre>
 
 <pre class="anchors">


### PR DESCRIPTION
There are now *two* specs that define the `WebSocket` interface: [[HTML]](https://html.spec.whatwg.org/multipage/web-sockets.html#the-websocket-interface) and [[WEBSOCKETS]](https://websockets.spec.whatwg.org/#the-websocket-interface). This causes a Bikeshed error, since it doesn't know which one to pick:
```
LINK ERROR: Multiple possible 'WebSocket' idl refs.
Arbitrarily chose https://html.spec.whatwg.org/multipage/web-sockets.html#websocket
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:html; type:interface; text:WebSocket
spec:websockets; type:interface; text:WebSocket
{{WebSocket}}
make: *** [Makefile:23: deploy] Error 22
```

This adds a link default for `WebSocket` to use the \[HTML] definition, like it was before. I'm not sure if this is still correct, or whether we should migrate to \[WEBSOCKETS]?

(No normative changes.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1198.html" title="Last updated on Dec 14, 2021, 11:26 PM UTC (c3e5540)">Preview</a> | <a href="https://whatpr.org/streams/1198/21a81c6...c3e5540.html" title="Last updated on Dec 14, 2021, 11:26 PM UTC (c3e5540)">Diff</a>