### PR TITLE
Clarify: tee is unsafe for independent consumption since it backpressures to the faster consumer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -164,7 +164,8 @@ execute any cancellation mechanism of the [=underlying source=].
 Consumers can also <dfn lt="tee a readable stream">tee</dfn> a readable stream using its
 {{ReadableStream/tee()}} method. This will [=locked to a reader|lock=] the stream, making it
 no longer directly usable; however, it will create two new streams, called <dfn lt="branches of a
-readable stream tee">branches</dfn>, which can be consumed independently.
+readable stream tee">branches</dfn>, which can be consumed independently or in sequence,
+so long as the unconsumed data at the branch that is consumed more slowly fits in memory.
 
 For streams representing bytes, an extended version of the [=readable stream=] is provided to handle
 bytes efficiently, in particular by minimizing copies. The [=underlying source=] for such a readable
@@ -257,9 +258,10 @@ sink=], which gets updated as the ultimate sink finishes writing [=chunks=]. The
 {{ReadableStream/pipeTo()}} method used to construct the chain automatically ensures this
 information propagates back through the [=pipe chain=].
 
-When [=tee a readable stream|teeing=] a readable stream, the [=backpressure=] signals from its two
-[=branches of a readable stream tee|branches=] will aggregate, such that if neither branch is read
+When [=tee a readable stream|teeing=] a readable stream, the [=backpressure=] signals from the
+faster [=branches of a readable stream tee|branch=] will propagate. If neither branch is read
 from, a backpressure signal will be sent to the [=underlying source=] of the original stream.
+Unread data will accumulate without limit onto the buffer of the slower consumed branch.
 
 Piping [=locks=] the readable and writable streams, preventing them from being manipulated for the
 duration of the pipe operation. This allows the implementation to perform important optimizations,
@@ -960,11 +962,13 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
  1. Return ? [$ReadableStreamTee$]([=this=], false).
 
  <div class="example" id="example-tee-and-pipe">
-  Teeing a stream is most useful when you wish to let two independent consumers read from the stream
-  in parallel, perhaps even at different speeds. For example, given a writable stream
+  Teeing a stream is most useful when you wish to let two consumers read from the stream
+  in parallel or in sequence, perhaps even at different speeds,
+  so long as the difference in consumption fits in memory.
+  For example, given a writable stream
   <code>cacheEntry</code> representing an on-disk file, and another writable stream
   <code>httpRequestBody</code> representing an upload to a remote server, you could pipe the same
-  readable stream to both destinations at once:
+  readable stream to both destinations at once assuming that the data fits in memory:
 
   <xmp highlight="js">
   const [forLocal, forRemote] = readableStream.tee();


### PR DESCRIPTION
<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->
Unfortunately, the built-in tee algorithm backpressures to the faster consumer and buffers without limit to the slower consumer. Therefore, it is generally not safe to use when the two branches are read by independent consumers at different speed, since the consumer will eventually run out of memory.

I believe that this was an unfortunate design mistake because it conflicts with the suggestion in [Stream requirements:. You must be able to pipe a stream to more than one writable stream.](https://github.com/whatwg/streams/blob/e9355ce79925947e8eb496563d599c329769d315/Requirements.md#you-must-be-able-to-pipe-a-stream-to-more-than-one-writable-stream) which said, “The tee stream can use a number of strategies to govern how the speed of its outputs affect the backpressure signals it gives off, but  the simplest strategy is to pass aggregate backpressure signals directly up the chain, thus letting the speed of the slowest output determine the speed of the tee.” This also differs from analogous operations in other libraries such as [repeated nodejs Readable.pipe](https://nodejs.org/api/stream.html#readablepipedestination-options) or [akka-streams Source.alsoTo](https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/alsoTo.html) which backpressure to the *slower* consumer and only require a bounded buffer.

As I said in a node-fetch issue https://github.com/node-fetch/node-fetch/issues/1568, I think this unbounded buffering algorithm of `ReadableStream.tee()` from https://github.com/whatwg/streams/pull/311 was a mistake. The built-in operations of a `ReadableStream` should only need a fixed-size buffer. , but at this point it is too late to fix it.

But at least we can clarify the informational text, which implied that it is safe to `tee()` a stream and consume it independently. It is generally not safe to consume a `tee()`’d stream independently unless the difference in consumed data fits in memory.

- [ ] At least two implementers are interested (and none opposed):
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
