### PR TITLE
TransformStream cleanup using "Transformer.cancel"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7197,8 +7197,7 @@ reason.
  for="TransformStream/set up"><var>transformAlgorithm</var></dfn>, an optional algorithm <dfn
  export for="TransformStream/set up"><var>flushAlgorithm</var></dfn>, and an optional algorithm <dfn
  export for="TransformStream/set up"><var>cancelAlgorithm</var></dfn>, perform the following steps.
- |transformAlgorithm|, if given, |flushAlgorithm|, and, if given, |cancelAlgorithm|, may return a
- promise.
+ |transformAlgorithm|, if given, |flushAlgorithm| and |cancelAlgorithm|, may return a promise.
 
  1. Let |writableHighWaterMark| be 1.
  1. Let |writableSizeAlgorithm| be an algorithm that returns 1.

--- a/index.bs
+++ b/index.bs
@@ -5497,7 +5497,7 @@ dictionary Transformer {
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<undefined> (TransformStreamDefaultController controller);
 callback TransformerTransformCallback = Promise<undefined> (any chunk, TransformStreamDefaultController controller);
-callback TransformerCancelCallback = Promise<undefined> (any reason, TransformStreamDefaultController controller);
+callback TransformerCancelCallback = Promise<undefined> (any reason);
 </xmp>
 
 <dl>
@@ -5560,7 +5560,7 @@ callback TransformerCancelCallback = Promise<undefined> (any reason, TransformSt
    {{Transformer/flush|flush()}}; the stream is already in the process of successfully closing down,
    and terminating it would be counterproductive.)
 
-  <dt><dfn dict-member for="Transformer" lt="cancel">cancel(<var ignore>reason</var>, <var ignore>controller</var>)</dfn></dt>
+  <dt><dfn dict-member for="Transformer" lt="cancel">cancel(<var ignore>reason</var>)</dfn></dt>
   <dd>
    <p>A function called when the [=writable side=] is aborted, or when the [=readable side=] is
    cancelled.
@@ -5948,8 +5948,8 @@ The following abstract operations support the implementaiton of the
     with argument list «&nbsp;|controller|&nbsp;» and [=callback this value=] |transformer|.
  1. If |transformerDict|["{{Transformer/cancel}}"] [=map/exists=], set |cancelAlgorithm| to an
     algorithm which takes an argument |reason| and returns the result of [=invoking=]
-    |transformerDict|["{{Transformer/cancel}}"] with argument list «&nbsp;|reason|,
-    |controller|&nbsp;» and [=callback this value=] |transformer|.
+    |transformerDict|["{{Transformer/cancel}}"] with argument list «&nbsp;|reason|&nbsp;» and
+    [=callback this value=] |transformer|.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
     |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|).
 </div>

--- a/index.bs
+++ b/index.bs
@@ -5888,6 +5888,18 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
+ <dfn abstract-op lt="TransformStreamSetBackpressure"
+ id="transform-stream-set-backpressure">TransformStreamSetBackpressure(|stream|,
+ |backpressure|)</dfn> performs the following steps:
+
+ 1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is not |backpressure|.
+ 1. If |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined, [=resolve=]
+    stream.[=TransformStream/[[backpressureChangePromise]]=] with undefined.
+ 1. Set |stream|.[=TransformStream/[[backpressureChangePromise]]=] to [=a new promise=].
+ 1. Set |stream|.[=TransformStream/[[backpressure]]=] to |backpressure|.
+</div>
+
+<div algorithm>
  <dfn abstract-op lt="TransformStreamUnblockWrite"
  id="transform-stream-unblock-write">TransformStreamUnblockWrite(|stream|)</dfn> performs the
  following steps:
@@ -5898,18 +5910,6 @@ The following abstract operations operate on {{TransformStream}} instances at a 
  <p class="note">The [$TransformStreamDefaultSinkWriteAlgorithm$] abstract operation could be
  waiting for the promise stored in the [=TransformStream/[[backpressureChangePromise]]=] slot to
  resolve. The call to [$TransformStreamSetBackpressure$] ensures that the promise always resolves.
-</div>
-
-<div algorithm>
- <dfn abstract-op lt="TransformStreamSetBackpressure"
- id="transform-stream-set-backpressure">TransformStreamSetBackpressure(|stream|,
- |backpressure|)</dfn> performs the following steps:
-
- 1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is not |backpressure|.
- 1. If |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined, [=resolve=]
-    stream.[=TransformStream/[[backpressureChangePromise]]=] with undefined.
- 1. Set |stream|.[=TransformStream/[[backpressureChangePromise]]=] to [=a new promise=].
- 1. Set |stream|.[=TransformStream/[[backpressure]]=] to |backpressure|.
 </div>
 
 <h4 id="ts-default-controller-abstract-ops">Default controllers</h4>

