### PR TITLE
Commit pull-into descriptors after filling from queue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3331,7 +3331,12 @@ The following abstract operations support the implementation of the
  1. Otherwise, if ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
      |transferredBuffer|, |byteOffset|, |byteLength|).
-  1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+  1. Let |filledPullIntos| be the result of performing
+     ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+  1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
+    1. Perform !
+       [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+       |filledPullInto|).
  1. Otherwise,
   1. Assert: ! [$IsReadableStreamLocked$](|stream|) is false.
   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
@@ -3555,10 +3560,7 @@ The following abstract operations support the implementation of the
      |pullIntoDescriptor|) is true,
    1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
    1. [=list/Append=] |pullIntoDescriptor| to |filledPullIntos|.
- 1. [=list/For each=] |pullIntoDescriptor| of |filledPullIntos|,
-  1. Perform !
-     [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
-     |pullIntoDescriptor|).
+ 1. Return |filledPullIntos|.
 </div>
 
 <div algorithm>
@@ -3707,7 +3709,12 @@ The following abstract operations support the implementation of the
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`none`",
   1. Perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
      |pullIntoDescriptor|).
-  1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+  1. Let |filledPullIntos| be the result of performing
+     ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+  1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
+    1. Perform !
+       [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+       |filledPullInto|).
   1. Return.
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] &lt; |pullIntoDescriptor|'s
     [=pull-into descriptor/minimum fill=], return.
@@ -3728,7 +3735,12 @@ The following abstract operations support the implementation of the
  1. Perform !
     [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
     |pullIntoDescriptor|).
- 1. Perform ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+ 1. Let |filledPullIntos| be the result of performing
+    ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+ 1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
+   1. Perform !
+      [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+      |filledPullInto|).
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -3690,11 +3690,14 @@ The following abstract operations support the implementation of the
     perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
+  1. Let |filledPullIntos| be a new empty [=list=].
   1. [=While=] ! [$ReadableStreamGetNumReadIntoRequests$](|stream|) > 0,
    1. Let |pullIntoDescriptor| be !
       [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
+   1. [=list/Append=] |pullIntoDescriptor| to |filledPullIntos|.
+  1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
    1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|stream|,
-      |pullIntoDescriptor|).
+      |filledPullInto|).
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -6881,9 +6881,9 @@ The following abstract operations are a grab-bag of utilities.
  <dfn abstract-op lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
  |fromBuffer|, |fromIndex|, |count|)</dfn> performs the following steps:
 
- 1. Assert: [$Type$](|toBuffer|) is Object.
+ 1. Assert: |toBuffer| [=is an Object=].
  1. Assert: |toBuffer| has an \[[ArrayBufferData]] internal slot.
- 1. Assert: [$Type$](|fromBuffer|) is Object.
+ 1. Assert: |fromBuffer| [=is an Object=].
  1. Assert: |fromBuffer| has an \[[ArrayBufferData]] internal slot.
  1. If |toBuffer| is |fromBuffer|, return false.
  1. If ! [$IsDetachedBuffer$](|toBuffer|) is true, return false.

--- a/index.bs
+++ b/index.bs
@@ -3441,12 +3441,13 @@ The following abstract operations support the implementation of the
      queue entry/byte length=]).
   1. Let |destStart| be |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=] +
      |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=].
-  1. If ! [$SafeCopyDataBlockBytes$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=],
+  1. Assert: ! [$CanCopyDataBlockBytes$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=],
      |destStart|, |headOfQueue|'s [=readable byte stream queue entry/buffer=],
-     |headOfQueue|'s [=readable byte stream queue entry/byte offset=], |bytesToCopy|) is false,
-   1. Let |e| be a {{TypeError}} exception.
-   1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
-   1. Return false.
+     |headOfQueue|'s [=readable byte stream queue entry/byte offset=], |bytesToCopy|) is true.
+  1. Perform ! [$CopyDataBlockBytes$](|pullIntoDescriptor|'s [=pull-into
+     descriptor/buffer=].\[[ArrayBufferData]], |destStart|,
+     |headOfQueue|'s [=readable byte stream queue entry/buffer=].\[[ArrayBufferData]],
+     |headOfQueue|'s [=readable byte stream queue entry/byte offset=], |bytesToCopy|).
   1. If |headOfQueue|'s [=readable byte stream queue entry/byte length=] is |bytesToCopy|,
    1. [=list/Remove=] |queue|[0].
   1. Otherwise,
