### PR TITLE
Editorial: update WPT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,6 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: 18
     - run: npm install
     - run: npm test

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -46,6 +46,7 @@ async function main() {
     rootURL: 'streams/',
     setup(window) {
       window.queueMicrotask = queueMicrotask;
+      window.structuredClone = structuredClone;
       window.fetch = async function (url) {
         const filePath = path.join(wptPath, url);
         if (!filePath.startsWith(wptPath)) {


### PR DESCRIPTION
It looks like it's been a while since we synced the reference implementation with the latest WPT. This aims to fix that.

The following errors came up:
* `Error: Unexpected URL: /common/gc.js`: I opened https://github.com/domenic/wpt-runner/pull/27 to include this file.
* `structuredClone is not defined`: I expose this function in the test runner, and bumped the CI to Node 18.
* `enqueue() must not synchronously call write algorithm`: This test was added in https://github.com/web-platform-tests/wpt/pull/39103, but was not tested against the reference implementation. I'm not entirely sure what the intention was here: does the spec need to be updated for this? 😕