### PR TITLE
Editorial: Narrow ReadableStreamBYOBRequest.view to Uint8Array

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1990,7 +1990,7 @@ The Web IDL definition for the {{ReadableStreamBYOBRequest}} class is given as f
 <xmp class="idl">
 [Exposed=*]
 interface ReadableStreamBYOBRequest {
-  readonly attribute ArrayBufferView? view;
+  readonly attribute Uint8Array? view;
 
   undefined respond([EnforceRange] unsigned long long bytesWritten);
   undefined respondWithNewView(ArrayBufferView view);

--- a/reference-implementation/lib/ReadableStreamBYOBRequest.webidl
+++ b/reference-implementation/lib/ReadableStreamBYOBRequest.webidl
@@ -1,6 +1,6 @@
 [Exposed=(Window,Worker,Worklet)]
 interface ReadableStreamBYOBRequest {
-  readonly attribute ArrayBufferView? view;
+  readonly attribute Uint8Array? view;
 
   undefined respond([EnforceRange] unsigned long long bytesWritten);
   undefined respondWithNewView(ArrayBufferView view);

--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -18,7 +18,7 @@
     "eslint": "^6.8.0",
     "minimatch": "^10.0.1",
     "opener": "^1.5.2",
-    "webidl2js": "^18.0.0",
-    "wpt-runner": "^6.0.0"
+    "webidl2js": "^19.1.0",
+    "wpt-runner": "^7.0.0"
   }
 }


### PR DESCRIPTION
`ReadableStreamBYOBRequest.view` is always constructed as a `Uint8Array` in the specification. Reflect this in the Web IDL.

Fixes #1366.

- [x] At least two implementers are interested (and none opposed): N/A
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * N/A: The existing tests already cover this, [see example](https://github.com/web-platform-tests/wpt/blob/7cb0bce2608006c5c16961d970248508d1724d5e/streams/readable-byte-streams/general.any.js#L383). The new IDL will be [automatically picked up by WPT](https://github.com/web-platform-tests/wpt/blob/b27a097e4a6a25436daff3b0588f9d4f813feecd/interfaces/README.md) after this PR is merged. (I have verified locally that the IDL harness tests still pass with the new IDL.)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/506189181
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2034973
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=313301
   * Deno: https://github.com/denoland/deno/issues/33476
   * Node.js: https://github.com/nodejs/node/issues/62952
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/pull/43934
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1367.html" title="Last updated on Apr 25, 2026, 1:07 PM UTC (868b4e4)">Preview</a> | <a href="https://whatpr.org/streams/1367/7611362...868b4e4.html" title="Last updated on Apr 25, 2026, 1:07 PM UTC (868b4e4)">Diff</a>