### PR TITLE
Warn about async processing of written/transformed chunks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,9 +19,6 @@ spec:infra; type:dfn; text:list
 spec:html; type:dfn; text:entangle
 spec:html; type:dfn; text:message port post message steps
 spec:html; type:dfn; text:port message queue
-# TODO: remove these once whatwg/html#7414 is merged
-spec:websockets; type:interface; text:WebSocket
-spec:websockets; type:attribute; text:bufferedAmount; for:WebSocket
 </pre>
 
 <pre class="anchors">
@@ -34,7 +31,6 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMASCRIPT
   text: ArrayBuffer; url: #sec-arraybuffer-objects
   text: DataView; url: #sec-dataview-objects
   text: Number; url: #sec-ecmascript-language-types-number-type
-  text: SharedArrayBuffer; url: #sec-sharedarraybuffer-objects
   text: Uint8Array; url: #sec-typedarray-objects
   text: %Object.prototype%; url: #sec-properties-of-the-object-prototype-object
  type: dfn
@@ -4033,28 +4029,11 @@ callback UnderlyingSinkAbortCallback = Promise<undefined> (optional any reason);
    its previous value, only increasing to signal the desire for more chunks once the write
    succeeds.
 
-   <div class="warning" id="warning-async-processing-of-written-chunks">
-    <p>Asynchronous processing of the passed [=chunk=] can be problematic, since the caller of
-    {{WritableStreamDefaultWriter/write()|writer.write()}} might still keep a reference to the
-    chunk and mutate it even after it reaches this {{UnderlyingSink/write|write()}} function. The
-    best practice is to synchronously take a copy of, or possibly
-    [$StructuredSerializeWithTransfer|transfer$], the passed chunk, so that the data written is
-    exactly the same as the data that was supplied by the [=producer=] when they called
-    {{WritableStreamDefaultWriter/write()|writer.write()}}. This is usually done by passing off the
-    chunk to some other web platform API that will create such a copy, but if the underlying sink
-    implementation does not synchronously call such an API itself, it should defensively make a
-    copy (perhaps using {{WindowOrWorkerGlobalScope/structuredClone()}}).
-
-    <p><a href="https://github.com/whatwg/streams/issues/495">Issue #495</a> discusses future
-    extensions to the writable stream API which could formalize the process of transferring, and
-    then reusing the backing memory of, {{Uint8Array}} chunks.
-
-    <p>Alternately, if the stream explicitly accepts shared memory via {{SharedArrayBuffer}}
-    [=chunks=] (or [=chunks=] that are {{BufferSource}} objects backed by a {{SharedArrayBuffer}}),
-    then this is an advertisement that racy behavior is to be expected and that the [=producer=]
-    needs to be extra careful. In such cases, the underlying sink implementer does not need to copy
-    or transfer the {{SharedArrayBuffer}}.
-   </div>
+   <p>Finally, the promise potentially returned by this function is used to ensure that <a
+   href="#write-mutable-chunks">well-behaved</a> [=producers=] do not attempt to mutate the
+   [=chunk=] before it has been fully processed. (This is not guaranteed by any specification
+   machinery, but instead is an informal contract between [=producers=] and the [=underlying
+   sink=].)
 
   <dt><dfn dict-member for="UnderlyingSink" lt="close">close()</dfn></dt>
   <dd>
@@ -4357,6 +4336,11 @@ following table:
   <p>Note that what "success" means is up to the [=underlying sink=]; it might indicate simply that
   the [=chunk=] has been accepted, and not necessarily that it is safely saved to its ultimate
   destination.
+
+  <p id="write-mutable-chunks">If <var ignore>chunk</var> is mutable, [=producers=] are advised to
+  avoid mutating it after passing it to {{WritableStreamDefaultWriter/write()}}, until after the
+  promise returned by {{WritableStreamDefaultWriter/write()}} settles. This ensures that the
+  [=underlying sink=] receives and processes the same value that was passed in.
 </dl>
 
 <div algorithm>
@@ -5487,11 +5471,13 @@ callback TransformerTransformCallback = Promise<undefined> (any chunk, Transform
   success or failure of the transformation. A rejected promise will error both the readable and
   writable sides of the transform stream.
 
+  <p>The promise potentially returned by this function is used to ensure that <a
+  href="#write-mutable-chunks">well-behaved</a> [=producers=] do not attempt to mutate the [=chunk=]
+  before it has been fully transformed. (This is not guaranteed by any specification machinery, but
+  instead is an informal contract between [=producers=] and the [=transformer=].)
+
   <p>If no {{Transformer/transform|transform()}} method is supplied, the identity transform is
   used, which enqueues chunks unchanged from the writable side to the readable side.
-
-  <p class="warning">A similar warning applies for asynchronous processing of the given [=chunk=]
-  as was given <a href="#warning-async-processing-of-written-chunks">for writable streams</a>.
 
   <dt><dfn dict-member for="Transformer" lt="flush">flush(<var ignore>controller</var>)</dfn></dt>
   <dd>
@@ -6952,6 +6938,13 @@ for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) retu
     |writeAlgorithm|, |closeAlgorithmWrapper|, |abortAlgorithmWrapper|, |highWaterMark|,
     |sizeAlgorithm|).
 