--- a/index.bs
+++ b/index.bs
@@ -5749,7 +5749,7 @@ the following table:
  <tbody>
   <tr>
    <td><dfn>\[[cancelAlgorithm]]</dfn>
-   <td class="non-normative">A promise-returning algorithm, taking one argument (the [=reason=] for
+   <td class="non-normative">A promise-returning algorithm, taking one argument (the reason for
    cancellation), which communicates a requested cancellation to the [=transformer=]
   <tr>
    <td><dfn>\[[finishPromise]]</dfn>
@@ -6122,18 +6122,6 @@ The following abstract operation is used to implement the [=underlying source=] 
 side=] of [=transform streams=].
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSourcePullAlgorithm"
- id="transform-stream-default-source-pull">TransformStreamDefaultSourcePullAlgorithm(|stream|)</dfn>
- performs the following steps:
-
- 1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is true.
- 1. Assert: |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined.
- 1. Perform ! [$TransformStreamSetBackpressure$](|stream|, false).
- 1. Return |stream|.[=TransformStream/[[backpressureChangePromise]]=].
-</div>
-
-
-<div algorithm>
  <dfn abstract-op lt="TransformStreamDefaultSourceCancelAlgorithm"
  id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
@@ -6160,6 +6148,17 @@ side=] of [=transform streams=].
    1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
    1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
  1. Return |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="TransformStreamDefaultSourcePullAlgorithm"
+ id="transform-stream-default-source-pull">TransformStreamDefaultSourcePullAlgorithm(|stream|)</dfn>
+ performs the following steps:
+
+ 1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is true.
+ 1. Assert: |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined.
+ 1. Perform ! [$TransformStreamSetBackpressure$](|stream|, false).
+ 1. Return |stream|.[=TransformStream/[[backpressureChangePromise]]=].
 </div>
 
 <h2 id="qs">Queuing strategies</h2>
@@ -7209,7 +7208,7 @@ reason.
  for="TransformStream/set up"><var>transformAlgorithm</var></dfn>, an optional algorithm <dfn
  export for="TransformStream/set up"><var>flushAlgorithm</var></dfn>, and an optional algorithm <dfn
  export for="TransformStream/set up"><var>cancelAlgorithm</var></dfn>, perform the following steps.
- |transformAlgorithm|, if given, |flushAlgorithm| and |cancelAlgorithm|, may return a promise.
+ |transformAlgorithm| and, if given, |flushAlgorithm| and |cancelAlgorithm|, may return a promise.
 
  1. Let |writableHighWaterMark| be 1.
  1. Let |writableSizeAlgorithm| be an algorithm that returns 1.

--- a/index.bs
+++ b/index.bs
@@ -5562,11 +5562,11 @@ callback TransformerCancelCallback = Promise<undefined> (any reason);
 
   <dt><dfn dict-member for="Transformer" lt="cancel">cancel(<var ignore>reason</var>)</dfn></dt>
   <dd>
-   <p>A function called when the [=writable side=] is aborted, or when the [=readable side=] is
-   cancelled.
+   <p>A function called when the [=readable side=] is cancelled, or when the [=writable side=] is
+   aborted.
 
-   <p>Typically this is used to clean up underlying transformer resources when the  stream is
-   aborted or cancelled.
+   <p>Typically this is used to clean up underlying transformer resources when the stream is aborted
+   or cancelled.
 
    <p>If the cancellation process is asynchronous, the function can return a promise to signal
    success or failure; the result will be communicated to the caller of
@@ -6076,6 +6076,8 @@ side=] of [=transform streams=].
  performs the following steps:
 
  1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
+ 1. If |readable|.[=ReadableStream/[[state]]=] is not "`readable`", return
+    [=a promise resolved with=] undefined.
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
  1. Let |flushPromise| be the result of performing
     |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=].

--- a/index.bs
+++ b/index.bs
@@ -5591,9 +5591,9 @@ callback TransformerCancelCallback = Promise<undefined> (any reason);
 </dl>
 
 The <code>controller</code> object passed to {{Transformer/start|start()}},
