### PR TITLE
Editorial: Add a non-promise version of "fully reading" a stream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6821,7 +6821,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
   1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
    ::
-    1. If |chunk| is not a {{Uint8Array}} object, [=reject=] |promise| with a {{TypeError}} and
+    1. If |chunk| is not a {{Uint8Array}} object, call |failureSteps| with a {{TypeError}} and
        abort these steps.
     1. Append the bytes represented by |chunk| to |bytes|.
     1. [=Read-loop=] given |reader|, |bytes|, |successSteps|, and |failureSteps|.

--- a/index.bs
+++ b/index.bs
@@ -6816,7 +6816,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
  <div algorithm="read-loop">
   For the purposes of the above algorithm, to <dfn>read-loop</dfn> given |reader|, |bytes|,
-  |successSteps|, and |failureSteps:
+  |successSteps|, and |failureSteps|:
 
   1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|

--- a/index.bs
+++ b/index.bs
@@ -6809,7 +6809,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
 <div algorithm="read all bytes">
  <p>To <dfn export for="ReadableStreamDefaultReader" lt="read all bytes|reading all bytes">read all
- bytes as a promise</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given |successSteps|,
+ bytes</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given |successSteps|,
  which is an algorithm accepting a [=byte sequence=], and |failureSteps|, which is an algorithm
  accepting a JavaScript value: [=read-loop=] given |reader|, a new [=byte sequence=],
  |successSteps|, and |failureSteps|.

--- a/index.bs
+++ b/index.bs
@@ -6809,30 +6809,21 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
 <div algorithm="read all bytes">
  <p>To <dfn export for="ReadableStreamDefaultReader" lt="read all bytes|reading all bytes">read all
- bytes as a promise</dfn> from a {{ReadableStreamDefaultReader}} |reader|, perform the following
- steps. The result will be a {{Promise}} for a [=byte sequence=].
-
- 1. Let |promise| be [=a new promise=].
- 1. Let |success steps| given a [=byte sequence=] |data| be to [=resolve=] |promise| with |data|.
- 1. Let |failure steps| given a JavaScript value |error| be to [=reject=] |promise| with |error|.
- 1. [=Consume all bytes=] from |reader| given |success steps| and |failure steps|.
-
- <p>To <dfn export for="ReadableStreamDefaultReader">consume all bytes</dfn> from
- {{ReadableStreamDefaultReader}} |reader|, given |success steps|, which is an algorithm accepting a
- [=byte sequence=], and |failure steps|, which is an algorithm accepting a JavaScript value,
- [=read-loop=] given |reader|, a new [=byte sequence=], |success steps|, and |failure steps|.
+ bytes as a promise</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given |successSteps|,
+ which is an algorithm accepting a [=byte sequence=], and |failureSteps|, which is an algorithm
+ accepting a JavaScript value, [=read-loop=] given |reader|, a new [=byte sequence=],
+ |successSteps|, and |failureSteps|.
 
  <div algorithm="read-loop">
   For the purposes of the above algorithm, to <dfn>read-loop</dfn> given |reader|, |bytes|,
-  |success steps|, and |failure steps|:
+  |successSteps|, and |failureSteps:
 
   1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
    ::
-    1. If |chunk| is not a {{Uint8Array}} object, call |failure steps| with a {{TypeError}} and
-       abort these steps.
-    1. Append the bytes represented by |chunk| to |bytes|.
-    1. [=Read-loop=] given |reader|, |bytes|, |success steps| and |failure steps|.
+    1. [=get a copy of the bytes held by the buffer source|Get a copy of the bytes held by=] |chunk|
+       and append the result to |bytes|.
+    1. [=Read-loop=] given |reader|, |bytes|, |successSteps| and |failureSteps|.
        <p class="note">This recursion could potentially cause a stack overflow if implemented
        directly. Implementations will need to mitigate this, e.g. by using a non-recursive variant
        of this algorithm, or [=queue a microtask|queuing a microtask=], or using a more direct
@@ -6840,10 +6831,10 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
    : [=read request/close steps=]
    ::
-    1. Call |success steps| with |bytes|.
+    1. Call |successSteps| with |bytes|.
    : [=read request/error steps=], given |e|
    ::
-    1. Call |failure steps| with |e|.
+    1. Call |failureSteps| with |e|.
   1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
  </div>
 

--- a/index.bs
+++ b/index.bs
@@ -6821,9 +6821,10 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
   1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
    ::
-    1. [=get a copy of the bytes held by the buffer source|Get a copy of the bytes held by=] |chunk|
-       and append the result to |bytes|.
-    1. [=Read-loop=] given |reader|, |bytes|, |successSteps| and |failureSteps|.
+    1. If |chunk| is not a {{Uint8Array}} object, [=reject=] |promise| with a {{TypeError}} and
+       abort these steps.
+    1. Append the bytes represented by |chunk| to |bytes|.
+    1. [=Read-loop=] given |reader|, |bytes|, |successSteps|, and |failureSteps|.
        <p class="note">This recursion could potentially cause a stack overflow if implemented
        directly. Implementations will need to mitigate this, e.g. by using a non-recursive variant
        of this algorithm, or [=queue a microtask|queuing a microtask=], or using a more direct

