### PR TITLE
Add an abstraction to pull from buffer into ReadableStream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6763,7 +6763,7 @@ mark=] is greater than zero.
     [=BufferSource/byte length=].
  1. Let |extractSize| be the smaller value of |available| and |desiredSize|.
  1. Let |bytes| be the result of extracting |extractSize| of bytes from |buffer|.
- 1. If |stream|s [=ReadableStream/current BYOB request view=] is non-null, then:
+ 1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then:
   1. [=ArrayBufferView/Write=] |bytes| into |stream|'s
      [=ReadableStream/current BYOB request view=].
   1. Perform ? [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],

--- a/index.bs
+++ b/index.bs
@@ -6752,6 +6752,29 @@ mark=] is greater than zero.
      [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=], |chunk|).
 </div>
 
+<div algorithm>
+ To <dfn export for="ReadableStream">pull from buffer</dfn> |buffer| into a
+ {{ReadableStream}} |stream|:
+
+ 1. Let |available| be the size of |buffer|.
+ 1. Let |desiredSize| be |available|.
+ 1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then set
+    |desiredSize| to |stream|'s [=ReadableStream/current BYOB request view=]'s
+    [=BufferSource/byte length=].
+ 1. Let |extractSize| be the smaller value of |available| and |desiredSize|.
+ 1. Let |bytes| be the result of extracting |extractSize| of bytes from |buffer|.
+ 1. If |stream|s [=ReadableStream/current BYOB request view=] is non-null, then:
+  1. [=ArrayBufferView/write=] |bytes| into |stream|'s
+     [=ReadableStream/current BYOB request view=].
+  1. Perform ? [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
+     |bytes|).
+ 1. Otherwise,
+  1. Set |view| to the result of [=ArrayBufferView/create|creating=] a
+     {{Uint8Array}} from |bytes| in |stream|'s [=relevant Realm=].
+  1. Perform ?
+     [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=], |view|).
+</div>
+
 <hr>
 
 The following algorithm must only be used on {{ReadableStream}} instances initialized via the above

--- a/index.bs
+++ b/index.bs
@@ -6753,8 +6753,8 @@ mark=] is greater than zero.
 </div>
 
 <div algorithm>
- To <dfn export for="ReadableStream">pull from buffer</dfn> |buffer| into a
- {{ReadableStream}} |stream|:
+ To <dfn export for="ReadableStream">pull from buffer</dfn> |buffer| into a {{ReadableStream}}
+ |stream|:
 
  1. Let |available| be the size of |buffer|.
  1. Let |desiredSize| be |available|.

--- a/index.bs
+++ b/index.bs
@@ -6752,33 +6752,9 @@ mark=] is greater than zero.
      [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=], |chunk|).
 </div>
 
-<div algorithm>
- To <dfn export for="ReadableStream">pull from bytes</dfn> with a [=byte sequence=] |bytes| into a
- {{ReadableStream}} |stream|:
-
- 1. Let |available| be the [=byte sequence/length=] of |bytes|.
- 1. Let |desiredSize| be |available|.
- 1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then set
-    |desiredSize| to |stream|'s [=ReadableStream/current BYOB request view=]'s
-    [=BufferSource/byte length=].
- 1. Let |pullSize| be the smaller value of |available| and |desiredSize|.
- 1. Let |pulled| be the first |pullSize| bytes from |bytes|.
- 1. Remove the first |pullSize| bytes from |bytes|.
- 1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then:
-  1. [=ArrayBufferView/Write=] |pulled| into |stream|'s
-     [=ReadableStream/current BYOB request view=].
-  1. Perform ? [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
-     |pullSize|).
- 1. Otherwise,
-  1. Set |view| to the result of [=ArrayBufferView/create|creating=] a
-     {{Uint8Array}} from |pulled| in |stream|'s [=relevant Realm=].
-  1. Perform ?
-     [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=], |view|).
-</div>
-
 <hr>
 
-The following algorithm must only be used on {{ReadableStream}} instances initialized via the above
+The following algorithms must only be used on {{ReadableStream}} instances initialized via the above
 [=ReadableStream/set up with byte reading support=] algorithm:
 
 <div algorithm>
@@ -6808,10 +6784,38 @@ They should only [=ArrayBufferView/create=] a new {{ArrayBufferView}} to pass to
 [=ReadableStream/enqueue=] when the [=ReadableStream/current BYOB request view=] is null, or when
 they have more bytes on hand than the [=ReadableStream/current BYOB request view=]'s
 [=BufferSource/byte length=]. This avoids unnecessary copies and better respects the wishes of the