-{{Transformer/transform|transform()}}, {{Transformer/flush|flush()}}, and
-{{Transformer/cancel|cancel()}} is an instance of {{TransformStreamDefaultController}}, and has the
-ability to enqueue [=chunks=] to the [=readable side=], or to terminate or error the stream.
+{{Transformer/transform|transform()}}, and {{Transformer/flush|flush()}} is an instance of
+{{TransformStreamDefaultController}}, and has the ability to enqueue [=chunks=] to the
+[=readable side=], or to terminate or error the stream.
 
 <h4 id="ts-prototype">Constructor and properties</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -5489,6 +5489,7 @@ dictionary Transformer {
   TransformerStartCallback start;
   TransformerTransformCallback transform;
   TransformerFlushCallback flush;
+  TransformerCancelCallback cancel;
   any readableType;
   any writableType;
 };
@@ -5496,6 +5497,7 @@ dictionary Transformer {
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<undefined> (TransformStreamDefaultController controller);
 callback TransformerTransformCallback = Promise<undefined> (any chunk, TransformStreamDefaultController controller);
+callback TransformerCancelCallback = Promise<undefined> (any reason, TransformStreamDefaultController controller);
 </xmp>
 
 <dl>
@@ -5558,6 +5560,25 @@ callback TransformerTransformCallback = Promise<undefined> (any chunk, Transform
    {{Transformer/flush|flush()}}; the stream is already in the process of successfully closing down,
    and terminating it would be counterproductive.)
 
+  <dt><dfn dict-member for="Transformer" lt="cancel">cancel(<var ignore>reason</var>, <var ignore>controller</var>)</dfn></dt>
+  <dd>
+   <p>A function called when the [=writable side=] is aborted, or when the [=readable side=] is
+   cancelled.
+
+   <p>Typically this is used to clean up underlying transformer resources when the  stream is
+   aborted or cancelled.
+
+   <p>If the cancellation process is asynchronous, the function can return a promise to signal
+   success or failure; the result will be communicated to the caller of
+   {{WritableStream/abort()|stream.writable.abort()}} or
+   {{ReadableStream/cancel()|stream.readable.cancel()}}. Throwing an exception is treated the same
+   as returning a rejected promise.
+
+   <p>(Note that there is no need to call
+   {{TransformStreamDefaultController/terminate()|controller.terminate()}} inside
+   {{Transformer/cancel|cancel()}}; the stream is already in the process of cancelling/aborting, and
+   terminating it would be counterproductive.)
+
  <dt><dfn dict-member for="Transformer">readableType</dfn></dt>
  <dd>
   <p>This property is reserved for future use, so any attempts to supply a value will throw an
@@ -5570,9 +5591,9 @@ callback TransformerTransformCallback = Promise<undefined> (any chunk, Transform
 </dl>
 
 The <code>controller</code> object passed to {{Transformer/start|start()}},
-{{Transformer/transform|transform()}}, and {{Transformer/flush|flush()}} is an instance of
-{{TransformStreamDefaultController}}, and has the ability to enqueue [=chunks=] to the [=readable
-side=], or to terminate or error the stream.
+{{Transformer/transform|transform()}}, {{Transformer/flush|flush()}}, and
+{{Transformer/cancel|cancel()}} is an instance of {{TransformStreamDefaultController}}, and has the
+ability to enqueue [=chunks=] to the [=readable side=], or to terminate or error the stream.
 
 <h4 id="ts-prototype">Constructor and properties</h4>
 
@@ -5727,6 +5748,10 @@ the following table:
    <th>Description (<em>non-normative</em>)</th>
  <tbody>
   <tr>
+   <td><dfn>\[[cancelAlgorithm]]</dfn>
+   <td class="non-normative">A promise-returning algorithm, taking one argument (the [=reason=] for
+   cancellation), which communicates a requested cancellation to the [=transformer=]
+  <tr>
    <td><dfn>\[[flushAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=transformer=]
@@ -5819,8 +5844,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
  1. Let |pullAlgorithm| be the following steps:
   1. Return ! [$TransformStreamDefaultSourcePullAlgorithm$](|stream|).
  1. Let |cancelAlgorithm| be the following steps, taking a |reason| argument:
-  1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |reason|).
-  1. Return [=a promise resolved with=] undefined.
+  1. Return ! [$TransformStreamDefaultSourceCancelAlgorithm$](|stream|, |reason|).
  1. Set |stream|.[=TransformStream/[[readable]]=] to ! [$CreateReadableStream$](|startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
  1. Set |stream|.[=TransformStream/[[backpressure]]=] and
@@ -5854,6 +5878,14 @@ The following abstract operations operate on {{TransformStream}} instances at a 
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.[=TransformStream/[[controller]]=]).
  1. Perform !
     [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=TransformStream/[[writable]]=].[=WritableStream/[[controller]]=], |e|).
+ 1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="TransformStreamUnblockWrite"
+ id="transform-stream-unblock-write">TransformStreamUnblockWrite(|stream|)</dfn> performs the
+ following steps:
+
  1. If |stream|.[=TransformStream/[[backpressure]]=] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
     false).
 
