### PR TITLE
add TrasformStream finally callback

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5422,14 +5422,14 @@ dictionary Transformer {
   TransformerStartCallback start;
   TransformerTransformCallback transform;
   TransformerFlushCallback flush;
-  TransformerCancelCallback cancel;
+  TransformerFinallyCallback finally;
   any readableType;
   any writableType;
 };
 
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<undefined> (TransformStreamDefaultController controller);
-callback TransformerCancelCallback = Promise<undefined> (optional any reason);
+callback TransformerFinallyCallback = Promise<undefined> ();
 callback TransformerTransformCallback = Promise<undefined> (any chunk, TransformStreamDefaultController controller);
 </xmp>
 
@@ -5488,16 +5488,9 @@ callback TransformerTransformCallback = Promise<undefined> (any chunk, Transform
    {{Transformer/flush|flush()}}; the stream is already in the process of successfully closing down,
    and terminating it would be counterproductive.)
 
-  <dt><dfn dict-member for="Transformer" lt="cancel">cancel(<var ignore>reason</var>)</dfn></dt>
+  <dt><dfn dict-member for="Transformer" lt="finally">finally()</dfn></dt>
   <dd>
-  <p>A function that is called whenever either the [=readable side=] is cancelled via
-  {{ReadableStream/cancel()|stream.cancel()}} or {{ReadableStreamGenericReader/cancel()|reader.cancel()}},
-  or the [=writable side=] via {{WritableStream/abort()|stream.abort()}} or
-  {{WritableStreamDefaultWriter/abort()|writer.abort()}}. It takes as its argument the same
-  value as was passed to those methods by the consumer.
-
-  <p>For more cancel causes, see {{UnderlyingSource/cancel|cancel()}} for more details.
-  For more abort causes, see {{UnderlyingSink/abort|abort()}} for more details.
+  <p>A function that is called when the transformer ends, be it through closing, erroring, or terminating.
 
  <dt><dfn dict-member for="Transformer">readableType</dfn></dt>
  <dd>
@@ -5672,9 +5665,9 @@ the following table:
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=transformer=]
   <tr>
-   <td><dfn>\[[cancelAlgorithm]]</dfn>
-   <td class="non-normative">A promise-returning algorithm, taking one argument (the cancel reason),
-    which communicates a requested cancelation to the [=transformer=]
+   <td><dfn>\[[finallyAlgorithm]]</dfn>
+   <td class="non-normative">A promise-returning algorithm, which communicates a requested closing
+   or cancellation to the [=transformer=]
   <tr>
    <td><dfn>\[[stream]]</dfn>
    <td class="non-normative">The {{TransformStream}} instance controlled
@@ -5796,12 +5789,12 @@ The following abstract operations operate on {{TransformStream}} instances at a 
  id="transform-stream-error-writable-and-unblock-write">TransformStreamErrorWritableAndUnblockWrite(|stream|,
  |e|)</dfn> performs the following steps:
 
- 1. Perform ! |stream|.[=TransformStream/[[controller]]=].[=TransformStreamDefaultController/[[cancelAlgorithm]]=](|e|).
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.[=TransformStream/[[controller]]=]).
  1. Perform !
     [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=TransformStream/[[writable]]=].[=WritableStream/[[controller]]=], |e|).
  1. If |stream|.[=TransformStream/[[backpressure]]=] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
     false).
+ 1. Perform ! |stream|.[=TransformStream/[[controller]]=].[=TransformStreamDefaultController/[[finallyAlgorithm]]=]().
 
  <p class="note">The [$TransformStreamDefaultSinkWriteAlgorithm$] abstract operation could be
  waiting for the promise stored in the [=TransformStream/[[backpressureChangePromise]]=] slot to
@@ -5828,7 +5821,7 @@ The following abstract operations support the implementaiton of the
 <div algorithm>
  <dfn abstract-op lt="SetUpTransformStreamDefaultController"
  id="set-up-transform-stream-default-controller">SetUpTransformStreamDefaultController(|stream|,
- |controller|, |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|)</dfn> performs the following steps:
+ |controller|, |transformAlgorithm|, |flushAlgorithm|, |finallyAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{TransformStream}}.
  1. Assert: |stream|.[=TransformStream/[[controller]]=] is undefined.
@@ -5837,7 +5830,7 @@ The following abstract operations support the implementaiton of the
  1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to
     |transformAlgorithm|.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to |flushAlgorithm|.