--- a/index.bs
+++ b/index.bs
@@ -6809,17 +6809,22 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
 <div algorithm="read all bytes">
  <p>To <dfn export for="ReadableStreamDefaultReader" lt="read all bytes|reading all bytes">read all
- bytes</dfn> from a {{ReadableStreamDefaultReader}} |reader|, perform the following steps. The
- result will be a {{Promise}} for a [=byte sequence=].
+ bytes as a promise</dfn> from a {{ReadableStreamDefaultReader}} |reader|, perform the following
+ steps. The result will be a {{Promise}} for a [=byte sequence=].
 
  1. Let |promise| be [=a new promise=].
- 1. Let |bytes| be an empty [=byte sequence=].
- 1. [=Read-loop=] given |reader|, |bytes|, and |promise|.
- 1. Return |promise|.
+ 1. Let |success steps| given a [=byte sequence=] |data| be to [=resolve=] |promise| with |data|.
+ 1. Let |failure steps| given a JavaScript value |error| be to [=reject=] |promise| with |error|.
+ 1. [=Consume all bytes=] from |reader| given |success steps| and |failure steps|.
+
+ <p>To <dfn export for="ReadableStreamDefaultReader">consume all bytes</dfn> from
+ {{ReadableStreamDefaultReader}} |reader|, given |success steps|, which is an algorithm accepting a
+ [=byte sequence=], and |failure steps|, which is an algorithm accepting a JavaScript value,
+ [=read-loop=] given |reader|, a new [=byte sequence=], |success steps|, and |failure steps|.
 
  <div algorithm="read-loop">
-  For the purposes of the above algorithm, to <dfn>read-loop</dfn> given |reader|, |bytes|, and
-  |promise|:
+  For the purposes of the above algorithm, to <dfn>read-loop</dfn> given |reader|, |bytes|,
+  |success steps|, and |failure steps|:
 
   1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
@@ -6827,7 +6832,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
     1. If |chunk| is not a {{Uint8Array}} object, [=reject=] |promise| with a {{TypeError}} and
        abort these steps.
     1. Append the bytes represented by |chunk| to |bytes|.
-    1. [=Read-loop=] given |reader|, |bytes|, and |promise|.
+    1. [=Read-loop=] given |reader|, |bytes|, |success steps| and |failure steps|.
        <p class="note">This recursion could potentially cause a stack overflow if implemented
        directly. Implementations will need to mitigate this, e.g. by using a non-recursive variant
        of this algorithm, or [=queue a microtask|queuing a microtask=], or using a more direct
@@ -6835,10 +6840,10 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
    : [=read request/close steps=]
    ::
-    1. [=Resolve=] |promise| with |bytes|.
+    1. Call |success steps| with |bytes|.
    : [=read request/error steps=], given |e|
    ::
-    1. [=Reject=] |promise| with |e|.
+    1. Call |failure steps| with |e|.
   1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
  </div>
 

--- a/index.bs
+++ b/index.bs
@@ -6811,7 +6811,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
  <p>To <dfn export for="ReadableStreamDefaultReader" lt="read all bytes|reading all bytes">read all
  bytes as a promise</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given |successSteps|,
  which is an algorithm accepting a [=byte sequence=], and |failureSteps|, which is an algorithm
- accepting a JavaScript value, [=read-loop=] given |reader|, a new [=byte sequence=],
+ accepting a JavaScript value: [=read-loop=] given |reader|, a new [=byte sequence=],
  |successSteps|, and |failureSteps|.
 
  <div algorithm="read-loop">

--- a/index.bs
+++ b/index.bs
@@ -6829,7 +6829,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
   1. Let |readRequest| be a new [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
    ::
-    1. If |chunk| is not a {{Uint8Array}} object, [=reject=] |promise| with a {{TypeError}} and
+    1. If |chunk| is not a {{Uint8Array}} object, call |failure steps| with a {{TypeError}} and
        abort these steps.
     1. Append the bytes represented by |chunk| to |bytes|.
     1. [=Read-loop=] given |reader|, |bytes|, |success steps| and |failure steps|.


### PR DESCRIPTION
This makes it easier for non-JS consumers of streams, like the Fetch specs, to use streams without a JS
execution context.

See https://github.com/whatwg/fetch/issues/1568

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1250.html" title="Last updated on Dec 13, 2022, 7:26 AM UTC (52dc6af)">Preview</a> | <a href="https://whatpr.org/streams/1250/839a5a6...52dc6af.html" title="Last updated on Dec 13, 2022, 7:26 AM UTC (52dc6af)">Diff</a>