@@ -5882,7 +5914,8 @@ The following abstract operations support the implementaiton of the
 <div algorithm>
  <dfn abstract-op lt="SetUpTransformStreamDefaultController"
  id="set-up-transform-stream-default-controller">SetUpTransformStreamDefaultController(|stream|,
- |controller|, |transformAlgorithm|, |flushAlgorithm|)</dfn> performs the following steps:
+ |controller|, |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|)</dfn> performs the
+ following steps:
 
  1. Assert: |stream| [=implements=] {{TransformStream}}.
  1. Assert: |stream|.[=TransformStream/[[controller]]=] is undefined.
@@ -5891,6 +5924,7 @@ The following abstract operations support the implementaiton of the
  1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to
     |transformAlgorithm|.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to |flushAlgorithm|.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=] to |cancelAlgorithm|.
 </div>
 
 <div algorithm>
@@ -5904,6 +5938,7 @@ The following abstract operations support the implementaiton of the
   1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |flushAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
+ 1. Let |cancelAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
  1. If |transformerDict|["{{Transformer/transform}}"] [=map/exists=], set |transformAlgorithm| to an
     algorithm which takes an argument |chunk| and returns the result of [=invoking=]
     |transformerDict|["{{Transformer/transform}}"] with argument list «&nbsp;|chunk|,
@@ -5911,8 +5946,12 @@ The following abstract operations support the implementaiton of the
  1. If |transformerDict|["{{Transformer/flush}}"] [=map/exists=], set |flushAlgorithm| to an
     algorithm which returns the result of [=invoking=] |transformerDict|["{{Transformer/flush}}"]
     with argument list «&nbsp;|controller|&nbsp;» and [=callback this value=] |transformer|.
+ 1. If |transformerDict|["{{Transformer/cancel}}"] [=map/exists=], set |cancelAlgorithm| to an
+    algorithm which takes an argument |reason| and returns the result of [=invoking=]
+    |transformerDict|["{{Transformer/cancel}}"] with argument list «&nbsp;|reason|,
+    |controller|&nbsp;» and [=callback this value=] |transformer|.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
-    |transformAlgorithm|, |flushAlgorithm|).
+    |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|).
 </div>
 
 <div algorithm>
@@ -5931,6 +5970,7 @@ The following abstract operations support the implementaiton of the
 
  1. Set |controller|.[=TransformStreamDefaultController/[[transformAlgorithm]]=] to undefined.
  1. Set |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=] to undefined.
+ 1. Set |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=] to undefined.
 </div>
 
 <div algorithm>
@@ -6021,8 +6061,13 @@ side=] of [=transform streams=].
  id="transform-stream-default-sink-abort-algorithm">TransformStreamDefaultSinkAbortAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
- 1. Perform ! [$TransformStreamError$](|stream|, |reason|).
- 1. Return [=a promise resolved with=] undefined.
+ 1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
+ 1. [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |reason|).
+ 1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
+ 1. Let |cancelPromise| be the result of performing
+    |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
+ 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
+ 1. Return |cancelPromise|.
 </div>
 
 <div algorithm>
@@ -6060,6 +6105,30 @@ side=] of [=transform streams=].
  1. Assert: |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined.
  1. Perform ! [$TransformStreamSetBackpressure$](|stream|, false).
  1. Return |stream|.[=TransformStream/[[backpressureChangePromise]]=].
+</div>
+
+
+<div algorithm>
+ <dfn abstract-op lt="TransformStreamDefaultSourceCancelAlgorithm"
+ id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|reason|,
+ |stream|)</dfn> performs the following steps:
+
+ 1. Let |writable| be |stream|.[=TransformStream/[[writable]]=].
+ 1. If |writable|.[=WritableStream/[[state]]=] is not "`writable`", return
+    [=a promise resolved with=] undefined.
+ 1. Perform !
+    [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |reason|).
+ 1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+ 1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
+ 1. Let |cancelPromise| be the result of performing
+    |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
+ 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
+ 1. Return |cancelPromise|.
+
+ <p class="note">The early return prevents the cancellation algorithm from being called if the
+ writable side is already (in the process of being) closed. This is important, because the
+ cancellation algorithm <span class=allow-2119>must</span> not run if the flush algorithm has
+ already been run.
 </div>
 
 <h2 id="qs">Queuing strategies</h2>
