### PR TITLE
Fix invalid high water mark for tee branches

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2073,7 +2073,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
  1. Perform ! [$InitializeReadableStream$](|stream|).
  1. Let |controller| be a [=new=] {{ReadableByteStreamController}}.
  1. Perform ? [$SetUpReadableByteStreamController$](|stream|, |controller|, |startAlgorithm|,
-    |pullAlgorithm|, |cancelAlgorithm|, 0, undefined).
+    |pullAlgorithm|, |cancelAlgorithm|, 1, undefined).
  1. Return |stream|.
 
  <p class="note">This abstract operation will throw an exception if and only if the supplied
@@ -6459,7 +6459,7 @@ abstract operations are used to implement these "cross-realm transforms".
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |sizeAlgorithm| be an algorithm that returns 1.
  1. Perform ! [$SetUpReadableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
-    |pullAlgorithm|, |cancelAlgorithm|, 0, |sizeAlgorithm|).
+    |pullAlgorithm|, |cancelAlgorithm|, 1, |sizeAlgorithm|).
 
  <p class="note">Implementations are encouraged to explicitly handle failures from the asserts in
  this algorithm, as the input might come from an untrusted context. Failure to do so could lead to


### PR DESCRIPTION
[strategyHWM](https://streams.spec.whatwg.org/#readablebytestreamcontroller-strategyhwm) must be a positive number because [ReadableStreamDefaultControllerShouldCallPull](https://streams.spec.whatwg.org/#readable-stream-default-controller-should-call-pull) and [ReadableByteStreamControllerShouldCallPull](https://streams.spec.whatwg.org/#readable-byte-stream-controller-should-call-pull) return true when desiredSize > 0, so if [strategyHWM](https://streams.spec.whatwg.org/#readablebytestreamcontroller-strategyhwm) is zero (and thus desiredSize = strategyHWM - queueTotalSize will initially be 0) the tee branches would signal backpressure forever.

As written, `tee()` would signal backpressure forever. If this were the case we could take the opportunity to fix the backpressure behavior to fully backpressure to the slower consumer rather than only partial backpressure to the faster consumer (#1233). But alas it looks like various vendors have fixed this bug already at least somewhat.

* [nodejs](https://github.com/nodejs/node/blob/v18.2.0/lib/internal/webstreams/readablestream.js#L1186) uses strategyHWM=1
* [chromium](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/streams/readable_stream.cc;l=1030;drc=8d6a246c9be4f6b731dc7f6e680b7d5e13a512b5) uses stragegyHWM=1
* from [readableStreamTee](https://github.com/denoland/deno/blob/6a7151539737e4abe1b12095c9e1bc3ed9376f48/ext/web/06_streams.js#L2368), deno apparently creates an always-backpressuring [ReadableByteStreamController](https://github.com/denoland/deno/blob/6a7151539737e4abe1b12095c9e1bc3ed9376f48/ext/web/06_streams.js#L488) (**bug**) but uses strategyHWM=1 for [ReadableByteStreamDefaultController](https://github.com/denoland/deno/blob/6a7151539737e4abe1b12095c9e1bc3ed9376f48/ext/web/06_streams.js#L336)
* Similarly from [ReadableStreamTee](https://searchfox.org/mozilla-central/rev/3419858c997f422e3e70020a46baae7f0ec6dacc/dom/streams/ReadableStream.cpp#819), gecko seems to [CreateReadableStream](https://searchfox.org/mozilla-central/rev/3419858c997f422e3e70020a46baae7f0ec6dacc/dom/streams/ReadableStream.cpp#741) with aHighWaterMark=Nothing which turns into 1.0 for non-byte stream, but for byte streams they [create a ReadableStream with aHighWaterMark=0](https://searchfox.org/mozilla-central/rev/3419858c997f422e3e70020a46baae7f0ec6dacc/dom/streams/ReadableStream.cpp#871) (**bug**)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1234.html" title="Last updated on Jun 1, 2022, 1:42 AM UTC (8894265)">Preview</a> | <a href="https://whatpr.org/streams/1234/e9355ce...8894265.html" title="Last updated on Jun 1, 2022, 1:42 AM UTC (8894265)">Diff</a>