### PR TITLE
Editorial: Export definition "writable stream writer"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -328,7 +328,7 @@ non-byte readable stream can only vend default readers. Default readers are inst
 {{ReadableStreamDefaultReader}} class, while BYOB readers are instances of
 {{ReadableStreamBYOBReader}}.
 
-Similarly, a <dfn lt="writer|writable stream writer">writable stream writer</dfn>, or simply
+Similarly, a <dfn export lt="writer|writable stream writer">writable stream writer</dfn>, or simply
 writer, is an object that allows direct writing of [=chunks=] to a [=writable stream=]. Without a
 writer, a [=producer=] can only perform the high-level operations of [=abort a writable
 stream|aborting=] the stream or [=piping=] a readable stream to the writable stream. Writers are


### PR DESCRIPTION
The "writable stream writer" definition is useful to the WebSocketStream API standard text, so export it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1304.html" title="Last updated on Jan 31, 2024, 12:31 PM UTC (47a80db)">Preview</a> | <a href="https://whatpr.org/streams/1304/6a214a3...47a80db.html" title="Last updated on Jan 31, 2024, 12:31 PM UTC (47a80db)">Diff</a>