### PR TITLE
add missing controller argument for ReadableByteStreamControllerError in ReadableByteStreamControllerEnqueueClonedChunkToQueue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3270,7 +3270,7 @@ The following abstract operations support the implementation of the
 
  1. Let |cloneResult| be [$CloneArrayBuffer$](|buffer|, |byteOffset|, |byteLength|, {{%ArrayBuffer%}}).
  1. If |cloneResult| is an abrupt completion,
-  1. Perform ! [$ReadableByteStreamControllerError$](|cloneResult|.\[[Value]]).
+  1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |cloneResult|.\[[Value]]).
   1. Return |cloneResult|.
  1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
     |cloneResult|.\[[Value]], 0, |byteLength|).


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1206.html" title="Last updated on Jan 14, 2022, 2:07 PM UTC (02b3899)">Preview</a> | <a href="https://whatpr.org/streams/1206/5c9a34c...02b3899.html" title="Last updated on Jan 14, 2022, 2:07 PM UTC (02b3899)">Diff</a>