### PR TITLE
Meta: implement `TransferArrayBuffer` correctly in reference implementation

### DIFF
--- a/reference-implementation/lib/abstract-ops/readable-streams.js
+++ b/reference-implementation/lib/abstract-ops/readable-streams.js
@@ -1584,6 +1584,8 @@ function ReadableByteStreamControllerPullInto(controller, view, min, readIntoReq
   assert(minimumFill >= elementSize && minimumFill <= view.byteLength);
   assert(minimumFill % elementSize === 0);
 
+  const byteOffset = view.byteOffset;
+  const byteLength = view.byteLength;
   const ctor = view.constructor;
 
   let buffer;
@@ -1597,8 +1599,8 @@ function ReadableByteStreamControllerPullInto(controller, view, min, readIntoReq
   const pullIntoDescriptor = {
     buffer,
     bufferByteLength: buffer.byteLength,
-    byteOffset: view.byteOffset,
-    byteLength: view.byteLength,
+    byteOffset,
+    byteLength,
     bytesFilled: 0,
     minimumFill,
     elementSize,


### PR DESCRIPTION
Previously, the reference implementation did not implement the `TransferArrayBuffer` abstract op correctly, because we didn't have a way of doing that synchronously in user-land code. Today, we can use `ArrayBuffer.prototype.transfer()` for that.

- [x] ~~At least two implementers are interested (and none opposed)~~
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/54350
- [x] ~~[Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed~~
- [x] ~~[MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed~~
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1353.html" title="Last updated on Aug 17, 2025, 11:38 AM UTC (852ded4)">Preview</a> | <a href="https://whatpr.org/streams/1353/4f2a2c1...852ded4.html" title="Last updated on Aug 17, 2025, 11:38 AM UTC (852ded4)">Diff</a>