@@ -7106,9 +7175,11 @@ reason.
 <div algorithm="create a TransformStream">
  To <dfn export for="TransformStream" lt="set up|setting up">set up</dfn> a
  newly-[=new|created-via-Web IDL=] {{TransformStream}} |stream| given an algorithm <dfn export
- for="TransformStream/set up"><var>transformAlgorithm</var></dfn> and an optional algorithm <dfn
- export for="TransformStream/set up"><var>flushAlgorithm</var></dfn>, perform the following steps.
- |transformAlgorithm| and, if given, |flushAlgorithm|, may return a promise.
+ for="TransformStream/set up"><var>transformAlgorithm</var></dfn>, an optional algorithm <dfn
+ export for="TransformStream/set up"><var>flushAlgorithm</var></dfn>, and an optional algorithm <dfn
+ export for="TransformStream/set up"><var>cancelAlgorithm</var></dfn>, perform the following steps.
+ |transformAlgorithm|, if given, |flushAlgorithm|, and, if given, |cancelAlgorithm|, may return a
+ promise.
 
  1. Let |writableHighWaterMark| be 1.
  1. Let |writableSizeAlgorithm| be an algorithm that returns 1.
@@ -7124,12 +7195,16 @@ reason.
      null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
+ 1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps given a value |reason|:
+  1. Let |result| be the result of running |cancelAlgorithm| given |reason|, if |cancelAlgorithm|
+     was given, or null otherwise. If this throws an exception |e|, return
+     [=a promise rejected with=] |e|.
  1. Let |startPromise| be [=a promise resolved with=] undefined.
  1. Perform ! [$InitializeTransformStream$](|stream|, |startPromise|, |writableHighWaterMark|,
     |writableSizeAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
  1. Let |controller| be a [=new=] {{TransformStreamDefaultController}}.
  1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
-    |transformAlgorithmWrapper|, |flushAlgorithmWrapper|).
+    |transformAlgorithmWrapper|, |flushAlgorithmWrapper|, |cancelAlgorithmWrapper|).
 
  Other specifications should be careful when constructing their
  <i>[=TransformStream/set up/transformAlgorithm=]</i> to avoid [=in parallel=] reads from the given

--- a/index.bs
+++ b/index.bs
@@ -5752,6 +5752,12 @@ the following table:
    <td class="non-normative">A promise-returning algorithm, taking one argument (the [=reason=] for
    cancellation), which communicates a requested cancellation to the [=transformer=]
   <tr>
+   <td><dfn>\[[finishPromise]]</dfn>
+   <td class="non-normative">A promise which resolves on completion of either the
+   [=TransformStreamDefaultController/[[cancelAlgorithm]]=] or the
+   [=TransformStreamDefaultController/[[flushAlgorithm]]=]. If this field is unpopulated (that is,
+   undefined), then neither of those algorithms have been [=invoked=] yet
+  <tr>
    <td><dfn>\[[flushAlgorithm]]</dfn>
    <td class="non-normative">A promise-returning algorithm which communicates a requested close to
    the [=transformer=]
@@ -6061,13 +6067,22 @@ side=] of [=transform streams=].
  id="transform-stream-default-sink-abort-algorithm">TransformStreamDefaultSinkAbortAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
- 1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
- 1. [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |reason|).
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
+ 1. If |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] is not undefined, return
+    |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
+ 1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
+ 1. Let |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] be a new promise.
  1. Let |cancelPromise| be the result of performing
     |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
- 1. Return |cancelPromise|.
+ 1. [=React=] to |cancelPromise|:
+  1. If |cancelPromise| was fulfilled, then:
+   1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |reason|).
+   1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
+  1. If |cancelPromise| was rejected with reason |r|, then:
+   1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |r|).
+   1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
+ 1. Return |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
 </div>
 
 <div algorithm>
@@ -6075,22 +6090,22 @@ side=] of [=transform streams=].
  id="transform-stream-default-sink-close-algorithm">TransformStreamDefaultSinkCloseAlgorithm(|stream|)</dfn>
  performs the following steps:
 
- 1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
- 1. If |readable|.[=ReadableStream/[[state]]=] is not "`readable`", return
-    [=a promise resolved with=] undefined.
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
+ 1. If |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] is not undefined, return
+    |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
+ 1. Let |readable| be |stream|.[=TransformStream/[[readable]]=].
+ 1. Let |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] be a new promise.
  1. Let |flushPromise| be the result of performing
     |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
