### PR TITLE
Update WPT tests to ToT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,6 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: 18
     - run: npm install
     - run: npm test

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -19,6 +19,6 @@
     "minimatch": "^3.0.4",
     "opener": "^1.5.1",
     "webidl2js": "^16.2.0",
-    "wpt-runner": "^4.0.0"
+    "wpt-runner": "^5.0.0"
   }
 }

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -48,6 +48,7 @@ async function main() {
     rootURL: 'streams/',
     setup(window) {
       window.queueMicrotask = queueMicrotask;
+      window.structuredClone = structuredClone;
       window.fetch = async function (url) {
         const filePath = path.join(wptPath, url);
         if (!filePath.startsWith(wptPath)) {

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -36,6 +36,8 @@ async function main() {
     // These tests use ArrayBuffers backed by WebAssembly.Memory objects, which *should* be non-transferable.
     // However, our TransferArrayBuffer implementation cannot detect these, and will incorrectly "transfer" them anyway.
     'readable-byte-streams/non-transferable-buffers.any.html'
+    'readable-streams/garbage-collection.any.html', // FIXME: We should reenable this test, once the server provides common/gc.js.
+    'piping/general-addition.any.html' // FIXME: reenable this test as part of https://github.com/whatwg/streams/issues/1243.
   ];
   const anyTestPattern = /\.any\.html$/;
 

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -35,7 +35,7 @@ async function main() {
   const excludeGlobs = [
     // These tests use ArrayBuffers backed by WebAssembly.Memory objects, which *should* be non-transferable.
     // However, our TransferArrayBuffer implementation cannot detect these, and will incorrectly "transfer" them anyway.
-    'readable-byte-streams/non-transferable-buffers.any.html'
+    'readable-byte-streams/non-transferable-buffers.any.html',
     'readable-streams/garbage-collection.any.html', // FIXME: We should reenable this test, once the server provides common/gc.js.
     'piping/general-addition.any.html' // FIXME: reenable this test as part of https://github.com/whatwg/streams/issues/1243.
   ];

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -36,7 +36,7 @@ async function main() {
     // These tests use ArrayBuffers backed by WebAssembly.Memory objects, which *should* be non-transferable.
     // However, our TransferArrayBuffer implementation cannot detect these, and will incorrectly "transfer" them anyway.
     'readable-byte-streams/non-transferable-buffers.any.html',
-    'readable-streams/garbage-collection.any.html', // FIXME: We should reenable this test, once the server provides common/gc.js.
+    'readable-streams/garbage-collection.any.html', // FIXME: reenable this test once server provides common/gc.js.
     'piping/general-addition.any.html' // FIXME: reenable this test as part of https://github.com/whatwg/streams/issues/1243.
   ];
   const anyTestPattern = /\.any\.html$/;

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -52,7 +52,7 @@ async function main() {
     rootURL: 'streams/',
     setup(window) {
       window.queueMicrotask = queueMicrotask;
-      window.structuredClone = structuredClone;
+      window.structuredClone = globalThis.structuredClone;
       window.fetch = async function (url) {
         const filePath = path.join(wptPath, url);
         if (!filePath.startsWith(wptPath)) {

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -37,7 +37,6 @@ async function main() {
     // These tests use ArrayBuffers backed by WebAssembly.Memory objects, which *should* be non-transferable.
     // However, our TransferArrayBuffer implementation cannot detect these, and will incorrectly "transfer" them anyway.
     'readable-byte-streams/non-transferable-buffers.any.html',
-    'readable-streams/garbage-collection.any.html', // FIXME: reenable this test once server provides common/gc.js.
     'readable-streams/owning-type-message-port.any.html', // disabled due to MessagePort use.
     'readable-streams/owning-type-video-frame.any.html', // disabled due to VideoFrame use.
     'readable-streams/owning-type.any.html', // FIXME: reenable this test once owning type PR lands.

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -33,11 +33,15 @@ async function main() {
 
   const filterGlobs = process.argv.length >= 3 ? process.argv.slice(2) : ['**/*.html'];
   const excludeGlobs = [
+    'piping/general-addition.any.html', // FIXME: reenable this test as part of https://github.com/whatwg/streams/issues/1243.
     // These tests use ArrayBuffers backed by WebAssembly.Memory objects, which *should* be non-transferable.
     // However, our TransferArrayBuffer implementation cannot detect these, and will incorrectly "transfer" them anyway.
     'readable-byte-streams/non-transferable-buffers.any.html',
     'readable-streams/garbage-collection.any.html', // FIXME: reenable this test once server provides common/gc.js.
-    'piping/general-addition.any.html' // FIXME: reenable this test as part of https://github.com/whatwg/streams/issues/1243.
+    'readable-streams/owning-type-message-port.any.html', // disabled due to MessagePort use.
+    'readable-streams/owning-type-video-frame.any.html', // disabled due to VideoFrame use.
+    'readable-streams/owning-type.any.html', // FIXME: reenable this test once owning type PR lands.
+    'transferable/transform-stream-members.any.html' // FIXME: reenable if structuredClone is aligned.
   ];
   const anyTestPattern = /\.any\.html$/;
 


### PR DESCRIPTION
We skip two test files until the test infra and the spec/ref implementation gets updated.
This is equivalent to https://github.com/whatwg/streams/pull/1264, except for skipping the tests.