### PR TITLE
Remove ReadableStreamBYOBReadResult 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1159,12 +1159,12 @@ The Web IDL definition for the {{ReadableStreamDefaultReader}} class is given as
 interface ReadableStreamDefaultReader {
   constructor(ReadableStream stream);
 
-  Promise<ReadableStreamDefaultReadResult> read();
+  Promise<ReadableStreamReadResult> read();
   undefined releaseLock();
 };
 ReadableStreamDefaultReader includes ReadableStreamGenericReader;
 
-dictionary ReadableStreamDefaultReadResult {
+dictionary ReadableStreamReadResult {
   any value;
   boolean done;
 };
@@ -1267,12 +1267,12 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
   : [=read request/chunk steps=], given |chunk|
   ::
-   1. [=Resolve=] |promise| with «[ "{{ReadableStreamDefaultReadResult/value}}" → |chunk|,
-      "{{ReadableStreamDefaultReadResult/done}}" → false ]».
+   1. [=Resolve=] |promise| with «[ "{{ReadableStreamReadResult/value}}" → |chunk|,
+      "{{ReadableStreamReadResult/done}}" → false ]».
   : [=read request/close steps=]
   ::
-   1. [=Resolve=] |promise| with «[ "{{ReadableStreamDefaultReadResult/value}}" → undefined,
-      "{{ReadableStreamDefaultReadResult/done}}" → true ]».
+   1. [=Resolve=] |promise| with «[ "{{ReadableStreamReadResult/value}}" → undefined,
+      "{{ReadableStreamReadResult/done}}" → true ]».
   : [=read request/error steps=], given |e|
   ::
    1. [=Reject=] |promise| with |e|.
@@ -1302,15 +1302,10 @@ The Web IDL definition for the {{ReadableStreamBYOBReader}} class is given as fo
 interface ReadableStreamBYOBReader {
   constructor(ReadableStream stream);
 
-  Promise<ReadableStreamBYOBReadResult> read(ArrayBufferView view);
+  Promise<ReadableStreamReadResult> read(ArrayBufferView view);
   undefined releaseLock();
 };
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;
-
-dictionary ReadableStreamBYOBReadResult {
-  (ArrayBufferView or undefined) value;
-  boolean done;
-};
 </xmp>
 
 <h4 id="byob-reader-internal-slots">Internal slots</h4>
@@ -1432,12 +1427,12 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
  1. Let |readIntoRequest| be a new [=read-into request=] with the following [=struct/items=]:
   : [=read-into request/chunk steps=], given |chunk|
   ::
-   1. [=Resolve=] |promise| with «[ "{{ReadableStreamBYOBReadResult/value}}" → |chunk|,
-      "{{ReadableStreamBYOBReadResult/done}}" → false ]».
+   1. [=Resolve=] |promise| with «[ "{{ReadableStreamReadResult/value}}" → |chunk|,
+      "{{ReadableStreamReadResult/done}}" → false ]».
   : [=read-into request/close steps=], given |chunk|
   ::
-   1. [=Resolve=] |promise| with «[ "{{ReadableStreamBYOBReadResult/value}}" → |chunk|,
-      "{{ReadableStreamBYOBReadResult/done}}" → true ]».
+   1. [=Resolve=] |promise| with «[ "{{ReadableStreamReadResult/value}}" → |chunk|,
+      "{{ReadableStreamReadResult/done}}" → true ]».
   : [=read-into request/error steps=], given |e|
   ::
    1. [=Reject=] |promise| with |e|.

--- a/reference-implementation/lib/ReadableStreamBYOBReadResult.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBReadResult.webidl
@@ -1,4 +1,0 @@
-dictionary ReadableStreamBYOBReadResult {
-  (ArrayBufferView or undefined) value;
-  boolean done;
-};

--- a/reference-implementation/lib/ReadableStreamBYOBReader.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBReader.webidl
@@ -2,7 +2,7 @@
 interface ReadableStreamBYOBReader {
   constructor(ReadableStream stream);
 
-  Promise<ReadableStreamBYOBReadResult> read(ArrayBufferView view);
+  Promise<ReadableStreamReadResult> read(ArrayBufferView view);
   undefined releaseLock();
 };
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;

--- a/reference-implementation/lib/ReadableStreamDefaultReadResult.webidl
+++ b/reference-implementation/lib/ReadableStreamDefaultReadResult.webidl
@@ -1,4 +1,0 @@
-dictionary ReadableStreamDefaultReadResult {
-  any value;
-  boolean done;
-};

--- a/reference-implementation/lib/ReadableStreamDefaultReader.webidl
+++ b/reference-implementation/lib/ReadableStreamDefaultReader.webidl
@@ -2,7 +2,7 @@
 interface ReadableStreamDefaultReader {
   constructor(ReadableStream stream);
 
-  Promise<ReadableStreamDefaultReadResult> read();
+  Promise<ReadableStreamReadResult> read();
   undefined releaseLock();
 };
 ReadableStreamDefaultReader includes ReadableStreamGenericReader;

--- a/reference-implementation/lib/ReadableStreamReadResult.webidl
+++ b/reference-implementation/lib/ReadableStreamReadResult.webidl
@@ -1,0 +1,4 @@
+dictionary ReadableStreamReadResult {
+  any value;
+  boolean done;
+};


### PR DESCRIPTION
<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

In https://github.com/whatwg/streams/pull/1214, ReadableStreamBYOBReadResult was changed to have a value property of type `(ArrayBufferView or undefined) value`, since it is possible for the value to be undefined.

However, the WebIDL specification says that is invalid IDL:

> undefined must not be used as the type of an argument in any circumstance (in
> an operation, callback function, constructor operation, etc), or as the type
> of a dictionary member, whether directly or in a union. Instead, use an
> optional argument or a non-required dictionary member.
>
-- https://webidl.spec.whatwg.org/#idl-undefined

So this commit instead removes ReadableStreamBYOBReadResult entirely, in favour of a renamed ReadableStreamDefaultReadResult, which has type `any` for its value.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1752880
   * Safari: …
   * Deno: …
   * Node.js: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1227.html" title="Last updated on Apr 18, 2022, 4:39 PM UTC (128dd56)">Preview</a> | <a href="https://whatpr.org/streams/1227/9538b77...128dd56.html" title="Last updated on Apr 18, 2022, 4:39 PM UTC (128dd56)">Diff</a>