- 1. Return the result of [=reacting=] to |flushPromise|:
+ 1. [=React=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
-   1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", throw
-      |readable|.[=ReadableStream/[[storedError]]=].
-   1. Perform !
-      [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
+   1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
+   1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
   1. If |flushPromise| was rejected with reason |r|, then:
-   1. Perform ! [$TransformStreamError$](|stream|, |r|).
-   1. Throw |readable|.[=ReadableStream/[[storedError]]=].
+   1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |r|).
+   1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
+ 1. Return |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
 </div>
 
 <h4 id="ts-default-source-abstract-ops">Default sources</h4>
@@ -6115,22 +6130,24 @@ side=] of [=transform streams=].
  id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|reason|,
  |stream|)</dfn> performs the following steps:
 
- 1. Let |writable| be |stream|.[=TransformStream/[[writable]]=].
- 1. If |writable|.[=WritableStream/[[state]]=] is not "`writable`", return
-    [=a promise resolved with=] undefined.
- 1. Perform !
-    [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |reason|).
- 1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
+ 1. If |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] is not undefined, return
+    |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
+ 1. Let |writable| be |stream|.[=TransformStream/[[writable]]=].
+ 1. Let |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] be a new promise.
  1. Let |cancelPromise| be the result of performing
     |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
- 1. Return |cancelPromise|.
-
- <p class="note">The early return prevents the cancellation algorithm from being called if the
- writable side is already (in the process of being) closed. This is important, because the
- cancellation algorithm <span class=allow-2119>must</span> not run if the flush algorithm has
- already been run.
+ 1. [=React=] to |cancelPromise|:
+  1. If |cancelPromise| was fulfilled, then:
+   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |reason|).
+   1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+   1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
+  1. If |cancelPromise| was rejected with reason |r|, then:
+   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |r|).
+   1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+   1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
+ 1. Return |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
 </div>
 
 <h2 id="qs">Queuing strategies</h2>

--- a/index.bs
+++ b/index.bs
@@ -6077,8 +6077,12 @@ side=] of [=transform streams=].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. [=React=] to |cancelPromise|:
   1. If |cancelPromise| was fulfilled, then:
-   1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |reason|).
-   1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
+   1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", [=reject=]
+      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with 
+      |readable|.[=ReadableStream/[[storedError]]=].
+   1. Otherwise:
+    1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |reason|).
+    1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
   1. If |cancelPromise| was rejected with reason |r|, then:
    1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |r|).
    1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
@@ -6100,8 +6104,12 @@ side=] of [=transform streams=].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. [=React=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
-   1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
-   1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
+   1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", [=reject=]
+      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with 
+      |readable|.[=ReadableStream/[[storedError]]=].
+   1. Otherwise:
+    1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
+    1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
   1. If |flushPromise| was rejected with reason |r|, then:
    1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |r|).
    1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
@@ -6140,9 +6148,13 @@ side=] of [=transform streams=].
  1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
  1. [=React=] to |cancelPromise|:
   1. If |cancelPromise| was fulfilled, then:
-   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |reason|).
-   1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
-   1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
+   1. If |writable|.[=WritableStream/[[state]]=] is "`errored`", [=reject=]
+      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with 
+      |writable|.[=WritableStream/[[storedError]]=].
+   1. Otherwise:
+    1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |reason|).
+    1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+    1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
   1. If |cancelPromise| was rejected with reason |r|, then:
    1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |r|).
    1. Perform ! [$TransformStreamUnblockWrite$](|stream|).

--- a/index.bs
+++ b/index.bs
@@ -6135,8 +6135,8 @@ side=] of [=transform streams=].
 
 <div algorithm>
  <dfn abstract-op lt="TransformStreamDefaultSourceCancelAlgorithm"
- id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|reason|,
- |stream|)</dfn> performs the following steps:
+ id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|stream|,
+ |reason|)</dfn> performs the following steps:
 
  1. Let |controller| be |stream|.[=TransformStream/[[controller]]=].
  1. If |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] is not undefined, return

--- a/index.bs
+++ b/index.bs
@@ -6078,7 +6078,7 @@ side=] of [=transform streams=].
  1. [=React=] to |cancelPromise|:
   1. If |cancelPromise| was fulfilled, then:
    1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", [=reject=]
-      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with 
+      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with
       |readable|.[=ReadableStream/[[storedError]]=].
    1. Otherwise:
     1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |reason|).
