### PR TITLE
Editorial: Mark high water mark definition as exported

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ producer, but not yet processed and acknowledged by the [=underlying sink=].
 A <dfn>queuing strategy</dfn> is an object that determines how a stream should signal
 [=backpressure=] based on the state of its [=internal queue=]. The queuing strategy assigns a size
 to each [=chunk=], and compares the total size of all chunks in the queue to a specified number,
-known as the <dfn>high water mark</dfn>. The resulting difference, high water mark minus total size,
+known as the <dfn export>high water mark</dfn>. The resulting difference, high water mark minus total size,
 is used to determine the <dfn lt="desired size to fill a stream's internal queue">desired size to
 fill the stream's queue</dfn>.
 

--- a/index.bs
+++ b/index.bs
@@ -277,9 +277,9 @@ producer, but not yet processed and acknowledged by the [=underlying sink=].
 A <dfn>queuing strategy</dfn> is an object that determines how a stream should signal
 [=backpressure=] based on the state of its [=internal queue=]. The queuing strategy assigns a size
 to each [=chunk=], and compares the total size of all chunks in the queue to a specified number,
-known as the <dfn export>high water mark</dfn>. The resulting difference, high water mark minus total size,
-is used to determine the <dfn lt="desired size to fill a stream's internal queue">desired size to
-fill the stream's queue</dfn>.
+known as the <dfn export>high water mark</dfn>. The resulting difference, high water mark minus
+total size, is used to determine the <dfn lt="desired size to fill a stream's internal
+queue">desired size to fill the stream's queue</dfn>.
 
 For readable streams, an underlying source can use this desired size as a backpressure signal,
 slowing down chunk generation so as to try to keep the desired size above or at zero. For writable


### PR DESCRIPTION
used e.g. in WebTransport


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1221.html" title="Last updated on Feb 24, 2022, 7:16 PM UTC (8e2092a)">Preview</a> | <a href="https://whatpr.org/streams/1221/cc936c1...8e2092a.html" title="Last updated on Feb 24, 2022, 7:16 PM UTC (8e2092a)">Diff</a>