### PR TITLE
Use `(ArrayBufferView or undefined)` for ReadableStreamBYOBReadResult

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1308,7 +1308,7 @@ interface ReadableStreamBYOBReader {
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;
 
 dictionary ReadableStreamBYOBReadResult {
-  ArrayBufferView value;
+  (ArrayBufferView or undefined) value;
   boolean done;
 };
 </xmp>

--- a/reference-implementation/lib/ReadableStreamBYOBReadResult.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBReadResult.webidl
@@ -1,4 +1,4 @@
 dictionary ReadableStreamBYOBReadResult {
-  ArrayBufferView value;
+  (ArrayBufferView or undefined) value;
   boolean done;
 };


### PR DESCRIPTION
Closes https://github.com/whatwg/webidl/issues/1094.

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/62c22e4362e19418022e03ca4f5bea76b998fa3f/streams/readable-byte-streams/tee.any.js#L503
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1752880
   * Safari: …
   * Deno: …
   * Node.js: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams-1/1214.html" title="Last updated on Feb 1, 2022, 7:24 PM UTC (288c312)">Preview</a> | <a href="https://whatpr.org/streams/1214/5afb0e0...288c312.html" title="Last updated on Feb 1, 2022, 7:24 PM UTC (288c312)">Diff</a>