@@ -6851,7 +6852,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SafeCopyDataBlockBytes">SafeCopyDataBlockBytes(|toBuffer|, |toIndex|,
+ <dfn abstract-op lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
  |fromBuffer|, |fromIndex|, |count|)</dfn> performs the following steps:
 
  1. Assert: [$Type$](|toBuffer|) is Object.
@@ -6863,8 +6864,6 @@ The following abstract operations are a grab-bag of utilities.
  1. If ! [$IsDetachedBuffer$](|fromBuffer|) is true, return false.
  1. If |toIndex| + |count| > |toBuffer|.\[[ArrayBufferByteLength]], return false.
  1. If |fromIndex| + |count| > |fromBuffer|.\[[ArrayBufferByteLength]], return false.
- 1. Perform ! [$CopyDataBlockBytes$](|toBuffer|.\[[ArrayBufferData]], |toIndex|,
-    |fromBuffer|.\[[ArrayBufferData]], |fromIndex|, |count|).
  1. Return true.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3444,6 +3444,11 @@ The following abstract operations support the implementation of the
   1. Assert: ! [$CanCopyDataBlockBytes$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=],
      |destStart|, |headOfQueue|'s [=readable byte stream queue entry/buffer=],
      |headOfQueue|'s [=readable byte stream queue entry/byte offset=], |bytesToCopy|) is true.
+     <p class="warning">If this assertion were to fail (due to a bug in this specification or
+     its implementation), then the next step may read from or write to potentially invalid memory.
+     The user agent should always check this assertion, and stop in an [=implementation-defined=]
+     manner if it fails (e.g. by crashing the process, or by
+     <a abstract-op lt="ReadableByteStreamControllerError">erroring the stream</a>).
   1. Perform ! [$CopyDataBlockBytes$](|pullIntoDescriptor|'s [=pull-into
      descriptor/buffer=].\[[ArrayBufferData]], |destStart|,
      |headOfQueue|'s [=readable byte stream queue entry/buffer=].\[[ArrayBufferData]],

--- a/index.bs
+++ b/index.bs
@@ -3416,6 +3416,7 @@ The following abstract operations support the implementation of the
     |maxBytesToCopy|.
  1. Let |totalBytesToCopyRemaining| be |maxBytesToCopy|.
  1. Let |ready| be false.
+ 1. Assert: ! [$IsDetachedBuffer$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]) is false.
  1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] < |pullIntoDescriptor|'s
     [=pull-into descriptor/minimum fill=].
  1. Let |remainderBytes| be the remainder after dividing |maxBytesFilled| by |pullIntoDescriptor|'s

--- a/index.bs
+++ b/index.bs
@@ -3732,11 +3732,11 @@ The following abstract operations support the implementation of the
       |remainderSize|).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] − |remainderSize|.
+ 1. Let |filledPullIntos| be the result of performing
+    ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
  1. Perform !
     [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
     |pullIntoDescriptor|).
- 1. Let |filledPullIntos| be the result of performing
-    ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
  1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
    1. Perform !
       [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],

--- a/index.bs
+++ b/index.bs
@@ -3441,10 +3441,12 @@ The following abstract operations support the implementation of the
      queue entry/byte length=]).
   1. Let |destStart| be |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=] +
      |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=].
-  1. Perform ! [$CopyDataBlockBytes$](|pullIntoDescriptor|'s [=pull-into
-     descriptor/buffer=].\[[ArrayBufferData]], |destStart|,
-     |headOfQueue|'s [=readable byte stream queue entry/buffer=].\[[ArrayBufferData]],
-     |headOfQueue|'s [=readable byte stream queue entry/byte offset=], |bytesToCopy|).
+  1. If ! [$SafeCopyDataBlockBytes$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=],
+     |destStart|, |headOfQueue|'s [=readable byte stream queue entry/buffer=],
+     |headOfQueue|'s [=readable byte stream queue entry/byte offset=], |bytesToCopy|) is false,
+   1. Let |e| be a {{TypeError}} exception.
+   1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
+   1. Return false.
   1. If |headOfQueue|'s [=readable byte stream queue entry/byte length=] is |bytesToCopy|,
    1. [=list/Remove=] |queue|[0].
   1. Otherwise,
