### PR TITLE
Add WritableStream.write convenience method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4064,6 +4064,7 @@ interface WritableStream {
 
   readonly attribute boolean locked;
 
+  Promise<undefined> write(optional any chunk);
   Promise<undefined> abort(optional any reason);
   Promise<undefined> close();
   WritableStreamDefaultWriter getWriter();
@@ -4270,6 +4271,17 @@ as seen for example in [[#example-ws-no-backpressure]].
  <dd>
   <p>Returns whether or not the writable stream is [=locked to a writer=].
 
+ <dt><code>await <var ignore>stream</var>.{{WritableStream/write(chunk)|write}}([ <var ignore>chunk</var> ])</code>
+ <dd>
+  <p>Writes a [=chunk=] of data to the stream just like the {{WritableStreamDefaultWriter/write()}}
+   method.
+
+  <p>This is a convenience method that first acquires a writer, then writes the chunk, and releases
+   the writer (regardless of the outcome of the write). The returned promise will fulfill if the
+   write was successful, or reject if the write failed. Additionally, it will reject with a
+   {{TypeError}} if the stream is currently [=locked to a writer|locked=] (without attempting to
+   write).
+
  <dt><code>await <var ignore>stream</var>.{{WritableStream/abort(reason)|abort}}([ <var ignore>reason</var> ])</code>
  <dd>
   <p>[=abort a writable stream|Aborts=] the stream, signaling that the producer can no longer
@@ -4330,6 +4342,22 @@ as seen for example in [[#example-ws-no-backpressure]].
  The <dfn id="ws-locked" attribute for="WritableStream">locked</dfn> getter steps are:
 
  1. Return ! [$IsWritableStreamLocked$]([=this=]).
+</div>
+
+<div algorithm>
+ The <dfn id="ws-write" method for="WritableStream">write(|chunk|)</dfn> method steps are:
+
+ 1. Let |result| be ? [$AcquireWritableStreamDefaultWriter$]([=this=]).
+ 1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
+ 1. Let |writer| be |result|.\[[Value]].
+ 1. Let |writePromise| be ! [$WritableStreamDefaultWriterWrite$]([=this=], |chunk|).
+ 1. Return the result of [=reacting=] to |writePromise|:
+  1. If |writePromise| is fulfilled with a value |v|, then:
+   1. Perform ! [$WritableStreamDefaultWriterRelease$]([=this=]).
+   1. Return |v|.
+  1. If |writePromise| is rejected with a value |r|, then:
+   1. Perform ! [$WritableStreamDefaultWriterRelease$]([=this=]).
+   1. Return [=a promise rejected with=] |r|.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Add a WriteableStream.write convenience method to write a single chunk. It locks, writes, then unlocks all in one call.

- [ ] At least two implementers are interested (and none opposed):
   * Deno
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
