### PR TITLE
Meta: upgrade webidl2js dependency to v17

### DIFF
--- a/reference-implementation/lib/ReadableStream-impl.js
+++ b/reference-implementation/lib/ReadableStream-impl.js
@@ -15,7 +15,7 @@ exports.implementation = class ReadableStreamImpl {
     if (underlyingSource === undefined) {
       underlyingSource = null;
     }
-    const underlyingSourceDict = UnderlyingSource.convert(underlyingSource);
+    const underlyingSourceDict = UnderlyingSource.convert(globalObject, underlyingSource);
 
     aos.InitializeReadableStream(this);
 

--- a/reference-implementation/lib/TransformStream-impl.js
+++ b/reference-implementation/lib/TransformStream-impl.js
@@ -11,7 +11,7 @@ exports.implementation = class TransformStreamImpl {
     if (transformer === undefined) {
       transformer = null;
     }
-    const transformerDict = Transformer.convert(transformer);
+    const transformerDict = Transformer.convert(globalObject, transformer);
     if ('readableType' in transformerDict) {
       throw new RangeError('Invalid readableType specified');
     }

--- a/reference-implementation/lib/WritableStream-impl.js
+++ b/reference-implementation/lib/WritableStream-impl.js
@@ -11,7 +11,7 @@ exports.implementation = class WritableStreamImpl {
     if (underlyingSink === undefined) {
       underlyingSink = null;
     }
-    const underlyingSinkDict = UnderlyingSink.convert(underlyingSink);
+    const underlyingSinkDict = UnderlyingSink.convert(globalObject, underlyingSink);
     if ('type' in underlyingSinkDict) {
       throw new RangeError('Invalid type is specified');
     }

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -18,7 +18,7 @@
     "eslint": "^6.8.0",
     "minimatch": "^3.0.4",
     "opener": "^1.5.1",
-    "webidl2js": "^16.2.0",
+    "webidl2js": "^17.1.0",
     "wpt-runner": "^5.0.0"
   }
 }


### PR DESCRIPTION
The `convert()` changes are for https://github.com/jsdom/webidl2js/pull/251.