@@ -6846,6 +6848,24 @@ The following abstract operations are a grab-bag of utilities.
 
  1. Let |serialized| be ? [$StructuredSerialize$](|v|).
  1. Return ? [$StructuredDeserialize$](|serialized|, [=the current Realm=]).
+</div>
+
+<div algorithm>
+ <dfn abstract-op lt="SafeCopyDataBlockBytes">SafeCopyDataBlockBytes(|toBuffer|, |toIndex|,
+ |fromBuffer|, |fromIndex|, |count|)</dfn> performs the following steps:
+
+ 1. Assert: [$Type$](|toBuffer|) is Object.
+ 1. Assert: |toBuffer| has an \[[ArrayBufferData]] internal slot.
+ 1. Assert: [$Type$](|fromBuffer|) is Object.
+ 1. Assert: |fromBuffer| has an \[[ArrayBufferData]] internal slot.
+ 1. If |toBuffer| is |fromBuffer|, return false.
+ 1. If ! [$IsDetachedBuffer$](|toBuffer|) is true, return false.
+ 1. If ! [$IsDetachedBuffer$](|fromBuffer|) is true, return false.
+ 1. If |toIndex| + |count| > |toBuffer|.\[[ArrayBufferByteLength]], return false.
+ 1. If |fromIndex| + |count| > |fromBuffer|.\[[ArrayBufferByteLength]], return false.
+ 1. Perform ! [$CopyDataBlockBytes$](|toBuffer|.\[[ArrayBufferData]], |toIndex|,
+    |fromBuffer|.\[[ArrayBufferData]], |fromIndex|, |count|).
+ 1. Return true.
 </div>
 
 <h2 id="other-specs">Using streams in other specifications</h2>

--- a/index.bs
+++ b/index.bs
@@ -3545,17 +3545,20 @@ The following abstract operations support the implementation of the
  performs the following steps:
 
  1. Assert: |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is false.
+ 1. Let |filledPullIntos| be a new empty [=list=].
  1. [=While=] |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
     [=list/is empty|empty=],
-  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, return.
+  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, then [=break=].
   1. Let |pullIntoDescriptor| be
      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
      |pullIntoDescriptor|) is true,
    1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
-   1. Perform !
-      [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
-      |pullIntoDescriptor|).
+   1. [=list/Append=] |pullIntoDescriptor| to |filledPullIntos|.
+ 1. [=list/For each=] |pullIntoDescriptor| of |filledPullIntos|,
+  1. Perform !
+     [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+     |pullIntoDescriptor|).
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -3691,10 +3691,12 @@ The following abstract operations support the implementation of the
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
   1. Let |filledPullIntos| be a new empty [=list=].
-  1. [=While=] ! [$ReadableStreamGetNumReadIntoRequests$](|stream|) > 0,
+  1. Let |i| be 0.
+  1. [=While=] |i| < ! [$ReadableStreamGetNumReadIntoRequests$](|stream|),
    1. Let |pullIntoDescriptor| be !
       [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
    1. [=list/Append=] |pullIntoDescriptor| to |filledPullIntos|.
+   1. Set |i| to |i| + 1.
   1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
    1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|stream|,
       |filledPullInto|).

--- a/reference-implementation/lib/abstract-ops/miscellaneous.js
+++ b/reference-implementation/lib/abstract-ops/miscellaneous.js
@@ -1,5 +1,5 @@
 'use strict';
