### PR TITLE
Release reader immediately when shutting down a pipe

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2305,6 +2305,14 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
       ! [$ReadableStreamBYOBReaderRelease$](|reader|).
    1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+   1. Set |reader| to ! [$AcquireReadableStreamDefaultReader$](|source|).
+      <p class="note">The initial reader is released to ensure that any pending read requests
+      are immediately aborted, and no more chunks are pulled from |source|. A new reader is
+      acquired in order to keep |source| locked until the shutdown is [=finalized=], for example
+      to [=cancel a readable stream|cancel=] |source| if necessary.
+      This exchange of readers is not observable to author code and the user agent is free to
+      implement this differently, for example by keeping the same reader and internally aborting
+      its pending read requests.
    1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
       [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
      1. If any [=chunks=] have been read but not yet written, write them to |dest|.
@@ -2320,6 +2328,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
       ! [$ReadableStreamBYOBReaderRelease$](|reader|).
    1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+   1. Set |reader| to ! [$AcquireReadableStreamDefaultReader$](|source|).
    1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
       [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
     1. If any [=chunks=] have been read but not yet written, write them to |dest|.
@@ -2328,8 +2337,10 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. [=Finalize=], passing along |error| if it was given.
   * <dfn id="rs-pipeTo-finalize"><i>Finalize</i></dfn>: both forms of shutdown will eventually ask
     to finalize, optionally with an error |error|, which means to perform the following steps:
-   1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined.
    1. Perform ! [$WritableStreamDefaultWriterRelease$](|writer|).
+   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
+      ! [$ReadableStreamBYOBReaderRelease$](|reader|).
+   1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. If |signal| is not undefined, [=AbortSignal/remove=] |abortAlgorithm| from |signal|.
    1. If |error| was given, [=reject=] |promise| with |error|.
    1. Otherwise, [=resolve=] |promise| with undefined.

--- a/index.bs
+++ b/index.bs
@@ -2302,6 +2302,9 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
     |originalError|, then:
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
+   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
+      ! [$ReadableStreamBYOBReaderRelease$](|reader|).
+   1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
       [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
      1. If any [=chunks=] have been read but not yet written, write them to |dest|.
@@ -2314,6 +2317,9 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
     ask to shutdown, optionally with an error |error|, then:
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
+   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
+      ! [$ReadableStreamBYOBReaderRelease$](|reader|).
+   1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
       [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
     1. If any [=chunks=] have been read but not yet written, write them to |dest|.
@@ -2322,10 +2328,8 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. [=Finalize=], passing along |error| if it was given.
   * <dfn id="rs-pipeTo-finalize"><i>Finalize</i></dfn>: both forms of shutdown will eventually ask
     to finalize, optionally with an error |error|, which means to perform the following steps:
+   1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined.
    1. Perform ! [$WritableStreamDefaultWriterRelease$](|writer|).
-   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
-      ! [$ReadableStreamBYOBReaderRelease$](|reader|).
-   1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. If |signal| is not undefined, [=AbortSignal/remove=] |abortAlgorithm| from |signal|.
    1. If |error| was given, [=reject=] |promise| with |error|.
    1. Otherwise, [=resolve=] |promise| with undefined.

--- a/index.bs
+++ b/index.bs
@@ -2337,10 +2337,9 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. [=Finalize=], passing along |error| if it was given.
   * <dfn id="rs-pipeTo-finalize"><i>Finalize</i></dfn>: both forms of shutdown will eventually ask
     to finalize, optionally with an error |error|, which means to perform the following steps:
+   1. Assert: |reader| [=implements=] {{ReadableStreamDefaultReader}}.
    1. Perform ! [$WritableStreamDefaultWriterRelease$](|writer|).
-   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
-      ! [$ReadableStreamBYOBReaderRelease$](|reader|).
-   1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. If |signal| is not undefined, [=AbortSignal/remove=] |abortAlgorithm| from |signal|.
    1. If |error| was given, [=reject=] |promise| with |error|.
    1. Otherwise, [=resolve=] |promise| with undefined.

--- a/index.bs
+++ b/index.bs
@@ -2279,7 +2279,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
        |source|.[=ReadableStream/[[storedError]]=].
     1. Otherwise, [=shutdown=] with |source|.[=ReadableStream/[[storedError]]=].
    1. <strong>Errors must be propagated backward:</strong> if |dest|.[=WritableStream/[[state]]=]
-      is or becomes "`errored`", then
+      is or becomes "`erroring`" or "`errored`", then
     1. If |preventCancel| is false, [=shutdown with an action=] of !
        [$ReadableStreamCancel$](|source|, |dest|.[=WritableStream/[[storedError]]=]) and with
        |dest|.[=WritableStream/[[storedError]]=].

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -227,33 +227,50 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     // Errors must be propagated forward
-    sourceIsOrBecomesErrored(() => {
+    function sourceIsOrBecomesErrored() {
       const storedError = source._storedError;
       if (preventAbort === false) {
         shutdownWithAction(() => WritableStreamAbort(dest, storedError), true, storedError);
       } else {
         shutdown(true, storedError);
       }
-    });
+    }
 
     // Errors must be propagated backward
-    destIsOrBecomesErroringOrErrored(() => {
+    function destIsOrBecomesErroringOrErrored() {
       const storedError = dest._storedError;
       if (preventCancel === false) {
         shutdownWithAction(() => ReadableStreamCancel(source, storedError), true, storedError);
       } else {
         shutdown(true, storedError);
       }
-    });
+    }
 
     // Closing must be propagated forward
-    sourceIsOrBecomesClosed(() => {
+    function sourceIsOrBecomesClosed() {
       if (preventClose === false) {
         shutdownWithAction(() => WritableStreamDefaultWriterCloseWithErrorPropagation(writer));
       } else {
         shutdown();
       }
-    });
+    }
+
+    function checkState() {
+      const sourceState = source._state;
+      const destState = dest._state;
+      if (sourceState === 'errored') {
+        // Errors must be propagated forward
+        sourceIsOrBecomesErrored();
+      } else if (destState === 'erroring' || destState === 'errored') {
+        // Errors must be propagated backward
+        destIsOrBecomesErroringOrErrored();
+      } else if (sourceState === 'closed') {
+        // Closing must be propagated forward
+        sourceIsOrBecomesClosed();
+      }
+    }
+
+    checkState();
 
     // Closing must be propagated backward
     if (WritableStreamCloseQueuedOrInFlight(dest) === true || dest._state === 'closed') {
@@ -266,6 +283,11 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       }
     }
 
+    if (!shuttingDown) {
+      readerAddStateChangeListener(reader, checkState);
+      defaultWriterAddStateChangeListener(writer, checkState);
+    }
+
     setPromiseIsHandledToTrue(pipeLoop());
 
     function waitForWritesToFinish() {
@@ -276,42 +298,6 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
         currentWrite,
         () => oldCurrentWrite !== currentWrite ? waitForWritesToFinish() : undefined
       );
-    }
-
-    function sourceIsOrBecomesErrored(action) {
-      const state = source._state;
-      if (state === 'errored') {
-        action();
-      } else if (state === 'readable') {
-        readerAddStateChangeListener(reader, () => sourceIsOrBecomesErrored(action));
-      } else {
-        assert(state === 'closed');
-        // Handled in "closing must be propagated forward"
-      }
-    }
-
-    function sourceIsOrBecomesClosed(action) {
-      const state = source._state;
-      if (source._state === 'closed') {
-        action();
-      } else if (state === 'readable') {
-        readerAddStateChangeListener(reader, () => sourceIsOrBecomesClosed(action));
-      } else {
-        assert(state === 'errored');
-        // Handled in "errors must be propagated forward"
-      }
-    }
-
-    function destIsOrBecomesErroringOrErrored(action) {
-      const state = dest._state;
-      if (state === 'erroring' || state === 'errored') {
-        action(dest._storedError);
-      } else if (state === 'writable') {
-        defaultWriterAddStateChangeListener(writer, () => destIsOrBecomesErroringOrErrored(action));
-      } else {
-        assert(state === 'closed');
-        // Handled in "closing must be propagated backward"
-      }
     }
 
     function shutdownWithAction(action, originalIsError, originalError) {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -9,8 +9,9 @@ const { CanTransferArrayBuffer, Call, CopyDataBlockBytes, CreateArrayFromList, G
 const { CanCopyDataBlockBytes, CloneAsUint8Array, IsNonNegativeNumber } = require('./miscellaneous.js');
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
-        WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterRelease,
-        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight } = require('./writable-streams.js');
+        WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterIsOrBecomesErrored,
+        WritableStreamDefaultWriterRelease, WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight } =
+  require('./writable-streams.js');
 const { CancelSteps, PullSteps, ReleaseSteps } = require('./internal-methods.js');
 
 const ReadableByteStreamController = require('../../generated/ReadableByteStreamController.js');
@@ -235,7 +236,8 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     });
 
     // Errors must be propagated backward