+ Other specificatons should be careful when constructing their
+ <i>[=WritableStream/set up/writeAlgorithm=]</i> to avoid [=in parallel=] reads from the given
+ [=chunk=], as such reads can violate the run-to-completion semantics of JavaScript. To avoid this,
+ they can make a synchronous copy or transfer of the given value, using operations such as
+ [$StructuredSerializeWithTransfer$], [=get a copy of the bytes held by the buffer source=], or
+ <a for="ArrayBuffer" lt="transfer">transferring an `ArrayBuffer`</a>.
+
  <div class="example" id="example-set-up-ws">
   Creating a {{WritableStream}} from other specifications is thus a two-step process, like so:
 
@@ -6962,6 +6955,8 @@ for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) retu
  <p class="note">Subclasses of {{WritableStream}} will use the [=WritableStream/set up=] operation
  directly on the [=this=] value inside their constructor steps.</p>
 </div>
+
+<hr>
 
 The following definitions must only be used on {{WritableStream}} instances initialized via the
 above [=WritableStream/set up=] algorithm:
@@ -7047,6 +7042,13 @@ reason.
  1. Let |controller| be a [=new=] {{TransformStreamDefaultController}}.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
     |transformAlgorithmWrapper|, |flushAlgorithmWrapper|).
+
+ Other specificatons should be careful when constructing their
+ <i>[=TransformStream/set up/transformAlgorithm=]</i> to avoid [=in parallel=] reads from the given
+ [=chunk=], as such reads can violate the run-to-completion semantics of JavaScript. To avoid this,
+ they can make a synchronous copy or transfer of the given value, using operations such as
+ [$StructuredSerializeWithTransfer$], [=get a copy of the bytes held by the buffer source=], or
+ <a for="ArrayBuffer" lt="transfer">transferring an `ArrayBuffer`</a>.
 
  <div class="example" id="example-set-up-ts">
   Creating a {{TransformStream}} from other specifications is thus a two-step process, like so:

--- a/index.bs
+++ b/index.bs
@@ -6938,12 +6938,14 @@ for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) retu
     |writeAlgorithm|, |closeAlgorithmWrapper|, |abortAlgorithmWrapper|, |highWaterMark|,
     |sizeAlgorithm|).
 
- Other specificatons should be careful when constructing their
+ Other specifications should be careful when constructing their
  <i>[=WritableStream/set up/writeAlgorithm=]</i> to avoid [=in parallel=] reads from the given
  [=chunk=], as such reads can violate the run-to-completion semantics of JavaScript. To avoid this,
  they can make a synchronous copy or transfer of the given value, using operations such as
  [$StructuredSerializeWithTransfer$], [=get a copy of the bytes held by the buffer source=], or
- <a for="ArrayBuffer" lt="transfer">transferring an `ArrayBuffer`</a>.
+ <a for="ArrayBuffer" lt="transfer">transferring an `ArrayBuffer`</a>. An exception is when the
+ [=chunk=] is a {{SharedArrayBuffer}}, for which it is understood that parallel mutations are a fact
+ of life.
 
  <div class="example" id="example-set-up-ws">
   Creating a {{WritableStream}} from other specifications is thus a two-step process, like so:
@@ -7043,12 +7045,14 @@ reason.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
     |transformAlgorithmWrapper|, |flushAlgorithmWrapper|).
 
- Other specificatons should be careful when constructing their
+ Other specifications should be careful when constructing their
  <i>[=TransformStream/set up/transformAlgorithm=]</i> to avoid [=in parallel=] reads from the given
  [=chunk=], as such reads can violate the run-to-completion semantics of JavaScript. To avoid this,
  they can make a synchronous copy or transfer of the given value, using operations such as
  [$StructuredSerializeWithTransfer$], [=get a copy of the bytes held by the buffer source=], or
- <a for="ArrayBuffer" lt="transfer">transferring an `ArrayBuffer`</a>.
+ <a for="ArrayBuffer" lt="transfer">transferring an `ArrayBuffer`</a>.  An exception is when the
+ [=chunk=] is a {{SharedArrayBuffer}}, for which it is understood that parallel mutations are a fact
+ of life.
 
  <div class="example" id="example-set-up-ts">
   Creating a {{TransformStream}} from other specifications is thus a two-step process, like so:

