### PR TITLE
Editorial: Add missing argument to cancel and abort wrapper algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6631,9 +6631,9 @@ to grow organically as needed.
      otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
- 1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps:
-  1. Let |result| be the result of running |cancelAlgorithm|, if |cancelAlgorithm| was given, or
-     null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
+ 1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps given a value |reason|:
+  1. Let |result| be the result of running |cancelAlgorithm| given |reason|, if |cancelAlgorithm| was
+     given, or null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. If |sizeAlgorithm| was not given, then set it to an algorithm that returns 1.
@@ -6659,9 +6659,9 @@ to grow organically as needed.
      otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
- 1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps:
-  1. Let |result| be the result of running |cancelAlgorithm|, if |cancelAlgorithm| was given, or
-     null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
+ 1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps given a value |reason|:
+  1. Let |result| be the result of running |cancelAlgorithm| given |reason|, if |cancelAlgorithm| was
+     given, or null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. Perform ! [$InitializeReadableStream$](|stream|).
@@ -6954,9 +6954,9 @@ for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) retu
      null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
- 1. Let |abortAlgorithmWrapper| be an algorithm that runs these steps:
-  1. Let |result| be the result of running |abortAlgorithm|, if |abortAlgorithm| was given, or
-     null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
+ 1. Let |abortAlgorithmWrapper| be an algorithm that runs these steps given a value |reason|:
+  1. Let |result| be the result of running |abortAlgorithm| given |reason|, if |abortAlgorithm| was
+     given, or null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. If |sizeAlgorithm| was not given, then set it to an algorithm that returns 1.


### PR DESCRIPTION
These algorithms are missing the `reason` argument that is taken elsewhere in the spec. Closes #1241, closes #1273


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/whatwg-streams/1275.html" title="Last updated on Apr 20, 2023, 4:09 PM UTC (79ff21a)">Preview</a> | <a href="https://whatpr.org/streams/1275/2942e89...79ff21a.html" title="Last updated on Apr 20, 2023, 4:09 PM UTC (79ff21a)">Diff</a>