### PR TITLE
Fix attempting to get the chunk size after strategy is cleared

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5373,6 +5373,10 @@ The following abstract operations support the implementation of the
  id="writable-stream-default-controller-get-chunk-size">WritableStreamDefaultControllerGetChunkSize(|controller|,
  |chunk|)</dfn> performs the following steps:
 
+ 1. If |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] is undefined, then:
+  1. Assert: |controller|.[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=] is "`erroring`" or
+     "`errored`".
+  1. Return 1.
  1. Let |returnValue| be the result of performing
     |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in |chunk|,
     and interpreting the result as a [=completion record=].

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -662,6 +662,11 @@ function WritableStreamDefaultControllerGetBackpressure(controller) {
 }
 
 function WritableStreamDefaultControllerGetChunkSize(controller, chunk) {
+  if (controller._strategySizeAlgorithm === undefined) {
+    assert(controller._stream._state === 'erroring' || controller._stream._state === 'errored');
+    return 1;
+  }
+
   try {
     return controller._strategySizeAlgorithm(chunk);
   } catch (chunkSizeE) {


### PR DESCRIPTION
Although a better fix might be to delay size calculation until we've verified that we're not in the erroring or errored states, that has observable differences for certain bad-strategy cases already in the WPT suite, and multiple implementations seem to have converged on this particular fix already.

Closes #1331.

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Already implemented in Chrome
   * Already implemented in Firefox
   * Other implementations behave observably the same way as those
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Already tested
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=283739
   * Deno: https://github.com/denoland/deno/issues/27102
   * Node.js: https://github.com/nodejs/node/issues/56014
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: small edge case; N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1333.html" title="Last updated on Nov 27, 2024, 4:29 AM UTC (bd98d4d)">Preview</a> | <a href="https://whatpr.org/streams/1333/8ebee1f...bd98d4d.html" title="Last updated on Nov 27, 2024, 4:29 AM UTC (bd98d4d)">Diff</a>