### PR TITLE
Editorial: Add mising ')' to ReadableStreamAddReadRequest definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2696,7 +2696,7 @@ the {{ReadableStream}}'s public API.
 
 <div algorithm>
  <dfn abstract-op lt="ReadableStreamAddReadRequest"
- id="readable-stream-add-read-request">ReadableStreamAddReadRequest(|stream|, |readRequest|</dfn>
+ id="readable-stream-add-read-request">ReadableStreamAddReadRequest(|stream|, |readRequest|)</dfn>
  performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[reader]]=] [=implements=] {{ReadableStreamDefaultReader}}.


### PR DESCRIPTION
Very minor typo I noticed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1335.html" title="Last updated on Dec 1, 2024, 2:24 PM UTC (18bd6c1)">Preview</a> | <a href="https://whatpr.org/streams/1335/1de47f0...18bd6c1.html" title="Last updated on Dec 1, 2024, 2:24 PM UTC (18bd6c1)">Diff</a>