### PR TITLE
Editorial: call correct Release() depending on chosen reader in pipeTo()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2219,7 +2219,9 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
   * <dfn id="rs-pipeTo-finalize"><i>Finalize</i></dfn>: both forms of shutdown will eventually ask
     to finalize, optionally with an error |error|, which means to perform the following steps:
    1. Perform ! [$WritableStreamDefaultWriterRelease$](|writer|).
-   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
+      ! [$ReadableStreamBYOBReaderRelease$](|reader|).
+   1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
    1. If |signal| is not undefined, [=AbortSignal/remove=] |abortAlgorithm| from |signal|.
    1. If |error| was given, [=reject=] |promise| with |error|.
    1. Otherwise, [=resolve=] |promise| with undefined.


### PR DESCRIPTION
The user agent is allowed to use a default reader *or* a BYOB reader for the pipe in [step 8](https://streams.spec.whatwg.org/commit-snapshots/3c6b8b3570cbe51be1f58f7140f612e521197d85/#readable-stream-pipe-to), but we always call `ReadableStreamDefaultReaderRelease` in [the finalize steps](https://streams.spec.whatwg.org/commit-snapshots/3c6b8b3570cbe51be1f58f7140f612e521197d85/#rs-pipeTo-finalize). This is incorrect: we should use the appropriate `Release()` abstract op corresponding to the chosen reader. This PR fixes that.

(Before #1168, we had a single `ReadableStreamReaderGenericRelease` that worked for both. So this was a small regression.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1209.html" title="Last updated on Jan 18, 2022, 11:34 PM UTC (4ac21bc)">Preview</a> | <a href="https://whatpr.org/streams/1209/3c6b8b3...4ac21bc.html" title="Last updated on Jan 18, 2022, 11:34 PM UTC (4ac21bc)">Diff</a>