### PR TITLE
Fix assertion when writing to a closed writable stream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5401,8 +5401,8 @@ The following abstract operations support the implementation of the
  |chunk|)</dfn> performs the following steps:
 
  1. If |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=] is undefined, then:
-  1. Assert: |controller|.[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=] is "`erroring`" or
-     "`errored`".
+  1. Assert: |controller|.[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=] is not
+     "`writable`".
   1. Return 1.
  1. Let |returnValue| be the result of performing
     |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in |chunk|,

--- a/reference-implementation/lib/abstract-ops/writable-streams.js
+++ b/reference-implementation/lib/abstract-ops/writable-streams.js
@@ -663,7 +663,7 @@ function WritableStreamDefaultControllerGetBackpressure(controller) {
 
 function WritableStreamDefaultControllerGetChunkSize(controller, chunk) {
   if (controller._strategySizeAlgorithm === undefined) {
-    assert(controller._stream._state === 'erroring' || controller._stream._state === 'errored');
+    assert(controller._stream._state !== 'writable');
     return 1;
   }
 


### PR DESCRIPTION
Closes #1341. /cc @daeyeon

<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * [Matches Chromium](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/streams/writable_stream_default_controller.cc;l=388-393;drc=d5af351cc29e7258499bad863b8e70298de981d2)
   * [Matches Firefox](https://searchfox.org/mozilla-central/rev/7bf5ed3b5364da0bee109bdcac3ab8c96df5a972/dom/streams/WritableStreamDefaultController.cpp#535-536)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/51819
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=283739
   * Deno: https://github.com/denoland/deno/issues/27102
   * Node.js: Fixed already by https://github.com/nodejs/node/pull/57280
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1342.html" title="Last updated on Apr 3, 2025, 7:09 AM UTC (5979711)">Preview</a> | <a href="https://whatpr.org/streams/1342/4d90f7f...5979711.html" title="Last updated on Apr 3, 2025, 7:09 AM UTC (5979711)">Diff</a>