-const { CopyDataBlockBytes, IsDetachedBuffer } = require('./ecmascript');
+const { IsDetachedBuffer } = require('./ecmascript');
 
 exports.IsNonNegativeNumber = v => {
   if (typeof v !== 'number') {
@@ -22,7 +22,7 @@ exports.CloneAsUint8Array = O => {
   return new Uint8Array(buffer);
 };
 
-exports.SafeCopyDataBlockBytes = (toBuffer, toIndex, fromBuffer, fromIndex, count) => {
+exports.CanCopyDataBlockBytes = (toBuffer, toIndex, fromBuffer, fromIndex, count) => {
   if (toBuffer === fromBuffer) {
     return false;
   }
@@ -38,6 +38,5 @@ exports.SafeCopyDataBlockBytes = (toBuffer, toIndex, fromBuffer, fromIndex, coun
   if (fromIndex + count > fromBuffer.byteLength) {
     return false;
   }
-  CopyDataBlockBytes(toBuffer, toIndex, fromBuffer, fromIndex, count);
   return true;
 };

--- a/reference-implementation/lib/abstract-ops/miscellaneous.js
+++ b/reference-implementation/lib/abstract-ops/miscellaneous.js
@@ -1,4 +1,5 @@
 'use strict';
+const { CopyDataBlockBytes, IsDetachedBuffer } = require('./ecmascript');
 
 exports.IsNonNegativeNumber = v => {
   if (typeof v !== 'number') {
@@ -19,4 +20,24 @@ exports.IsNonNegativeNumber = v => {
 exports.CloneAsUint8Array = O => {
   const buffer = O.buffer.slice(O.byteOffset, O.byteOffset + O.byteLength);
   return new Uint8Array(buffer);
+};
+
+exports.SafeCopyDataBlockBytes = (toBuffer, toIndex, fromBuffer, fromIndex, count) => {
+  if (toBuffer === fromBuffer) {
+    return false;
+  }
+  if (IsDetachedBuffer(toBuffer) === true) {
+    return false;
+  }
+  if (IsDetachedBuffer(fromBuffer) === true) {
+    return false;
+  }
+  if (toIndex + count > toBuffer.byteLength) {
+    return false;
+  }
+  if (fromIndex + count > fromBuffer.byteLength) {
+    return false;
+  }
+  CopyDataBlockBytes(toBuffer, toIndex, fromBuffer, fromIndex, count);
+  return true;
 };

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1676,9 +1676,13 @@ function ReadableByteStreamControllerRespondInClosedState(controller, firstDescr
 
   const stream = controller._stream;
   if (ReadableStreamHasBYOBReader(stream) === true) {
+    const filledPullIntos = [];
     while (ReadableStreamGetNumReadIntoRequests(stream) > 0) {
       const pullIntoDescriptor = ReadableByteStreamControllerShiftPendingPullInto(controller);
-      ReadableByteStreamControllerCommitPullIntoDescriptor(stream, pullIntoDescriptor);
+      filledPullIntos.push(pullIntoDescriptor);
+    }
+    for (const filledPullInto of filledPullIntos) {
+      ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto);
     }
   }
 }

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1533,9 +1533,10 @@ function ReadableByteStreamControllerInvalidateBYOBRequest(controller) {
 function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller) {
   assert(controller._closeRequested === false);
 
+  const filledPullIntos = [];
   while (controller._pendingPullIntos.length > 0) {
     if (controller._queueTotalSize === 0) {
-      return;
+      break;
     }
 
     const pullIntoDescriptor = controller._pendingPullIntos[0];
@@ -1543,12 +1544,12 @@ function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(contro
 
     if (ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor) === true) {
       ReadableByteStreamControllerShiftPendingPullInto(controller);
-
-      ReadableByteStreamControllerCommitPullIntoDescriptor(
-        controller._stream,
-        pullIntoDescriptor
-      );
+      filledPullIntos.push(pullIntoDescriptor);
     }
+  }
+
+  for (const pullIntoDescriptor of filledPullIntos) {
+    ReadableByteStreamControllerCommitPullIntoDescriptor(controller._stream, pullIntoDescriptor);
   }
 }
 

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -4,9 +4,9 @@ const assert = require('assert');
 const { promiseResolvedWith, promiseRejectedWith, newPromise, resolvePromise, rejectPromise, uponPromise,
         setPromiseIsHandledToTrue, waitForAllPromise, transformPromiseWith, uponFulfillment, uponRejection } =
   require('../helpers/webidl.js');
-const { CanTransferArrayBuffer, Call, CreateArrayFromList, GetIterator, GetMethod, IsDetachedBuffer,
+const { CanTransferArrayBuffer, Call, CopyDataBlockBytes, CreateArrayFromList, GetIterator, GetMethod, IsDetachedBuffer,
         IteratorComplete, IteratorNext, IteratorValue, TransferArrayBuffer, typeIsObject } = require('./ecmascript.js');
-const { CloneAsUint8Array, IsNonNegativeNumber, SafeCopyDataBlockBytes } = require('./miscellaneous.js');
+const { CanCopyDataBlockBytes, CloneAsUint8Array, IsNonNegativeNumber } = require('./miscellaneous.js');
 const { EnqueueValueWithSize, ResetQueue } = require('./queue-with-sizes.js');
 const { AcquireWritableStreamDefaultWriter, IsWritableStreamLocked, WritableStreamAbort,
         WritableStreamDefaultWriterCloseWithErrorPropagation, WritableStreamDefaultWriterRelease,
@@ -1448,13 +1448,9 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
 
     const destStart = pullIntoDescriptor.byteOffset + pullIntoDescriptor.bytesFilled;
 
-    if (SafeCopyDataBlockBytes(pullIntoDescriptor.buffer, destStart, headOfQueue.buffer, headOfQueue.byteOffset,
-                               bytesToCopy) === false) {
-      // This should never happen. Please report an issue if it does! https://github.com/whatwg/streams/issues
-      const e = new TypeError('Invalid buffer');
-      ReadableByteStreamControllerError(controller, e);
-      return false;
-    }
+    assert(CanCopyDataBlockBytes(pullIntoDescriptor.buffer, destStart, headOfQueue.buffer, headOfQueue.byteOffset,
+                                 bytesToCopy));
+    CopyDataBlockBytes(pullIntoDescriptor.buffer, destStart, headOfQueue.buffer, headOfQueue.byteOffset, bytesToCopy);
 
     if (headOfQueue.byteLength === bytesToCopy) {
       queue.shift();

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1677,9 +1677,11 @@ function ReadableByteStreamControllerRespondInClosedState(controller, firstDescr
   const stream = controller._stream;
   if (ReadableStreamHasBYOBReader(stream) === true) {
     const filledPullIntos = [];
-    while (ReadableStreamGetNumReadIntoRequests(stream) > 0) {
+    let i = 0;
+    while (i < ReadableStreamGetNumReadIntoRequests(stream)) {
       const pullIntoDescriptor = ReadableByteStreamControllerShiftPendingPullInto(controller);
       filledPullIntos.push(pullIntoDescriptor);
+      ++i;
     }
     for (const filledPullInto of filledPullIntos) {
       ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto);

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1425,6 +1425,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
 
   let totalBytesToCopyRemaining = maxBytesToCopy;
   let ready = false;
+  assert(!IsDetachedBuffer(pullIntoDescriptor.buffer));
   assert(pullIntoDescriptor.bytesFilled < pullIntoDescriptor.minimumFill);
   const remainderBytes = maxBytesFilled % pullIntoDescriptor.elementSize;
   const maxAlignedBytes = maxBytesFilled - remainderBytes;

--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1717,9 +1717,9 @@ function ReadableByteStreamControllerRespondInReadableState(controller, bytesWri
   }
 
   pullIntoDescriptor.bytesFilled -= remainderSize;
-  ReadableByteStreamControllerCommitPullIntoDescriptor(controller._stream, pullIntoDescriptor);
-
   const filledPullIntos = ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
+
+  ReadableByteStreamControllerCommitPullIntoDescriptor(controller._stream, pullIntoDescriptor);
   for (const filledPullInto of filledPullIntos) {
     ReadableByteStreamControllerCommitPullIntoDescriptor(controller._stream, filledPullInto);
   }


### PR DESCRIPTION
In [Chromium bug #339877167](https://issues.chromium.org/issues/339877167), it was discovered that a user could run JavaScript code *synchronously* during `ReadableStreamFulfillReadIntoRequest` by patching `Object.prototype.then`, and use this gadget to break some invariants within `ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue`.

To prevent this, we now postpone all calls to `ReadableByteStreamControllerCommitPullIntoDescriptor` until *after* all pull-into descriptors have been filled up by `ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue`. This way, we won't trigger any patched `then()` method until the stream is in a stable state.

Fixes GHSA-p5g2-876g-95h9.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/48085
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/381211736
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1933826
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=283771
   * Deno: https://github.com/denoland/deno/issues/27117
   * Node.js: https://github.com/nodejs/node/issues/56044
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1326.html" title="Last updated on Nov 27, 2024, 9:55 PM UTC (1391f21)">Preview</a> | <a href="https://whatpr.org/streams/1326/86d07e9...1391f21.html" title="Last updated on Nov 27, 2024, 9:55 PM UTC (1391f21)">Diff</a>