### PR TITLE
Editorial: fix markup errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5242,7 +5242,7 @@ The following abstract operations support the implementation and manipulation of
  1. Return |promise|.
 </div>
 
-<h4 id="ws-default-controller-abstract-ops">Default controllers</h3>
+<h4 id="ws-default-controller-abstract-ops">Default controllers</h4>
 
 The following abstract operations support the implementation of the
 {{WritableStreamDefaultController}} class.
@@ -6599,7 +6599,7 @@ a {{QueuingStrategy}} dictionary.
      list «&nbsp;|chunk|&nbsp;».
 </div>
 
-<h2 id="other-stuff">Supporting abstract operations</h4>
+<h2 id="other-stuff">Supporting abstract operations</h2>
 
 The following abstract operations each support the implementation of more than one type of stream,
 and as such are not grouped under the major sections above.
@@ -6815,7 +6815,7 @@ abstract operations are used to implement these "cross-realm transforms".
  security issues.</p>
 </div>
 
-<h3 id="misc-abstract-ops">Miscellaneous</h4>
+<h3 id="misc-abstract-ops">Miscellaneous</h3>
 
 The following abstract operations are a grab-bag of utilities.
 


### PR DESCRIPTION
These are caught by the new Bikeshed parser.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1338.html" title="Last updated on Jan 21, 2025, 2:04 AM UTC (4af3589)">Preview</a> | <a href="https://whatpr.org/streams/1338/f73f587...4af3589.html" title="Last updated on Jan 21, 2025, 2:04 AM UTC (4af3589)">Diff</a>