- 1. Set |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[finallyAlgorithm]]=] to |finallyAlgorithm|.
 </div>
 
 <div algorithm>
@@ -5851,7 +5844,7 @@ The following abstract operations support the implementaiton of the
   1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |flushAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
- 1. Let |cancelAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
+ 1. Let |finallyAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
  1. If |transformerDict|["{{Transformer/transform}}"] [=map/exists=], set |transformAlgorithm| to an
     algorithm which takes an argument |chunk| and returns the result of [=invoking=]
     |transformerDict|["{{Transformer/transform}}"] with argument list «&nbsp;|chunk|,
@@ -5859,12 +5852,11 @@ The following abstract operations support the implementaiton of the
  1. If |transformerDict|["{{Transformer/flush}}"] [=map/exists=], set |flushAlgorithm| to an
     algorithm which returns the result of [=invoking=] |transformerDict|["{{Transformer/flush}}"]
     with argument list «&nbsp;|controller|&nbsp;» and [=callback this value=] |transformer|.
- 1. If |transformerDict|["{{Transformer/cancel}}"] [=map/exists=], set |cancelAlgorithm| to an
-    algorithm which takes an argument |reason| and returns the result of [=invoking=]
-    |transformerDict|["{{Transformer/cancel}}"] with argument list «&nbsp;|reason|&nbsp;» and
-    [=callback this value=] |transformer|.
+ 1. If |transformerDict|["{{Transformer/finally}}"] [=map/exists=], set |finallyAlgorithm| to an
+    algorithm which returns the result of [=invoking=] |transformerDict|["{{Transformer/finally}}"]
+    with [=callback this value=] |transformer|.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
-    |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|).
+    |transformAlgorithm|, |flushAlgorithm|, |finallyAlgorithm|).
 </div>
 
 <div algorithm>
@@ -5883,7 +5875,6 @@ The following abstract operations support the implementaiton of the
 
  1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to undefined.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to undefined.
- 1. Set |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -5990,6 +5981,7 @@ side=] of [=transform streams=].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. Return the result of [=reacting=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
+   1. Perform ! |stream|.[=TransformStream/[[controller]]=].[=TransformStreamDefaultController/[[finallyAlgorithm]]=]().
    1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", throw
       |readable|.[=ReadableStream/[[storedError]]=].
    1. Perform !

--- a/index.bs
+++ b/index.bs
@@ -5422,12 +5422,14 @@ dictionary Transformer {
   TransformerStartCallback start;
   TransformerTransformCallback transform;
   TransformerFlushCallback flush;
+  TransformerCancelCallback cancel;
   any readableType;
   any writableType;
 };
 
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<undefined> (TransformStreamDefaultController controller);
+callback TransformerCancelCallback = Promise<undefined> (optional any reason);
 callback TransformerTransformCallback = Promise<undefined> (any chunk, TransformStreamDefaultController controller);
 </xmp>
 
@@ -5485,6 +5487,17 @@ callback TransformerTransformCallback = Promise<undefined> (any chunk, Transform
    {{TransformStreamDefaultController/terminate()|controller.terminate()}} inside
    {{Transformer/flush|flush()}}; the stream is already in the process of successfully closing down,
    and terminating it would be counterproductive.)
+
+  <dt><dfn dict-member for="Transformer" lt="cancel">cancel(<var ignore>reason</var>)</dfn></dt>
+  <dd>
+  <p>A function that is called whenever either the [=readable side=] is cancelled via
+  {{ReadableStream/cancel()|stream.cancel()}} or {{ReadableStreamGenericReader/cancel()|reader.cancel()}},
+  or the [=writable side=] via {{WritableStream/abort()|stream.abort()}} or
+  {{WritableStreamDefaultWriter/abort()|writer.abort()}}. It takes as its argument the same
+  value as was passed to those methods by the consumer.
+
+  <p>For more cancel causes, see {{UnderlyingSource/cancel|cancel()}} for more details.
+  For more abort causes, see {{UnderlyingSink/abort|abort()}} for more details.
 
  <dt><dfn dict-member for="Transformer">readableType</dfn></dt>
  <dd>
@@ -5659,6 +5672,10 @@ the following table:
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=transformer=]
   <tr>