-    isOrBecomesErrored(dest, writer._closedPromise, storedError => {
+    WritableStreamDefaultWriterIsOrBecomesErrored(writer, () => {
+      const storedError = dest._storedError;
       if (preventCancel === false) {
         shutdownWithAction(() => ReadableStreamCancel(source, storedError), true, storedError);
       } else {

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -10,7 +10,7 @@ const { CanCopyDataBlockBytes, CloneAsUint8Array, IsNonNegativeNumber } = requir
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
         WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterRelease,
-        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight, writerAddStateChangeListener } =
+        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight, writerSetStateChangeListener } =
   require('./writable-streams.js');
 const { CancelSteps, PullSteps, ReleaseSteps } = require('./internal-methods.js');
 
@@ -285,8 +285,8 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
 
     if (!shuttingDown) {
       assert(source._state === 'readable' && dest._state === 'writable');
-      readerAddStateChangeListener(reader, checkState);
-      writerAddStateChangeListener(writer, checkState);
+      readerSetStateChangeListener(reader, checkState);
+      writerSetStateChangeListener(writer, checkState);
 
       setPromiseIsHandledToTrue(pipeLoop());
     }
@@ -792,7 +792,7 @@ function ReadableStreamClose(stream) {
   }
 
   resolvePromise(reader._closedPromise, undefined);
-  readerRunStateChangeListeners(reader);
+  readerRunStateChangeListener(reader);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
     const readRequests = reader._readRequests;
@@ -817,7 +817,7 @@ function ReadableStreamError(stream, e) {
 
   rejectPromise(reader._closedPromise, e);
   setPromiseIsHandledToTrue(reader._closedPromise);
-  readerRunStateChangeListeners(reader);
+  readerRunStateChangeListener(reader);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
     ReadableStreamDefaultReaderErrorReadRequests(reader, e);
@@ -901,7 +901,7 @@ function ReadableStreamReaderGenericInitialize(reader, stream) {
   reader._stream = stream;
   stream._reader = reader;
 
-  reader._stateChangeListeners = [];
+  reader._stateChangeListener = undefined;
 
   if (stream._state === 'readable') {
     reader._closedPromise = newPromise();
@@ -937,19 +937,20 @@ function ReadableStreamReaderGenericRelease(reader) {
   stream._reader = undefined;
   reader._stream = undefined;
 
-  reader._stateChangeListeners = [];
+  reader._stateChangeListener = undefined;
 }
 
-function readerAddStateChangeListener(reader, stateChangeListener) {
+function readerSetStateChangeListener(reader, stateChangeListener) {
   const stream = reader._stream;
   assert(stream !== undefined);
-  reader._stateChangeListeners.push(stateChangeListener);
+  assert(reader._stateChangeListener === undefined);
+  reader._stateChangeListener = stateChangeListener;
 }
 
-function readerRunStateChangeListeners(reader) {
-  const stateChangeListeners = reader._stateChangeListeners;
-  reader._stateChangeListeners = [];
-  for (const stateChangeListener of stateChangeListeners) {
+function readerRunStateChangeListener(reader) {
+  const stateChangeListener = reader._stateChangeListener;
+  reader._stateChangeListener = undefined;
+  if (stateChangeListener !== undefined) {
     stateChangeListener();
   }
 }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -284,6 +284,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     if (!shuttingDown) {
+      assert(source._state === 'readable' && dest._state === 'writable');
       readerAddStateChangeListener(reader, checkState);
       writerAddStateChangeListener(writer, checkState);
 
@@ -941,7 +942,6 @@ function ReadableStreamReaderGenericRelease(reader) {
 function readerAddStateChangeListener(reader, stateChangeListener) {
   const stream = reader._stream;
   assert(stream !== undefined);
-  assert(stream._state === 'readable');
   reader._stateChangeListeners.push(stateChangeListener);
 }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -135,7 +135,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
   assert(IsReadableStreamLocked(source) === false);
   assert(IsWritableStreamLocked(dest) === false);
 
-  const reader = AcquireReadableStreamDefaultReader(source);
+  let reader = AcquireReadableStreamDefaultReader(source);
   const writer = AcquireWritableStreamDefaultWriter(dest);
 
   source._disturbed = true;
@@ -294,6 +294,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       }
       shuttingDown = true;
       ReadableStreamDefaultReaderRelease(reader);
+      reader = AcquireReadableStreamDefaultReader(source);
 
       if (dest._state === 'writable' && WritableStreamCloseQueuedOrInFlight(dest) === false) {
         uponFulfillment(waitForWritesToFinish(), doTheRest);
@@ -316,6 +317,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       }
       shuttingDown = true;
       ReadableStreamDefaultReaderRelease(reader);
+      reader = AcquireReadableStreamDefaultReader(source);
 
       if (dest._state === 'writable' && WritableStreamCloseQueuedOrInFlight(dest) === false) {
         uponFulfillment(waitForWritesToFinish(), () => finalize(isError, error));
@@ -325,8 +327,8 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     function finalize(isError, error) {
-      assert(reader._stream === undefined);
       WritableStreamDefaultWriterRelease(writer);
+      ReadableStreamDefaultReaderRelease(reader);
 
       if (signal !== undefined) {
         signal.removeEventListener('abort', abortAlgorithm);

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -9,8 +9,8 @@ const { CanTransferArrayBuffer, Call, CopyDataBlockBytes, CreateArrayFromList, G
 const { CanCopyDataBlockBytes, CloneAsUint8Array, IsNonNegativeNumber } = require('./miscellaneous.js');
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
-        WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterIsOrBecomesErrored,
-        WritableStreamDefaultWriterRelease, WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight } =
+        WritableStreamDefaultWriterCloseWithErrorPropagation,  WritableStreamDefaultWriterRelease,
+        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight, defaultWriterAddErrorListener } =
   require('./writable-streams.js');
 const { CancelSteps, PullSteps, ReleaseSteps } = require('./internal-methods.js');
 
@@ -236,7 +236,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     });
 
     // Errors must be propagated backward
-    WritableStreamDefaultWriterIsOrBecomesErrored(writer, () => {
+    defaultWriterAddErrorListener(writer, () => {
       const storedError = dest._storedError;
       if (preventCancel === false) {
         shutdownWithAction(() => ReadableStreamCancel(source, storedError), true, storedError);

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -286,9 +286,9 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     if (!shuttingDown) {
       readerAddStateChangeListener(reader, checkState);
       defaultWriterAddStateChangeListener(writer, checkState);
-    }
 
-    setPromiseIsHandledToTrue(pipeLoop());
+      setPromiseIsHandledToTrue(pipeLoop());
+    }
 
     function waitForWritesToFinish() {
       // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -201,6 +201,9 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       }
 
       return transformPromiseWith(writer._readyPromise, () => {
+        if (shuttingDown === true) {
+          return promiseResolvedWith(true);
+        }
         return new Promise((resolveRead, rejectRead) => {
           ReadableStreamDefaultReaderRead(
             reader,
@@ -290,6 +293,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
         return;
       }
       shuttingDown = true;
+      ReadableStreamDefaultReaderRelease(reader);
 
       if (dest._state === 'writable' && WritableStreamCloseQueuedOrInFlight(dest) === false) {
         uponFulfillment(waitForWritesToFinish(), doTheRest);
@@ -311,6 +315,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
         return;
       }
       shuttingDown = true;
+      ReadableStreamDefaultReaderRelease(reader);
 
       if (dest._state === 'writable' && WritableStreamCloseQueuedOrInFlight(dest) === false) {
         uponFulfillment(waitForWritesToFinish(), () => finalize(isError, error));
@@ -320,8 +325,8 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     function finalize(isError, error) {
+      assert(reader._stream === undefined);
       WritableStreamDefaultWriterRelease(writer);
-      ReadableStreamDefaultReaderRelease(reader);
 
       if (signal !== undefined) {
         signal.removeEventListener('abort', abortAlgorithm);

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -204,6 +204,9 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
         if (shuttingDown === true) {
           return promiseResolvedWith(true);
         }
+        if (dest._state !== 'writable' || WritableStreamCloseQueuedOrInFlight(dest) === true) {
+          return promiseResolvedWith(true);
+        }
         return new Promise((resolveRead, rejectRead) => {
           ReadableStreamDefaultReaderRead(
             reader,

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -10,7 +10,7 @@ const { CanCopyDataBlockBytes, CloneAsUint8Array, IsNonNegativeNumber } = requir
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
         WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterRelease,
-        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight, defaultWriterAddStateChangeListener } =
+        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight, writerAddStateChangeListener } =
   require('./writable-streams.js');
 const { CancelSteps, PullSteps, ReleaseSteps } = require('./internal-methods.js');
 
@@ -285,7 +285,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
 
     if (!shuttingDown) {
       readerAddStateChangeListener(reader, checkState);
-      defaultWriterAddStateChangeListener(writer, checkState);
+      writerAddStateChangeListener(writer, checkState);
 
       setPromiseIsHandledToTrue(pipeLoop());
     }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const { promiseResolvedWith, promiseRejectedWith, newPromise, resolvePromise, rejectPromise, uponPromise,
         setPromiseIsHandledToTrue, waitForAllPromise, transformPromiseWith, uponFulfillment, uponRejection } =
   require('../helpers/webidl.js');
+const { rethrowAssertionErrorRejection } = require('../helpers/miscellaneous.js');
 const { CanTransferArrayBuffer, Call, CopyDataBlockBytes, CreateArrayFromList, GetIterator, GetMethod, IsDetachedBuffer,
         IteratorComplete, IteratorNext, IteratorValue, TransferArrayBuffer, typeIsObject } = require('./ecmascript.js');
 const { CanCopyDataBlockBytes, CloneAsUint8Array, IsNonNegativeNumber } = require('./miscellaneous.js');
@@ -214,7 +215,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
             {
               chunkSteps: chunk => {
                 currentWrite = transformPromiseWith(
-                  WritableStreamDefaultWriterWrite(writer, chunk), undefined, () => {}
+                  WritableStreamDefaultWriterWrite(writer, chunk), undefined, rethrowAssertionErrorRejection
                 );
                 resolveRead(false);
               },

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -340,6 +340,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     function finalize(isError, error) {
+      assert(ReadableStreamDefaultReader.isImpl(reader));
       WritableStreamDefaultWriterRelease(writer);
       ReadableStreamDefaultReaderRelease(reader);
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -227,7 +227,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     // Errors must be propagated forward
-    isOrBecomesErrored(source, reader._closedPromise, storedError => {
+    sourceIsOrBecomesErrored(storedError => {
       if (preventAbort === false) {
         shutdownWithAction(() => WritableStreamAbort(dest, storedError), true, storedError);
       } else {
@@ -236,8 +236,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     });
 
     // Errors must be propagated backward
-    defaultWriterAddErrorListener(writer, () => {
-      const storedError = dest._storedError;
+    destIsOrBecomesErroringOrErrored(storedError => {
       if (preventCancel === false) {
         shutdownWithAction(() => ReadableStreamCancel(source, storedError), true, storedError);
       } else {
@@ -246,7 +245,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     });
 
     // Closing must be propagated forward
-    isOrBecomesClosed(source, reader._closedPromise, () => {
+    sourceIsOrBecomesClosed(() => {
       if (preventClose === false) {
         shutdownWithAction(() => WritableStreamDefaultWriterCloseWithErrorPropagation(writer));
       } else {
@@ -277,19 +276,31 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       );
     }
 
-    function isOrBecomesErrored(stream, promise, action) {
-      if (stream._state === 'errored') {
-        action(stream._storedError);
+    function sourceIsOrBecomesErrored(action) {
+      if (source._state === 'errored') {
+        action(source._storedError);
       } else {
-        uponRejection(promise, action);
+        uponRejection(reader._closedPromise, action);
       }
     }
 
-    function isOrBecomesClosed(stream, promise, action) {
-      if (stream._state === 'closed') {
+    function sourceIsOrBecomesClosed(action) {
+      if (source._state === 'closed') {
         action();
       } else {
-        uponFulfillment(promise, action);
+        uponFulfillment(reader._closedPromise, action);
+      }
+    }
+
+    function destIsOrBecomesErroringOrErrored(action) {
+      const state = dest._state;
+      if (state === 'erroring' || state === 'errored') {
+        action(dest._storedError);
+      } else if (state === 'writable') {
+        defaultWriterAddErrorListener(writer, action);
+      } else {
+        assert(state === 'closed');
+        // Handled in "closing must be propagated backward"
       }
     }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -9,8 +9,8 @@ const { CanTransferArrayBuffer, Call, CopyDataBlockBytes, CreateArrayFromList, G
 const { CanCopyDataBlockBytes, CloneAsUint8Array, IsNonNegativeNumber } = require('./miscellaneous.js');
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
-        WritableStreamDefaultWriterCloseWithErrorPropagation,  WritableStreamDefaultWriterRelease,
-        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight, defaultWriterAddErrorListener } =
+        WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterRelease,
+        WritableStreamDefaultWriterWrite, WritableStreamCloseQueuedOrInFlight, defaultWriterAddStateChangeListener } =
   require('./writable-streams.js');
 const { CancelSteps, PullSteps, ReleaseSteps } = require('./internal-methods.js');
 
@@ -227,7 +227,8 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     // Errors must be propagated forward
-    sourceIsOrBecomesErrored(storedError => {
+    sourceIsOrBecomesErrored(() => {
+      const storedError = source._storedError;
       if (preventAbort === false) {
         shutdownWithAction(() => WritableStreamAbort(dest, storedError), true, storedError);
       } else {
@@ -236,7 +237,8 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     });
 
     // Errors must be propagated backward
-    destIsOrBecomesErroringOrErrored(storedError => {
+    destIsOrBecomesErroringOrErrored(() => {
+      const storedError = dest._storedError;
       if (preventCancel === false) {
         shutdownWithAction(() => ReadableStreamCancel(source, storedError), true, storedError);
       } else {
@@ -277,18 +279,26 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
     }
 
     function sourceIsOrBecomesErrored(action) {
-      if (source._state === 'errored') {
-        action(source._storedError);
+      const state = source._state;
+      if (state === 'errored') {
+        action();
+      } else if (state === 'readable') {
+        readerAddStateChangeListener(reader, () => sourceIsOrBecomesErrored(action));
       } else {
-        uponRejection(reader._closedPromise, action);
+        assert(state === 'closed');
+        // Handled in "closing must be propagated forward"
       }
     }
 
     function sourceIsOrBecomesClosed(action) {
+      const state = source._state;
       if (source._state === 'closed') {
         action();
+      } else if (state === 'readable') {
+        readerAddStateChangeListener(reader, () => sourceIsOrBecomesClosed(action));
       } else {
-        uponFulfillment(reader._closedPromise, action);
+        assert(state === 'errored');
+        // Handled in "errors must be propagated forward"
       }
     }
 
@@ -297,7 +307,7 @@ function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventC
       if (state === 'erroring' || state === 'errored') {
         action(dest._storedError);
       } else if (state === 'writable') {
-        defaultWriterAddErrorListener(writer, action);
+        defaultWriterAddStateChangeListener(writer, () => destIsOrBecomesErroringOrErrored(action));
       } else {
         assert(state === 'closed');
         // Handled in "closing must be propagated backward"
@@ -794,6 +804,7 @@ function ReadableStreamClose(stream) {
   }
 
   resolvePromise(reader._closedPromise, undefined);
+  readerRunStateChangeListeners(reader);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
     const readRequests = reader._readRequests;
@@ -818,6 +829,7 @@ function ReadableStreamError(stream, e) {
 
   rejectPromise(reader._closedPromise, e);
   setPromiseIsHandledToTrue(reader._closedPromise);
+  readerRunStateChangeListeners(reader);
 
   if (ReadableStreamDefaultReader.isImpl(reader)) {
     ReadableStreamDefaultReaderErrorReadRequests(reader, e);
@@ -901,6 +913,8 @@ function ReadableStreamReaderGenericInitialize(reader, stream) {
   reader._stream = stream;
   stream._reader = reader;
 
+  reader._stateChangeListeners = [];
+
   if (stream._state === 'readable') {
     reader._closedPromise = newPromise();
   } else if (stream._state === 'closed') {
@@ -934,6 +948,23 @@ function ReadableStreamReaderGenericRelease(reader) {
 
   stream._reader = undefined;
   reader._stream = undefined;
+
+  reader._stateChangeListeners = [];
+}
+
+function readerAddStateChangeListener(reader, stateChangeListener) {
+  const stream = reader._stream;
+  assert(stream !== undefined);
+  assert(stream._state === 'readable');
+  reader._stateChangeListeners.push(stateChangeListener);
+}
+
+function readerRunStateChangeListeners(reader) {
+  const stateChangeListeners = reader._stateChangeListeners;
+  reader._stateChangeListeners = [];
+  for (const stateChangeListener of stateChangeListeners) {
+    stateChangeListener();
+  }
 }
 
 function ReadableStreamBYOBReaderRead(reader, view, min, readIntoRequest) {

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -483,20 +483,6 @@ function WritableStreamDefaultWriterGetDesiredSize(writer) {
   return WritableStreamDefaultControllerGetDesiredSize(stream._controller);
 }
 
-function WritableStreamDefaultWriterIsOrBecomesErrored(writer, errorListener) {
-  const stream = writer._stream;
-  if (stream === undefined) {
-    return;
-  }
-
-  const state = stream._state;
-  if (state === 'writable') {
-    writer._errorListeners.push(errorListener);
-  } else if (state === 'erroring' || state === 'errored') {
-    errorListener();
-  }
-}
-
 function WritableStreamDefaultWriterRelease(writer) {
   const stream = writer._stream;
   assert(stream !== undefined);
@@ -548,6 +534,20 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
   WritableStreamDefaultControllerWrite(controller, chunk, chunkSize);
 
   return promise;
+}
+
+function WritableStreamDefaultWriterIsOrBecomesErrored(writer, errorListener) {
+  const stream = writer._stream;
+  if (stream === undefined) {
+    return;
+  }
+
+  const state = stream._state;
+  if (state === 'writable') {
+    writer._errorListeners.push(errorListener);
+  } else if (state === 'erroring' || state === 'errored') {
+    errorListener();
+  }
 }
 
 // Default controllers

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -541,7 +541,6 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
 function writerAddStateChangeListener(writer, stateChangeListener) {
   const stream = writer._stream;
   assert(stream !== undefined);
-  assert(stream._state === 'writable');
   writer._stateChangeListeners.push(stateChangeListener);
 }
 

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -31,9 +31,9 @@ Object.assign(exports, {
   WritableStreamDefaultWriterClose,
   WritableStreamDefaultWriterCloseWithErrorPropagation,
   WritableStreamDefaultWriterGetDesiredSize,
-  WritableStreamDefaultWriterIsOrBecomesErrored,
   WritableStreamDefaultWriterRelease,
-  WritableStreamDefaultWriterWrite
+  WritableStreamDefaultWriterWrite,
+  defaultWriterAddErrorListener
 });
 
 // Working with writable streams
@@ -536,7 +536,7 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
   return promise;
 }
 
-function WritableStreamDefaultWriterIsOrBecomesErrored(writer, errorListener) {
+function defaultWriterAddErrorListener(writer, errorListener) {
   const stream = writer._stream;
   if (stream === undefined) {
     return;

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -33,7 +33,7 @@ Object.assign(exports, {
   WritableStreamDefaultWriterGetDesiredSize,
   WritableStreamDefaultWriterRelease,
   WritableStreamDefaultWriterWrite,
-  defaultWriterAddStateChangeListener
+  writerAddStateChangeListener
 });
 
 // Working with writable streams
@@ -244,7 +244,7 @@ function WritableStreamFinishErroring(stream) {
 
   const writer = stream._writer;
   if (writer !== undefined) {
-    defaultWriterRunStateChangeListeners(writer);
+    writerRunStateChangeListeners(writer);
   }
 
   if (stream._pendingAbortRequest === undefined) {
@@ -297,7 +297,7 @@ function WritableStreamFinishInFlightClose(stream) {
   const writer = stream._writer;
   if (writer !== undefined) {
     resolvePromise(writer._closedPromise, undefined);
-    defaultWriterRunStateChangeListeners(writer);
+    writerRunStateChangeListeners(writer);
   }
 
   assert(stream._pendingAbortRequest === undefined);
@@ -387,7 +387,7 @@ function WritableStreamStartErroring(stream, reason) {
   const writer = stream._writer;
   if (writer !== undefined) {
     WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, reason);
-    defaultWriterRunStateChangeListeners(writer, reason);
+    writerRunStateChangeListeners(writer, reason);
   }
 
   if (WritableStreamHasOperationMarkedInFlight(stream) === false && controller._started === true) {
@@ -538,14 +538,14 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
   return promise;
 }
 
-function defaultWriterAddStateChangeListener(writer, stateChangeListener) {
+function writerAddStateChangeListener(writer, stateChangeListener) {
   const stream = writer._stream;
   assert(stream !== undefined);
   assert(stream._state === 'writable');
   writer._stateChangeListeners.push(stateChangeListener);
 }
 
-function defaultWriterRunStateChangeListeners(writer) {
+function writerRunStateChangeListeners(writer) {
   const stateChangeListeners = writer._stateChangeListeners;
   writer._stateChangeListeners = [];
   for (const stateChangeListener of stateChangeListeners) {

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -381,7 +381,7 @@ function WritableStreamStartErroring(stream, reason) {
   const writer = stream._writer;
   if (writer !== undefined) {
     WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, reason);
-    defaultWriterRunErrorListeners(writer);
+    defaultWriterRunErrorListeners(writer, reason);
   }
 
   if (WritableStreamHasOperationMarkedInFlight(stream) === false && controller._started === true) {
@@ -534,23 +534,16 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
 
 function defaultWriterAddErrorListener(writer, errorListener) {
   const stream = writer._stream;
-  if (stream === undefined) {
-    return;
-  }
-
-  const state = stream._state;
-  if (state === 'writable') {
-    writer._errorListeners.push(errorListener);
-  } else if (state === 'erroring' || state === 'errored') {
-    errorListener();
-  }
+  assert(stream !== undefined);
+  assert(stream._state === 'writable');
+  writer._errorListeners.push(errorListener);
 }
 
-function defaultWriterRunErrorListeners(writer) {
+function defaultWriterRunErrorListeners(writer, error) {
   const errorListeners = writer._errorListeners;
   writer._errorListeners = [];
   for (const errorListener of errorListeners) {
-    errorListener();
+    errorListener(error);
   }
 }
 

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -381,11 +381,7 @@ function WritableStreamStartErroring(stream, reason) {
   const writer = stream._writer;
   if (writer !== undefined) {
     WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, reason);
-    const errorListeners = writer._errorListeners;
-    writer._errorListeners = [];
-    for (const errorListener of errorListeners) {
-      errorListener();
-    }
+    defaultWriterRunErrorListeners(writer);
   }
 
   if (WritableStreamHasOperationMarkedInFlight(stream) === false && controller._started === true) {
@@ -546,6 +542,14 @@ function defaultWriterAddErrorListener(writer, errorListener) {
   if (state === 'writable') {
     writer._errorListeners.push(errorListener);
   } else if (state === 'erroring' || state === 'errored') {
+    errorListener();
+  }
+}
+
+function defaultWriterRunErrorListeners(writer) {
+  const errorListeners = writer._errorListeners;
+  writer._errorListeners = [];
+  for (const errorListener of errorListeners) {
     errorListener();
   }
 }

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -33,7 +33,7 @@ Object.assign(exports, {
   WritableStreamDefaultWriterGetDesiredSize,
   WritableStreamDefaultWriterRelease,
   WritableStreamDefaultWriterWrite,
-  writerAddStateChangeListener
+  writerSetStateChangeListener
 });
 
 // Working with writable streams
@@ -144,7 +144,7 @@ function SetUpWritableStreamDefaultWriter(writer, stream) {
   writer._stream = stream;
   stream._writer = writer;
 
-  writer._stateChangeListeners = [];
+  writer._stateChangeListener = undefined;
 
   const state = stream._state;
 
@@ -244,7 +244,7 @@ function WritableStreamFinishErroring(stream) {
 
   const writer = stream._writer;
   if (writer !== undefined) {
-    writerRunStateChangeListeners(writer);
+    writerRunStateChangeListener(writer);
   }
 
   if (stream._pendingAbortRequest === undefined) {
@@ -297,7 +297,7 @@ function WritableStreamFinishInFlightClose(stream) {
   const writer = stream._writer;
   if (writer !== undefined) {
     resolvePromise(writer._closedPromise, undefined);
-    writerRunStateChangeListeners(writer);
+    writerRunStateChangeListener(writer);
   }
 
   assert(stream._pendingAbortRequest === undefined);
@@ -387,7 +387,7 @@ function WritableStreamStartErroring(stream, reason) {
   const writer = stream._writer;
   if (writer !== undefined) {
     WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, reason);
-    writerRunStateChangeListeners(writer, reason);
+    writerRunStateChangeListener(writer, reason);
   }
 
   if (WritableStreamHasOperationMarkedInFlight(stream) === false && controller._started === true) {
@@ -502,7 +502,7 @@ function WritableStreamDefaultWriterRelease(writer) {
   stream._writer = undefined;
   writer._stream = undefined;
 
-  writer._stateChangeListeners = [];
+  writer._stateChangeListener = undefined;
 }
 
 function WritableStreamDefaultWriterWrite(writer, chunk) {
@@ -538,16 +538,17 @@ function WritableStreamDefaultWriterWrite(writer, chunk) {
   return promise;
 }
 
-function writerAddStateChangeListener(writer, stateChangeListener) {
+function writerSetStateChangeListener(writer, stateChangeListener) {
   const stream = writer._stream;
   assert(stream !== undefined);
-  writer._stateChangeListeners.push(stateChangeListener);
+  assert(writer._stateChangeListener === undefined);
+  writer._stateChangeListener = stateChangeListener;
 }
 
-function writerRunStateChangeListeners(writer) {
-  const stateChangeListeners = writer._stateChangeListeners;
-  writer._stateChangeListeners = [];
-  for (const stateChangeListener of stateChangeListeners) {
+function writerRunStateChangeListener(writer) {
+  const stateChangeListener = writer._stateChangeListener;
+  writer._stateChangeListener = undefined;
+  if (stateChangeListener !== undefined) {
     stateChangeListener();
   }
 }


### PR DESCRIPTION
In #1207, we raised concern about whether it's currently possible for `pipeTo()` to drop chunks when the pipe shuts down *while it still has a pending read request*.

It turns out that this *is* indeed possible. [The new WPT tests](https://github.com/web-platform-tests/wpt/pull/32399) demonstrate at least one way this can happen: by aborting a pipe with an `AbortSignal`, and then enqueuing a chunk immediately after aborting the signal.

This PR fixes this by releasing the pipe's reader immediately when *starting* the shutdown process, rather than when it *finalizes* the shutdown. This ensures that any pending reads that were started are immediately rejected, and the chunks stay in the source's queue.

~This does have the side effect of releasing the reader *before* the pipe promise resolves. I don't know if this is acceptable.~ Fixed in https://github.com/whatwg/streams/pull/1208#issuecomment-1015911238.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/32399
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1208.html" title="Last updated on May 25, 2026, 9:25 PM UTC (5e26f17)">Preview</a> | <a href="https://whatpr.org/streams/1208/4c5b332...5e26f17.html" title="Last updated on May 25, 2026, 9:25 PM UTC (5e26f17)">Diff</a>