### PR TITLE
Assert that async iterator's reader is always active

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1012,8 +1012,7 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  ignore>stream</var> and |iterator|, are:
 
  1. Let |reader| be |iterator|'s [=ReadableStream async iterator/reader=].
- 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected
-    with=] a {{TypeError}}.
+ 1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=] is not undefined.
  1. Let |promise| be [=a new promise=].
  1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
   : [=read request/chunk steps=], given |chunk|
@@ -1036,8 +1035,7 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  ignore>stream</var>, |iterator|, and |arg|, are:
 
  1. Let |reader| be |iterator|'s [=ReadableStream async iterator/reader=].
- 1. If |reader|.[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise resolved
-    with=] undefined.
+ 1. Assert: |reader|.[=ReadableStreamGenericReader/[[stream]]=] is not undefined.
  1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=],
     as the async iterator machinery guarantees that any previous calls to `next()` have settled
     before this is called.

--- a/reference-implementation/lib/ReadableStream-impl.js
+++ b/reference-implementation/lib/ReadableStream-impl.js
@@ -119,11 +119,7 @@ exports.implementation = class ReadableStreamImpl {
 
   [idlUtils.asyncIteratorNext](iterator) {
     const reader = iterator._reader;
-    if (reader._stream === undefined) {
-      return promiseRejectedWith(
-        new TypeError('Cannot get the next iteration result once the reader has been released')
-      );
-    }
+    assert(reader._stream !== undefined);
 
     const promise = newPromise();
     const readRequest = {
@@ -143,10 +139,7 @@ exports.implementation = class ReadableStreamImpl {
 
   [idlUtils.asyncIteratorReturn](iterator, arg) {
     const reader = iterator._reader;
-    if (reader._stream === undefined) {
-      return promiseResolvedWith(undefined);
-    }
-
+    assert(reader._stream !== undefined);
     assert(reader._readRequests.length === 0);
 
     if (iterator._preventCancel === false) {


### PR DESCRIPTION
Fixes #1246.

I suppose this is mostly editorial? The behavior shouldn't change, since this check would never have triggered in practice.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1247.html" title="Last updated on Oct 18, 2022, 9:10 PM UTC (28487ba)">Preview</a> | <a href="https://whatpr.org/streams/1247/0fac034...28487ba.html" title="Last updated on Oct 18, 2022, 9:10 PM UTC (28487ba)">Diff</a>