--- a/index.bs
+++ b/index.bs
@@ -34,6 +34,7 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMASCRIPT
   text: ArrayBuffer; url: #sec-arraybuffer-objects
   text: DataView; url: #sec-dataview-objects
   text: Number; url: #sec-ecmascript-language-types-number-type
+  text: SharedArrayBuffer; url: #sec-sharedarraybuffer-objects
   text: Uint8Array; url: #sec-typedarray-objects
   text: %Object.prototype%; url: #sec-properties-of-the-object-prototype-object
  type: dfn
@@ -4032,6 +4033,29 @@ callback UnderlyingSinkAbortCallback = Promise<undefined> (optional any reason);
    its previous value, only increasing to signal the desire for more chunks once the write
    succeeds.
 
+   <div class="warning" id="warning-async-processing-of-written-chunks">
+    <p>Asynchronous processing of the passed [=chunk=] can be problematic, since the caller of
+    {{WritableStreamDefaultWriter/write()|writer.write()}} might still keep a reference to the
+    chunk and mutate it even after it reaches this {{UnderlyingSink/write|write()}} function. The
+    best practice is to synchronously take a copy of, or possibly
+    [$StructuredSerializeWithTransfer|transfer$], the passed chunk, so that the data written is
+    exactly the same as the data that was supplied by the [=producer=] when they called
+    {{WritableStreamDefaultWriter/write()|writer.write()}}. This is usually done by passing off the
+    chunk to some other web platform API that will create such a copy, but if the underlying sink
+    implementation does not synchronously call such an API itself, it should defensively make a
+    copy (perhaps using {{WindowOrWorkerGlobalScope/structuredClone()}}).
+
+    <p><a href="https://github.com/whatwg/streams/issues/495">Issue #495</a> discusses future
+    extensions to the writable stream API which could formalize the process of transferring, and
+    then reusing the backing memory of, {{Uint8Array}} chunks.
+
+    <p>Alternately, if the stream explicitly accepts shared memory via {{SharedArrayBuffer}}
+    [=chunks=] (or [=chunks=] that are {{BufferSource}} objects backed by a {{SharedArrayBuffer}}),
+    then this is an advertisement that racy behavior is to be expected and that the [=producer=]
+    needs to be extra careful. In such cases, the underlying sink implementer does not need to copy
+    or transfer the {{SharedArrayBuffer}}.
+   </div>
+
   <dt><dfn dict-member for="UnderlyingSink" lt="close">close()</dfn></dt>
   <dd>
    <p>A function that is called after the [=producer=] signals, via
@@ -5465,6 +5489,9 @@ callback TransformerTransformCallback = Promise<undefined> (any chunk, Transform
 
   <p>If no {{Transformer/transform|transform()}} method is supplied, the identity transform is
   used, which enqueues chunks unchanged from the writable side to the readable side.
+
+  <p class="warning">A similar warning applies for asynchronous processing of the given [=chunk=]
+  as was given <a href="#warning-async-processing-of-written-chunks">for writable streams</a>.
 
   <dt><dfn dict-member for="Transformer" lt="flush">flush(<var ignore>controller</var>)</dfn></dt>
   <dd>

--- a/index.bs
+++ b/index.bs
@@ -31,6 +31,7 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMASCRIPT
   text: ArrayBuffer; url: #sec-arraybuffer-objects
   text: DataView; url: #sec-dataview-objects
   text: Number; url: #sec-ecmascript-language-types-number-type
+  text: SharedArrayBuffer; url: #sec-sharedarraybuffer-objects
   text: Uint8Array; url: #sec-typedarray-objects
   text: %Object.prototype%; url: #sec-properties-of-the-object-prototype-object
  type: dfn


### PR DESCRIPTION
See https://github.com/WICG/serial/issues/165.

@reillyeon, WDYT? It's a bit tricky because this section is aimed at web developers, who don't really have access to "in parallel" constructs that modify the byte data. So it doesn't directly talk about how C++ implementers should behave. Do you think this is good enough? Or maybe we should add something to https://streams.spec.whatwg.org/#other-specs-ws-creation too?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1239.html" title="Last updated on Sep 5, 2022, 5:38 AM UTC (7fa1ff5)">Preview</a> | <a href="https://whatpr.org/streams/1239/e9355ce...7fa1ff5.html" title="Last updated on Sep 5, 2022, 5:38 AM UTC (7fa1ff5)">Diff</a>