### PR TITLE
Meta: improve test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,16 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: reference-implementation
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
     - run: npm install
     - run: npm test

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -12,12 +12,12 @@
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "license": "(CC0-1.0 OR MIT)",
   "devDependencies": {
-    "browserify": "^16.5.1",
-    "c8": "^7.7.2",
+    "browserify": "^17.0.1",
+    "c8": "^10.1.2",
     "debug": "^4.1.1",
     "eslint": "^6.8.0",
-    "minimatch": "^3.0.4",
-    "opener": "^1.5.1",
+    "minimatch": "^10.0.1",
+    "opener": "^1.5.2",
     "webidl2js": "^18.0.0",
     "wpt-runner": "^5.0.0"
   }

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -19,6 +19,6 @@
     "minimatch": "^10.0.1",
     "opener": "^1.5.2",
     "webidl2js": "^18.0.0",
-    "wpt-runner": "^5.0.0"
+    "wpt-runner": "^6.0.0"
   }
 }

--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const { promisify } = require('util');
 const wptRunner = require('wpt-runner');
-const minimatch = require('minimatch');
+const { minimatch } = require('minimatch');
 const readFileAsync = promisify(fs.readFile);
 
 // wpt-runner does not yet support unhandled rejection tracking a la


### PR DESCRIPTION
This adds a few new WPT tests in order to improve our test coverage.

I used `npm run coverage` on the reference implementation to look for statements that were never hit, or branches that were never taken. I then wrote new tests to hit those statements and/or take the other branches.

No normative changes, since the reference implementation already passes all new tests.

* WPT PR: https://github.com/web-platform-tests/wpt/pull/49447