### PR TITLE
Editorial: Plumb reason through abort and cancel algorithm wrappers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6895,8 +6895,8 @@ to grow organically as needed.
      otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
- 1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps:
-  1. Let |result| be the result of running |cancelAlgorithm|, if |cancelAlgorithm| was given, or
+ 1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps given |reason|:
+  1. Let |result| be the result of running |cancelAlgorithm| given |reason|, if |cancelAlgorithm| was given, or
      null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
@@ -7218,8 +7218,8 @@ for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) retu
      null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
- 1. Let |abortAlgorithmWrapper| be an algorithm that runs these steps:
-  1. Let |result| be the result of running |abortAlgorithm|, if |abortAlgorithm| was given, or
+ 1. Let |abortAlgorithmWrapper| be an algorithm that runs these steps given |reason|:
+  1. Let |result| be the result of running |abortAlgorithm| given |reason|, if |abortAlgorithm| was given, or
      null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
@@ -8314,6 +8314,7 @@ James Pryor,
 Janessa Det,
 Jason Orendorff,
 Jeffrey Yasskin,
+Jeremy Roman,
 Jens Nockert,
 Lennart Grahl,
 Luca Casonato,

--- a/index.bs
+++ b/index.bs
@@ -6896,8 +6896,9 @@ to grow organically as needed.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. Let |cancelAlgorithmWrapper| be an algorithm that runs these steps given |reason|:
-  1. Let |result| be the result of running |cancelAlgorithm| given |reason|, if |cancelAlgorithm| was given, or
-     null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
+  1. Let |result| be the result of running |cancelAlgorithm| given |reason|, if |cancelAlgorithm|
+     was given, or null otherwise. If this throws an exception |e|, return
+     [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. If |sizeAlgorithm| was not given, then set it to an algorithm that returns 1.
@@ -7219,8 +7220,9 @@ for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) retu
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. Let |abortAlgorithmWrapper| be an algorithm that runs these steps given |reason|:
-  1. Let |result| be the result of running |abortAlgorithm| given |reason|, if |abortAlgorithm| was given, or
-     null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
+  1. Let |result| be the result of running |abortAlgorithm| given |reason|, if |abortAlgorithm| was
+     given, or null otherwise. If this throws an exception |e|, return [=a promise rejected with=]
+     |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. If |sizeAlgorithm| was not given, then set it to an algorithm that returns 1.


### PR DESCRIPTION
These are clearly intended to pass the reason through.

Fixes #1241, fixes #1273.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1300.html" title="Last updated on Jan 9, 2024, 7:35 PM UTC (c5e2e75)">Preview</a> | <a href="https://whatpr.org/streams/1300/4dc123a...c5e2e75.html" title="Last updated on Jan 9, 2024, 7:35 PM UTC (c5e2e75)">Diff</a>