### PR TITLE
Editorial: account for removal of AbortSignal's follow

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6999,7 +6999,7 @@ above [=WritableStream/set up=] algorithm:
 |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[signal]]=].
 Specifications can [=AbortSignal/add=] or [=AbortSignal/remove=] algorithms to this
 {{AbortSignal}}, or consult whether it is [=AbortSignal/aborted=] and its [=AbortSignal/abort
-reason=]. Specifications should not [=AbortSignal/signal abort=], as that would interfere with the
+reason=]. Specifications must not [=AbortSignal/signal abort=], as that would interfere with the
 normal use of this signal to respond to the stream being [=abort a writable stream|aborted=].
 
 <p class="note">The usual usage is, after [=WritableStream/setting up=] the {{WritableStream}},

--- a/index.bs
+++ b/index.bs
@@ -6999,9 +6999,8 @@ above [=WritableStream/set up=] algorithm:
 |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[signal]]=].
 Specifications can [=AbortSignal/add=] or [=AbortSignal/remove=] algorithms to this
 {{AbortSignal}}, or consult whether it is [=AbortSignal/aborted=] and its [=AbortSignal/abort
-reason=]. Specifications should not [=AbortSignal/signal abort=] or make it [=AbortSignal/follow=]
-another {{AbortSignal}}, as that would interfere with the normal use of this signal to respond to
-the stream being [=abort a writable stream|aborted=].
+reason=]. Specifications should not [=AbortSignal/signal abort=], as that would interfere with the
+normal use of this signal to respond to the stream being [=abort a writable stream|aborted=].
 
 <p class="note">The usual usage is, after [=WritableStream/setting up=] the {{WritableStream}},
 [=AbortSignal/add=] an algorithm to its [=WritableStream/signal=], which aborts any ongoing write


### PR DESCRIPTION
"Follow" is being removed in https://github.com/whatwg/dom/pull/1152.

cc: @annevk. AFAIK this is the [only other use](https://dontcallmedom.github.io/webdex/f.html#follow%40%40AbortSignal%40dfn) aside from fetch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1277.html" title="Last updated on May 3, 2023, 6:25 PM UTC (d4a04ff)">Preview</a> | <a href="https://whatpr.org/streams/1277/2942e89...d4a04ff.html" title="Last updated on May 3, 2023, 6:25 PM UTC (d4a04ff)">Diff</a>