-stream's [=consumer=].
+stream's [=consumer=]. The following [=ReadableStream/pull from bytes=] algorithm implements these
+requirements, for the common case where bytes are derived from a [=byte sequence=] that serves as
+the specification-level representation of an [=underlying byte source=].
+
+<div algorithm>
+ To <dfn export for="ReadableStream">pull from bytes</dfn> with a [=byte sequence=] |bytes| into a
+ {{ReadableStream}} |stream|:
+
+ 1. Assert: |stream|.[=ReadableStream/[[controller]]=] [=implements=]
+    {{ReadableByteStreamController}}.
+ 1. Let |available| be |bytes|'s [=byte sequence/length=].
+ 1. Let |desiredSize| be |available|.
+ 1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then set |desiredSize|
+    to |stream|'s [=ReadableStream/current BYOB request view=]'s [=BufferSource/byte length=].
+ 1. Let |pullSize| be the smaller value of |available| and |desiredSize|.
+ 1. Let |pulled| be the first |pullSize| bytes of |bytes|.
+ 1. Remove the first |pullSize| bytes from |bytes|.
+ 1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then:
+  1. [=ArrayBufferView/Write=] |pulled| into |stream|'s [=ReadableStream/current BYOB request
+     view=].
+  1. Perform ? [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
+     |pullSize|).
+ 1. Otherwise,
+  1. Set |view| to the result of [=ArrayBufferView/create|creating=] a {{Uint8Array}} from |pulled|
+     in |stream|'s [=relevant Realm=].
+  1. Perform ? [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=],
+     |view|).
+</div>
 
 Specifications must not [=ArrayBuffer/write=] into the [=ReadableStream/current BYOB request view=]
-after [=ReadableStream/closing=] the corresponding {{ReadableStream}}.
+or [=ReadableStream/pull from bytes=] after [=ReadableStream/closing=] the corresponding
+{{ReadableStream}}.
 
 <h4 id="other-specs-rs-reading">Reading</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -6753,24 +6753,25 @@ mark=] is greater than zero.
 </div>
 
 <div algorithm>
- To <dfn export for="ReadableStream">pull from buffer</dfn> |buffer| into a {{ReadableStream}}
- |stream|:
+ To <dfn export for="ReadableStream">pull from bytes</dfn> with a [=byte sequence=] |bytes| into a
+ {{ReadableStream}} |stream|:
 
- 1. Let |available| be the size of |buffer|.
+ 1. Let |available| be the [=byte sequence/length=] of |bytes|.
  1. Let |desiredSize| be |available|.
  1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then set
     |desiredSize| to |stream|'s [=ReadableStream/current BYOB request view=]'s
     [=BufferSource/byte length=].
- 1. Let |extractSize| be the smaller value of |available| and |desiredSize|.
- 1. Let |bytes| be the result of extracting |extractSize| of bytes from |buffer|.
+ 1. Let |pullSize| be the smaller value of |available| and |desiredSize|.
+ 1. Let |pulled| be the first |pullSize| bytes from |bytes|.
+ 1. Remove the first |pullSize| bytes from |bytes|.
  1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then:
-  1. [=ArrayBufferView/Write=] |bytes| into |stream|'s
+  1. [=ArrayBufferView/Write=] |pulled| into |stream|'s
      [=ReadableStream/current BYOB request view=].
   1. Perform ? [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
-     |bytes|).
+     |pullSize|).
  1. Otherwise,
   1. Set |view| to the result of [=ArrayBufferView/create|creating=] a
-     {{Uint8Array}} from |bytes| in |stream|'s [=relevant Realm=].
+     {{Uint8Array}} from |pulled| in |stream|'s [=relevant Realm=].
   1. Perform ?
      [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=], |view|).
 </div>

--- a/index.bs
+++ b/index.bs
@@ -6784,9 +6784,13 @@ They should only [=ArrayBufferView/create=] a new {{ArrayBufferView}} to pass to
 [=ReadableStream/enqueue=] when the [=ReadableStream/current BYOB request view=] is null, or when
 they have more bytes on hand than the [=ReadableStream/current BYOB request view=]'s
 [=BufferSource/byte length=]. This avoids unnecessary copies and better respects the wishes of the
-stream's [=consumer=]. The following [=ReadableStream/pull from bytes=] algorithm implements these
-requirements, for the common case where bytes are derived from a [=byte sequence=] that serves as
-the specification-level representation of an [=underlying byte source=].
+stream's [=consumer=].
+
+The following [=ReadableStream/pull from bytes=] algorithm implements these requirements, for the
+common case where bytes are derived from a [=byte sequence=] that serves as the specification-level
+representation of an [=underlying byte source=]. Note that it is conservative and leaves bytes in
+the [=byte sequence=], instead of aggressively [=ReadableStream/enqueueing=] them, so callers of
+this algorithm might want to use the number of remaining bytes as a [=backpressure=] signal.
 
 <div algorithm>
  To <dfn export for="ReadableStream">pull from bytes</dfn> with a [=byte sequence=] |bytes| into a

--- a/index.bs
+++ b/index.bs
@@ -6764,7 +6764,7 @@ mark=] is greater than zero.
  1. Let |extractSize| be the smaller value of |available| and |desiredSize|.
  1. Let |bytes| be the result of extracting |extractSize| of bytes from |buffer|.
  1. If |stream|s [=ReadableStream/current BYOB request view=] is non-null, then:
-  1. [=ArrayBufferView/write=] |bytes| into |stream|'s
+  1. [=ArrayBufferView/Write=] |bytes| into |stream|'s
      [=ReadableStream/current BYOB request view=].
   1. Perform ? [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
      |bytes|).


### PR DESCRIPTION
<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Intended to fix the Fetch spec issue https://github.com/whatwg/fetch/issues/1610.

- [x] At least two implementers are interested (and none opposed): N/A, just moving existing steps from Fetch to Streams
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at: Same
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams-1/1263.html" title="Last updated on Apr 5, 2023, 1:21 AM UTC (15e9e15)">Preview</a> | <a href="https://whatpr.org/streams/1263/b45c0c5...15e9e15.html" title="Last updated on Apr 5, 2023, 1:21 AM UTC (15e9e15)">Diff</a>