### PR TITLE
Fix `[[ViewedArrayBuffer]].[[ByteLength]]` name in ReadableStreamBYOBRequest doc

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1446,7 +1446,7 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
  method steps are:
 
  1. If |view|.\[[ByteLength]] is 0, return [=a promise rejected with=] a {{TypeError}} exception.
- 1. If |view|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, return [=a promise rejected
+ 1. If |view|.\[[ViewedArrayBuffer]].\[[ByteLength]] is 0, return [=a promise rejected
     with=] a {{TypeError}} exception.
  1. If ! [$IsDetachedBuffer$](|view|.\[[ViewedArrayBuffer]]) is true, return
     [=a promise rejected with=] a {{TypeError}} exception.
@@ -1876,7 +1876,7 @@ has the following [=struct/items=]:
 for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
 
  1. If |chunk|.\[[ByteLength]] is 0, throw a {{TypeError}} exception.
- 1. If |chunk|.\[[ViewedArrayBuffer]].\[[ArrayBufferByteLength]] is 0, throw a {{TypeError}}
+ 1. If |chunk|.\[[ViewedArrayBuffer]].\[[ByteLength]] is 0, throw a {{TypeError}}
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[closeRequested]]=] is true, throw a {{TypeError}}
     exception.


### PR DESCRIPTION
While working on ReadableStreamBYOBRequest in Servo, we noticed that `[[ViewedArrayBuffer]].[[ArrayBufferByteLength]]` was wrongly used instead of `[[ViewedArrayBuffer]].[[ByteLength]]` in ReadableStreamBYOBRequest doc.

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1337.html" title="Last updated on Jan 22, 2025, 1:29 AM UTC (705e435)">Preview</a> | <a href="https://whatpr.org/streams/1337/d81b558...705e435.html" title="Last updated on Jan 22, 2025, 1:29 AM UTC (705e435)">Diff</a>