@@ -6105,7 +6105,7 @@ side=] of [=transform streams=].
  1. [=React=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
    1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", [=reject=]
-      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with 
+      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with
       |readable|.[=ReadableStream/[[storedError]]=].
    1. Otherwise:
     1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
@@ -6149,7 +6149,7 @@ side=] of [=transform streams=].
  1. [=React=] to |cancelPromise|:
   1. If |cancelPromise| was fulfilled, then:
    1. If |writable|.[=WritableStream/[[state]]=] is "`errored`", [=reject=]
-      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with 
+      |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with
       |writable|.[=WritableStream/[[storedError]]=].
    1. Otherwise:
     1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |reason|).

--- a/index.bs
+++ b/index.bs
@@ -7217,6 +7217,8 @@ reason.
   1. Let |result| be the result of running |cancelAlgorithm| given |reason|, if |cancelAlgorithm|
      was given, or null otherwise. If this throws an exception |e|, return
      [=a promise rejected with=] |e|.
+  1. If |result| is a {{Promise}}, then return |result|.
+  1. Return [=a promise resolved with=] undefined.
  1. Let |startPromise| be [=a promise resolved with=] undefined.
  1. Perform ! [$InitializeTransformStream$](|stream|, |startPromise|, |writableHighWaterMark|,
     |writableSizeAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).

--- a/reference-implementation/lib/Transformer.webidl
+++ b/reference-implementation/lib/Transformer.webidl
@@ -2,6 +2,7 @@ dictionary Transformer {
   TransformerStartCallback start;
   TransformerTransformCallback transform;
   TransformerFlushCallback flush;
+  TransformerCancelCallback cancel;
   any readableType;
   any writableType;
 };
