### PR TITLE
Propagate reason argument to resolved promise of cancel algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6016,7 +6016,8 @@ The following abstract operations support the implementaiton of the
   1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |flushAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
- 1. Let |cancelAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
+ 1. Let |cancelAlgorithm| be an algorithm which takes an argument |reason| and returns
+    [=a promise resolved with=] |reason|.
  1. If |transformerDict|["{{Transformer/transform}}"] [=map/exists=], set |transformAlgorithm| to an
     algorithm which takes an argument |chunk| and returns the result of [=invoking=]
     |transformerDict|["{{Transformer/transform}}"] with argument list «&nbsp;|chunk|,


### PR DESCRIPTION
When the user of the API does no supply a cancel algorithm make sure to
forward the reason argument to the resolved promise.

This changes step 4. of algorithm
SetUpTransformStreamDefaultControllerFromTransformer making sure to
forward the reason argument to the resolved promise. With this change
the reason argument in step 7. 'React to cancelPromise' of algorithm
TransformStreamDefaultSourceCancel will no longer be undefined.

--

I work on the Ladybird browser and think this PR might resolve a spec bug. We have some failing WPT tests in `transform-streams/backpressure/any.html`, specifically:
- writer.closed should resolve after readable is canceled during start
- writer.closed should resolve after readable is canceled with backpressure
- writer.closed should resolve after readable is canceled with no backpressure

Correcting step 4 in SetUpTransformStreamDefaultControllerFromTransformer as described above so that the reason argument is propagated to the resolved promise resolves these failing tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1324.html" title="Last updated on Aug 20, 2024, 8:52 PM UTC (eacb379)">Preview</a> | <a href="https://whatpr.org/streams/1324/53f7c7d...eacb379.html" title="Last updated on Aug 20, 2024, 8:52 PM UTC (eacb379)">Diff</a>