### PR TITLE
Use an AbortController instead of signaling abort on AbortSignal

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4446,6 +4446,10 @@ the following table:
    <td class="non-normative">A promise-returning algorithm, taking one argument (the abort reason),
    which communicates a requested abort to the [=underlying sink=]
   <tr>
+   <td><dfn>\[[abortController]]</dfn>
+   <td class="non-normative">An {{AbortController}} that can be used to abort the pending write or
+   close operation when the stream is [=abort a writable stream|aborted=].
+  <tr>
    <td><dfn>\[[closeAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=underlying sink=]
@@ -4456,10 +4460,6 @@ the following table:
    <td><dfn>\[[queueTotalSize]]</dfn>
    <td class="non-normative">The total size of all the chunks stored in
    [=WritableStreamDefaultController/[[queue]]=] (see [[#queue-with-sizes]])
-  <tr>
-   <td><dfn>\[[abortController]]</dfn>
-   <td class="non-normative">An {{AbortController}} that can be used to abort the pending write or
-   close operation when the stream is [=abort a writable stream|aborted=].
   <tr>
    <td><dfn>\[[started]]</dfn>
    <td class="non-normative">A boolean flag indicating whether the [=underlying sink=] has finished
@@ -4508,7 +4508,8 @@ closed. It is only used internally, and is never exposed to web developers.
  The <dfn id="ws-default-controller-signal" attribute
  for="WritableStreamDefaultController">signal</dfn> getter steps are:
 
- 1. Return [=this=].[=WritableStreamDefaultController/[[abortController]]=].{{AbortController/signal}}.
+ 1. Return [=this=].[=WritableStreamDefaultController/[[abortController]]=]'s
+    [=AbortController/signal=].
 </div>
 
 <div algorithm>
@@ -6997,9 +6998,10 @@ above [=WritableStream/set up=] algorithm:
 [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=WritableStream/[[controller]]=], |e|).
 
 <p>The <dfn export for="WritableStream">signal</dfn> of a {{WritableStream}} |stream| is
-|stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[abortController]]=].{{AbortController/signal}}.
-Specifications can [=AbortSignal/add=] or [=AbortSignal/remove=] algorithms to this {{AbortSignal}},
-or consult whether it is [=AbortSignal/aborted=] and its [=AbortSignal/abort reason=].
+|stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[abortController]]=]'s
+[=AbortController/signal=]. Specifications can [=AbortSignal/add=] or [=AbortSignal/remove=]
+algorithms to this {{AbortSignal}}, or consult whether it is [=AbortSignal/aborted=] and its
+[=AbortSignal/abort reason=].
 
 <p class="note">The usual usage is, after [=WritableStream/setting up=] the {{WritableStream}},
 [=AbortSignal/add=] an algorithm to its [=WritableStream/signal=], which aborts any ongoing write

--- a/index.bs
+++ b/index.bs
@@ -4457,8 +4457,8 @@ the following table:
    <td class="non-normative">The total size of all the chunks stored in
    [=WritableStreamDefaultController/[[queue]]=] (see [[#queue-with-sizes]])
   <tr>
-   <td><dfn>\[[signal]]</dfn>
-   <td class="non-normative">An {{AbortSignal}} that can be used to abort the pending write or
+   <td><dfn>\[[abortController]]</dfn>
+   <td class="non-normative">An {{AbortController}} that can be used to abort the pending write or
    close operation when the stream is [=abort a writable stream|aborted=].
   <tr>
    <td><dfn>\[[started]]</dfn>
@@ -4508,7 +4508,7 @@ closed. It is only used internally, and is never exposed to web developers.
  The <dfn id="ws-default-controller-signal" attribute
  for="WritableStreamDefaultController">signal</dfn> getter steps are:
 
- 1. Return [=this=].[=WritableStreamDefaultController/[[signal]]=].
+ 1. Return [=this=].[=WritableStreamDefaultController/[[abortController]]=].{{AbortController/signal}}.
 </div>
 
 <div algorithm>
@@ -4654,13 +4654,13 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 
  1. If |stream|.[=WritableStream/[[state]]=] is "`closed`" or "`errored`", return
     [=a promise resolved with=] undefined.
- 1. [=Signal abort=] on
-    |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[signal]]=] with
-    |reason|.
+ 1. [=AbortController/Signal abort=] on
+    |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[abortController]]=]
+    with |reason|.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`closed`" or "`errored`", return [=a promise resolved with=] undefined.
-    <p class="note">We re-check the state because [=signaling abort=] runs author code and that might
-    have changed the state.
+    <p class="note">We re-check the state because [=AbortController/signaling abort=] runs author
+    code and that might have changed the state.
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is not undefined, return
     |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort request/promise=].
  1. Assert: |state| is "`writable`" or "`erroring`".
@@ -5084,7 +5084,8 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=WritableStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
  1. Perform ! [$ResetQueue$](|controller|).
- 1. Set |controller|.[=WritableStreamDefaultController/[[signal]]=] to a new {{AbortSignal}}.
+ 1. Set |controller|.[=WritableStreamDefaultController/[[abortController]]=] to a new
+    {{AbortController}}.
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
  1. Set |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] to
     |sizeAlgorithm|.
@@ -6996,11 +6997,9 @@ above [=WritableStream/set up=] algorithm:
 [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=WritableStream/[[controller]]=], |e|).
 
 <p>The <dfn export for="WritableStream">signal</dfn> of a {{WritableStream}} |stream| is
-|stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[signal]]=].
-Specifications can [=AbortSignal/add=] or [=AbortSignal/remove=] algorithms to this
-{{AbortSignal}}, or consult whether it is [=AbortSignal/aborted=] and its [=AbortSignal/abort
-reason=]. Specifications must not [=AbortSignal/signal abort=], as that would interfere with the
-normal use of this signal to respond to the stream being [=abort a writable stream|aborted=].
+|stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[abortController]]=].{{AbortController/signal}}.
+Specifications can [=AbortSignal/add=] or [=AbortSignal/remove=] algorithms to this {{AbortSignal}},
+or consult whether it is [=AbortSignal/aborted=] and its [=AbortSignal/abort reason=].
 
 <p class="note">The usual usage is, after [=WritableStream/setting up=] the {{WritableStream}},
 [=AbortSignal/add=] an algorithm to its [=WritableStream/signal=], which aborts any ongoing write


### PR DESCRIPTION
For https://github.com/whatwg/dom/issues/1194 (and follow-up from https://github.com/whatwg/streams/pull/1277).

 - Replace WritableStreamDefaultController's [[signal]] with [[abortController]], using this abort controller's signal where [[signal]] was used. Signal abort on [[abortController]] rather than the [[signal]].
 - Remove the note/warning about specs not signaling abort on the WritableStream's signal, since this won't be allowed once AbortSignal's "signal abort" no longer exported.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1279.html" title="Last updated on May 25, 2023, 4:52 PM UTC (0303684)">Preview</a> | <a href="https://whatpr.org/streams/1279/cf7670a...0303684.html" title="Last updated on May 25, 2023, 4:52 PM UTC (0303684)">Diff</a>