### PR TITLE
Editorial: Export byte streams related terms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -177,8 +177,8 @@ readable stream tee">branches</dfn>, which can be consumed independently.
 For streams representing bytes, an extended version of the [=readable stream=] is provided to handle
 bytes efficiently, in particular by minimizing copies. The [=underlying source=] for such a readable
 stream is called an <dfn>underlying byte source</dfn>. A readable stream whose underlying source is
-an underlying byte source is sometimes called a <dfn export>readable byte stream</dfn>. Consumers of
-a readable byte stream can acquire a [=BYOB reader=] using the stream's
+an underlying byte source is sometimes called a <dfn export for="ReadableStream">readable byte stream</dfn>.
+Consumers of a readable byte stream can acquire a [=BYOB reader=] using the stream's
 {{ReadableStream/getReader()}} method.
 
 <h3 id="ws-model">Writable streams</h3>
@@ -322,8 +322,8 @@ stream|canceling=] the stream, or [=piping=] the readable stream to a writable s
 acquired via the stream's {{ReadableStream/getReader()}} method.
 
 A [=readable byte stream=] has the ability to vend two types of readers: <dfn export lt="default
-reader">default readers</dfn> and <dfn export lt="BYOB reader">BYOB readers</dfn>. BYOB ("bring your
-own buffer") readers allow reading into a developer-supplied buffer, thus minimizing copies. A
+reader">default readers</dfn> and <dfn export lt="BYOB reader" for="ReadableStream">BYOB readers</dfn>.
+BYOB ("bring your own buffer") readers allow reading into a developer-supplied buffer, thus minimizing copies. A
 non-byte readable stream can only vend default readers. Default readers are instances of the
 {{ReadableStreamDefaultReader}} class, while BYOB readers are instances of
 {{ReadableStreamBYOBReader}}.


### PR DESCRIPTION
This PR exports "readable byte streams" and "BYOB reader" as concepts that other specs can also reference from the streams spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1303.html" title="Last updated on Jan 29, 2024, 2:54 AM UTC (7fa97fc)">Preview</a> | <a href="https://whatpr.org/streams/1303/6a214a3...7fa97fc.html" title="Last updated on Jan 29, 2024, 2:54 AM UTC (7fa97fc)">Diff</a>