### PR TITLE
Editorial: Update use of WebIDL "invoke a callback function"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5251,8 +5251,8 @@ The following abstract operations support the implementation of the
  1. Let |abortAlgorithm| be an algorithm that returns [=a promise resolved with=] undefined.
  1. If |underlyingSinkDict|["{{UnderlyingSink/start}}"] [=map/exists=], then set |startAlgorithm| to
     an algorithm which returns the result of [=invoking=]
-    |underlyingSinkDict|["{{UnderlyingSink/start}}"] with argument list «&nbsp;|controller|&nbsp;»
-    and [=callback this value=] |underlyingSink|.
+    |underlyingSinkDict|["{{UnderlyingSink/start}}"] with argument list «&nbsp;|controller|&nbsp;»,
+    exception behavior "<code>rethrow</code>", and [=callback this value=] |underlyingSink|.
  1. If |underlyingSinkDict|["{{UnderlyingSink/write}}"] [=map/exists=], then set |writeAlgorithm| to
     an algorithm which takes an argument |chunk| and returns the result of [=invoking=]
     |underlyingSinkDict|["{{UnderlyingSink/write}}"] with argument list «&nbsp;|chunk|,


### PR DESCRIPTION
The only use which is not promise-returning is the "start" algorithm, which should rethrow the exception (so it can in turn be rethrown from the ReadableStream constructor.

Part of whatwg/webidl#1425.

- [x] At least two implementers are interested (and none opposed): n/a (no normative change)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at: n/a (no normative change)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: n/a (no normative change)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (no normative change)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