+   <td><dfn>\[[cancelAlgorithm]]</dfn>
+   <td class="non-normative">A promise-returning algorithm, taking one argument (the cancel reason),
+    which communicates a requested cancelation to the [=transformer=]
+  <tr>
    <td><dfn>\[[stream]]</dfn>
    <td class="non-normative">The {{TransformStream}} instance controlled
   <tr>
@@ -5779,6 +5796,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
  id="transform-stream-error-writable-and-unblock-write">TransformStreamErrorWritableAndUnblockWrite(|stream|,
  |e|)</dfn> performs the following steps:
 
+ 1. Perform ! |stream|.[=TransformStream/[[controller]]=].[=TransformStreamDefaultController/[[cancelAlgorithm]]=](|e|).
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.[=TransformStream/[[controller]]=]).
  1. Perform !
     [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=TransformStream/[[writable]]=].[=WritableStream/[[controller]]=], |e|).
@@ -5810,7 +5828,7 @@ The following abstract operations support the implementaiton of the
 <div algorithm>
  <dfn abstract-op lt="SetUpTransformStreamDefaultController"
  id="set-up-transform-stream-default-controller">SetUpTransformStreamDefaultController(|stream|,
- |controller|, |transformAlgorithm|, |flushAlgorithm|)</dfn> performs the following steps:
+ |controller|, |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{TransformStream}}.
  1. Assert: |stream|.[=TransformStream/[[controller]]=] is undefined.
@@ -5819,6 +5837,7 @@ The following abstract operations support the implementaiton of the
  1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to
     |transformAlgorithm|.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to |flushAlgorithm|.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
 </div>
 
 <div algorithm>
@@ -5832,6 +5851,7 @@ The following abstract operations support the implementaiton of the
   1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |flushAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
+ 1. Let |cancelAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
  1. If |transformerDict|["{{Transformer/transform}}"] [=map/exists=], set |transformAlgorithm| to an
     algorithm which takes an argument |chunk| and returns the result of [=invoking=]
     |transformerDict|["{{Transformer/transform}}"] with argument list «&nbsp;|chunk|,
@@ -5839,8 +5859,11 @@ The following abstract operations support the implementaiton of the
  1. If |transformerDict|["{{Transformer/flush}}"] [=map/exists=], set |flushAlgorithm| to an
     algorithm which returns the result of [=invoking=] |transformerDict|["{{Transformer/flush}}"]
     with argument list «&nbsp;|controller|&nbsp;» and [=callback this value=] |transformer|.
+ 1. If |transformerDict|["{{Transformer/cancel}}"] [=map/exists=], set |cancelAlgorithm| to an
+    algorithm which returns the result of [=invoking=] |transformerDict|["{{Transformer/cancel}}"]
+    with argument list «&nbsp;|reason|&nbsp;» and [=callback this value=] |transformer|.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
-    |transformAlgorithm|, |flushAlgorithm|).
+    |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|).
 </div>
 
 <div algorithm>
@@ -5859,6 +5882,7 @@ The following abstract operations support the implementaiton of the
 
  1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to undefined.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to undefined.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=] to undefined.
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -5860,8 +5860,9 @@ The following abstract operations support the implementaiton of the
     algorithm which returns the result of [=invoking=] |transformerDict|["{{Transformer/flush}}"]
     with argument list «&nbsp;|controller|&nbsp;» and [=callback this value=] |transformer|.
  1. If |transformerDict|["{{Transformer/cancel}}"] [=map/exists=], set |cancelAlgorithm| to an
-    algorithm which returns the result of [=invoking=] |transformerDict|["{{Transformer/cancel}}"]
-    with argument list «&nbsp;|reason|&nbsp;» and [=callback this value=] |transformer|.
+    algorithm which takes an argument |reason| and returns the result of [=invoking=]
+    |transformerDict|["{{Transformer/cancel}}"] with argument list «&nbsp;|reason|&nbsp;» and
+    [=callback this value=] |transformer|.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
     |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|).
 </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->
Closes https://github.com/whatwg/streams/issues/1212

The only thing left is what to do in case of the callback throwing/rejecting (and potentially somehow awaiting the callback? unsure if thats necessary).

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno: https://github.com/denoland/deno/pull/14686
   * Node.js: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1231.html" title="Last updated on May 23, 2022, 8:18 PM UTC (d9861f1)">Preview</a> | <a href="https://whatpr.org/streams/1231/e9355ce...d9861f1.html" title="Last updated on May 23, 2022, 8:18 PM UTC (d9861f1)">Diff</a>