@@ -9,3 +10,4 @@ dictionary Transformer {
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<undefined> (TransformStreamDefaultController controller);
 callback TransformerTransformCallback = Promise<undefined> (any chunk, TransformStreamDefaultController controller);
+callback TransformerCancelCallback = Promise<undefined> (any reason, TransformStreamDefaultController controller);

--- a/reference-implementation/lib/Transformer.webidl
+++ b/reference-implementation/lib/Transformer.webidl
@@ -10,4 +10,4 @@ dictionary Transformer {
 callback TransformerStartCallback = any (TransformStreamDefaultController controller);
 callback TransformerFlushCallback = Promise<undefined> (TransformStreamDefaultController controller);
 callback TransformerTransformCallback = Promise<undefined> (any chunk, TransformStreamDefaultController controller);
-callback TransformerCancelCallback = Promise<undefined> (any reason, TransformStreamDefaultController controller);
+callback TransformerCancelCallback = Promise<undefined> (any reason);

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -249,8 +249,12 @@ function TransformStreamDefaultSinkAbortAlgorithm(stream, reason) {
   TransformStreamDefaultControllerClearAlgorithms(controller);
 
   uponPromise(cancelPromise, () => {
-    ReadableStreamDefaultControllerError(readable._controller, reason);
-    resolvePromise(controller._finishPromise);
+    if (readable._state === 'errored') {
+      rejectPromise(controller._finishPromise, readable._storedError);
+    } else {
+      ReadableStreamDefaultControllerError(readable._controller, reason);
+      resolvePromise(controller._finishPromise);
+    }
   }, r => {
     ReadableStreamDefaultControllerError(readable._controller, r);
     rejectPromise(controller._finishPromise, r);
@@ -278,8 +282,12 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
   TransformStreamDefaultControllerClearAlgorithms(controller);
 
   uponPromise(flushPromise, () => {
-    ReadableStreamDefaultControllerClose(readable._controller);
-    resolvePromise(controller._finishPromise);
+    if (readable._state === 'errored') {
+      rejectPromise(controller._finishPromise, readable._storedError);
+    } else {
+      ReadableStreamDefaultControllerClose(readable._controller);
+      resolvePromise(controller._finishPromise);    
+    }
   }, r => {
     ReadableStreamDefaultControllerError(readable._controller, r);
     rejectPromise(controller._finishPromise, r);
@@ -324,9 +332,13 @@ function TransformStreamDefaultSourceCancelAlgorithm(stream, reason) {
   TransformStreamDefaultControllerClearAlgorithms(controller);
 
   uponPromise(cancelPromise, () => {
-    WritableStreamDefaultControllerErrorIfNeeded(writable._controller, reason);
-    TransformStreamUnblockWrite(stream);
-    resolvePromise(controller._finishPromise);
+    if (writable._state === 'errored') {
+      rejectPromise(controller._finishPromise, writable._storedError);
+    } else {
+      WritableStreamDefaultControllerErrorIfNeeded(writable._controller, reason);
+      TransformStreamUnblockWrite(stream);
+      resolvePromise(controller._finishPromise);
+    }
   }, r => {
     WritableStreamDefaultControllerErrorIfNeeded(writable._controller, r);
     TransformStreamUnblockWrite(stream);

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -140,7 +140,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer(stream, transforme
     flushAlgorithm = () => transformerDict.flush.call(transformer, controller);
   }
   if ('cancel' in transformerDict) {
-    cancelAlgorithm = reason => transformerDict.cancel.call(transformer, reason, controller);
+    cancelAlgorithm = reason => transformerDict.cancel.call(transformer, reason);
   }
 
   SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm, cancelAlgorithm);

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -286,7 +286,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
       rejectPromise(controller._finishPromise, readable._storedError);
     } else {
       ReadableStreamDefaultControllerClose(readable._controller);
-      resolvePromise(controller._finishPromise);    
+      resolvePromise(controller._finishPromise);
     }
   }, r => {
     ReadableStreamDefaultControllerError(readable._controller, r);

--- a/reference-implementation/lib/abstract-ops/transform-streams.js
+++ b/reference-implementation/lib/abstract-ops/transform-streams.js
@@ -234,7 +234,7 @@ function TransformStreamDefaultSinkAbortAlgorithm(stream, reason) {
   verbose('TransformStreamDefaultSinkAbortAlgorithm()');
 
   const controller = stream._controller;
-  if (controller._finishPromise) {
+  if (controller._finishPromise !== undefined) {
     return controller._finishPromise;
   }
 
@@ -263,7 +263,7 @@ function TransformStreamDefaultSinkCloseAlgorithm(stream) {
   verbose('TransformStreamDefaultSinkCloseAlgorithm()');
 
   const controller = stream._controller;
-  if (controller._finishPromise) {
+  if (controller._finishPromise !== undefined) {
     return controller._finishPromise;
   }
 
@@ -308,7 +308,7 @@ function TransformStreamDefaultSourceCancelAlgorithm(stream, reason) {
   verbose('TransformStreamDefaultSourceCancelAlgorithm()');
 
   const controller = stream._controller;
-  if (controller._finishPromise) {
+  if (controller._finishPromise !== undefined) {
     return controller._finishPromise;
   }
 


### PR DESCRIPTION
This commit adds a `cancel` hook to `Transformer`. This allows users to perform resource cleanup when the readable side of the `TransformStream` is cancelled, or the writable side is aborted.

To preserve existing behavior, when the readable side is cancelled with a reason, the writable side is always immediately aborted with that same reason. The same is true in the reverse case. This means that the status of both sides is always either `closed`, `erroring`, or `erroring` when the `cancel` hook is called.

`flush` and `cancel` are never both called. As per existing behaviour, when the writable side is closed the `flush` hook is called. If the readable side is cancelled while a promise returned from `flush` is still pending, `cancel` is not called. In this scenario the readable side ends up in the "errored" state, while the writable side ends up in the `closed` state.

I have opted for a `cancel` hook instead of a `finally` hook, to mirror the API in `WritableStream` - it has one hook for successful completion (`close`), and one hook for errored completion (`abort`). `Transformer` already has a `flush` hook for successful completion. The logical addition is an `cancel` hook for errored completion.

Closes #1212

---

Open questions:

- Is `cancel` the right name? Mirrors `ReadableStream`, but we use `abort` for `WritableStream`.
- Is the immediate cancellation behaviour correct?
  - Ie should call the `cancel` hook before or after cancelling the underlying streams?
  - Calling it before means that current behaviour is changed (number of microticks from `readable.cancel()` to the `writable` actually being aborted). This is the current behaviour.
  - Calling it after means that you can not modify the reason passed to the other side using the `cancel` hook. This is different to `abort` and `cancel` hooks in `WritableStream` and `ReadableStream` respectively.

---

- [x] At least two implementers are interested (and none opposed):
   * WebKit (https://github.com/whatwg/streams/pull/1283#issuecomment-1738663536)
   * Chromium (https://github.com/whatwg/streams/pull/1283#issuecomment-1738960442)
   * (Deno)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/40453
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1488142
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1856103
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=262424
   * Deno: https://github.com/denoland/deno/issues/20741
   * Node.js: https://github.com/nodejs/node/issues/49971
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/29375


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1283.html" title="Last updated on Sep 30, 2023, 2:07 AM UTC (4d2abe5)">Preview</a> | <a href="https://whatpr.org/streams/1283/8d7a0bf...4d2abe5.html" title="Last updated on Sep 30, 2023, 2:07 AM UTC (4d2abe5)">Diff</a>