### PR TITLE
Remove abstract-op

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -810,17 +810,17 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
     <p class="note">We cannot declare the |underlyingSource| argument as having the
     {{UnderlyingSource}} type directly, because doing so would lose the reference to the original
     object. We need to retain the object so we can [=invoke=] the various methods on it.
- 1. Perform ! [$InitializeReadableStream$]([=this=]).
+ 1. Perform ! [=InitializeReadableStream=]([=this=]).
  1. If |underlyingSourceDict|["{{UnderlyingSource/type}}"] is "{{ReadableStreamType/bytes}}":
   1. If |strategy|["{{QueuingStrategy/size}}"] [=map/exists=], throw a {{RangeError}} exception.
-  1. Let |highWaterMark| be ? [$ExtractHighWaterMark$](|strategy|, 0).
-  1. Perform ? [$SetUpReadableByteStreamControllerFromUnderlyingSource$]([=this=],
+  1. Let |highWaterMark| be ? [=ExtractHighWaterMark=](|strategy|, 0).
+  1. Perform ? [=SetUpReadableByteStreamControllerFromUnderlyingSource=]([=this=],
      |underlyingSource|, |underlyingSourceDict|, |highWaterMark|).
  1. Otherwise,
   1. Assert: |underlyingSourceDict|["{{UnderlyingSource/type}}"] does not [=map/exist=].
-  1. Let |sizeAlgorithm| be ! [$ExtractSizeAlgorithm$](|strategy|).
-  1. Let |highWaterMark| be ? [$ExtractHighWaterMark$](|strategy|, 1).
-  1. Perform ? [$SetUpReadableStreamDefaultControllerFromUnderlyingSource$]([=this=],
+  1. Let |sizeAlgorithm| be ! [=ExtractSizeAlgorithm=](|strategy|).
+  1. Let |highWaterMark| be ? [=ExtractHighWaterMark=](|strategy|, 1).
+  1. Perform ? [=SetUpReadableStreamDefaultControllerFromUnderlyingSource=]([=this=],
      |underlyingSource|, |underlyingSourceDict|, |highWaterMark|, |sizeAlgorithm|).
 </div>
 
@@ -828,21 +828,21 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
  The static <dfn id="rs-from" method for="ReadableStream">from(|asyncIterable|)</dfn> method steps
  are:
 
- 1. Return ? [$ReadableStreamFromIterable$](|asyncIterable|).
+ 1. Return ? [=ReadableStreamFromIterable=](|asyncIterable|).
 </div>
 
 <div algorithm>
  The <dfn id="rs-locked" attribute for="ReadableStream">locked</dfn> getter steps are:
 
- 1. Return ! [$IsReadableStreamLocked$]([=this=]).
+ 1. Return ! [=IsReadableStreamLocked=]([=this=]).
 </div>
 
 <div algorithm>
  The <dfn id="rs-cancel" method for="ReadableStream">cancel(|reason|)</dfn> method steps are:
 
- 1. If ! [$IsReadableStreamLocked$]([=this=]) is true, return [=a promise rejected with=] a
+ 1. If ! [=IsReadableStreamLocked=]([=this=]) is true, return [=a promise rejected with=] a
     {{TypeError}} exception.
- 1. Return ! [$ReadableStreamCancel$]([=this=], |reason|).
+ 1. Return ! [=ReadableStreamCancel=]([=this=], |reason|).
 </div>
 
 <div algorithm>
@@ -850,10 +850,10 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
  are:
 
  1. If |options|["{{ReadableStreamGetReaderOptions/mode}}"] does not [=map/exist=], return ?
-    [$AcquireReadableStreamDefaultReader$]([=this=]).
+    [=AcquireReadableStreamDefaultReader=]([=this=]).
  1. Assert: |options|["{{ReadableStreamGetReaderOptions/mode}}"] is
     "{{ReadableStreamReaderMode/byob}}".
- 1. Return ? [$AcquireReadableStreamBYOBReader$]([=this=]).
+ 1. Return ? [=AcquireReadableStreamBYOBReader=]([=this=]).
 
  <div class="example" id="example-read-all-chunks">
   An example of an abstraction that might benefit from using a reader is a function like the
@@ -890,12 +890,12 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
  The <dfn id="rs-pipe-through" method for="ReadableStream">pipeThrough(|transform|, |options|)</dfn>
  method steps are:
 
- 1. If ! [$IsReadableStreamLocked$]([=this=]) is true, throw a {{TypeError}} exception.
- 1. If ! [$IsWritableStreamLocked$](|transform|["{{ReadableWritablePair/writable}}"]) is true, throw
+ 1. If ! [=IsReadableStreamLocked=]([=this=]) is true, throw a {{TypeError}} exception.
+ 1. If ! [=IsWritableStreamLocked=](|transform|["{{ReadableWritablePair/writable}}"]) is true, throw
     a {{TypeError}} exception.
  1. Let |signal| be |options|["{{StreamPipeOptions/signal}}"] if it [=map/exists=], or undefined
     otherwise.
- 1. Let |promise| be ! [$ReadableStreamPipeTo$]([=this=],
+ 1. Let |promise| be ! [=ReadableStreamPipeTo=]([=this=],
     |transform|["{{ReadableWritablePair/writable}}"],
     |options|["{{StreamPipeOptions/preventClose}}"],
     |options|["{{StreamPipeOptions/preventAbort}}"],
@@ -920,13 +920,13 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
  The <dfn id="rs-pipe-to" method for="ReadableStream">pipeTo(|destination|, |options|)</dfn>
  method steps are:
 
- 1. If ! [$IsReadableStreamLocked$]([=this=]) is true, return [=a promise rejected with=] a
+ 1. If ! [=IsReadableStreamLocked=]([=this=]) is true, return [=a promise rejected with=] a
     {{TypeError}} exception.
- 1. If ! [$IsWritableStreamLocked$](|destination|) is true, return [=a promise rejected with=] a
+ 1. If ! [=IsWritableStreamLocked=](|destination|) is true, return [=a promise rejected with=] a
     {{TypeError}} exception.
  1. Let |signal| be |options|["{{StreamPipeOptions/signal}}"] if it [=map/exists=], or undefined
     otherwise.
- 1. Return ! [$ReadableStreamPipeTo$]([=this=], |destination|,
+ 1. Return ! [=ReadableStreamPipeTo=]([=this=], |destination|,
     |options|["{{StreamPipeOptions/preventClose}}"],
     |options|["{{StreamPipeOptions/preventAbort}}"],
     |options|["{{StreamPipeOptions/preventCancel}}"], |signal|).
@@ -978,7 +978,7 @@ option. If {{UnderlyingSource/type}} is set to undefined (including via omission
 <div algorithm>
  The <dfn id="rs-tee" method for="ReadableStream">tee()</dfn> method steps are:
 
- 1. Return ? [$ReadableStreamTee$]([=this=], false).
+ 1. Return ? [=ReadableStreamTee=]([=this=], false).
 
  <div class="example" id="example-tee-and-pipe">
   Teeing a stream is most useful when you wish to let two independent consumers read from the stream
@@ -1023,7 +1023,7 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  The [=asynchronous iterator initialization steps=] for a {{ReadableStream}}, given |stream|,
  |iterator|, and |args|, are:
 
- 1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
+ 1. Let |reader| be ? [=AcquireReadableStreamDefaultReader=](|stream|).
  1. Set |iterator|'s <dfn for="ReadableStream async iterator">reader</dfn> to |reader|.
  1. Let |preventCancel| be |args|[0]["{{ReadableStreamIteratorOptions/preventCancel}}"].
  1. Set |iterator|'s <dfn for="ReadableStream async iterator">prevent cancel</dfn> to
@@ -1043,13 +1043,13 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
    1. [=Resolve=] |promise| with |chunk|.
   : [=read request/close steps=]
   ::
-   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+   1. Perform ! [=ReadableStreamDefaultReaderRelease=](|reader|).
    1. [=Resolve=] |promise| with [=end of iteration=].
   : [=read request/error steps=], given |e|
   ::
-   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+   1. Perform ! [=ReadableStreamDefaultReaderRelease=](|reader|).
    1. [=Reject=] |promise| with |e|.
- 1. Perform ! [$ReadableStreamDefaultReaderRead$]([=this=], |readRequest|).
+ 1. Perform ! [=ReadableStreamDefaultReaderRead=]([=this=], |readRequest|).
  1. Return |promise|.
 </div>
 
@@ -1063,10 +1063,10 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
     as the async iterator machinery guarantees that any previous calls to `next()` have settled
     before this is called.
  1. If |iterator|'s [=ReadableStream async iterator/prevent cancel=] is false:
-  1. Let |result| be ! [$ReadableStreamReaderGenericCancel$](|reader|, |arg|).
-  1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+  1. Let |result| be ! [=ReadableStreamReaderGenericCancel=](|reader|, |arg|).
+  1. Perform ! [=ReadableStreamDefaultReaderRelease=](|reader|).
   1. Return |result|.
- 1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+ 1. Perform ! [=ReadableStreamDefaultReaderRelease=](|reader|).
  1. Return [=a promise resolved with=] undefined.
 </div>
 
@@ -1086,13 +1086,13 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  {{ReadableStream}} objects are [=transferable objects=]. Their [=transfer steps=], given |value|
  and |dataHolder|, are:
 
- 1. If ! [$IsReadableStreamLocked$](|value|) is true, throw a "{{DataCloneError}}" {{DOMException}}.
+ 1. If ! [=IsReadableStreamLocked=](|value|) is true, throw a "{{DataCloneError}}" {{DOMException}}.
  1. Let |port1| be a [=new=] {{MessagePort}} in [=the current Realm=].
  1. Let |port2| be a [=new=] {{MessagePort}} in [=the current Realm=].
  1. [=Entangle=] |port1| and |port2|.
  1. Let |writable| be a [=new=] {{WritableStream}} in [=the current Realm=].
- 1. Perform ! [$SetUpCrossRealmTransformWritable$](|writable|, |port1|).
- 1. Let |promise| be ! [$ReadableStreamPipeTo$](|value|, |writable|, false, false, false).
+ 1. Perform ! [=SetUpCrossRealmTransformWritable=](|writable|, |port1|).
+ 1. Let |promise| be ! [=ReadableStreamPipeTo=](|value|, |writable|, false, false, false).
  1. Set |promise|.\[[PromiseIsHandled]] to true.
  1. Set |dataHolder|.\[[port]] to ! [$StructuredSerializeWithTransfer$](|port2|, « |port2| »).
 </div>
@@ -1103,7 +1103,7 @@ default-reader-asynciterator-prototype-internal-slots">Asynchronous iteration</h
  1. Let |deserializedRecord| be ! [$StructuredDeserializeWithTransfer$](|dataHolder|.\[[port]],
     [=the current Realm=]).
  1. Let |port| be |deserializedRecord|.\[[Deserialized]].
- 1. Perform ! [$SetUpCrossRealmTransformReadable$](|value|, |port|).
+ 1. Perform ! [=SetUpCrossRealmTransformReadable=](|value|, |port|).
 
 </div>
 
@@ -1161,7 +1161,7 @@ internal slots described in the following table:
 
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. Return ! [$ReadableStreamReaderGenericCancel$]([=this=], |reason|).
+ 1. Return ! [=ReadableStreamReaderGenericCancel=]([=this=], |reason|).
 </div>
 
 <h3 id="default-reader-class">The {{ReadableStreamDefaultReader}} class</h3>
@@ -1273,7 +1273,7 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  lt="ReadableStreamDefaultReader(stream)">new ReadableStreamDefaultReader(|stream|)</dfn>
  constructor steps are:
 
- 1. Perform ? [$SetUpReadableStreamDefaultReader$]([=this=], |stream|).
+ 1. Perform ? [=SetUpReadableStreamDefaultReader=]([=this=], |stream|).
 </div>
 
 <div algorithm>
@@ -1295,7 +1295,7 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
   : [=read request/error steps=], given |e|
   ::
    1. [=Reject=] |promise| with |e|.
- 1. Perform ! [$ReadableStreamDefaultReaderRead$]([=this=], |readRequest|).
+ 1. Perform ! [=ReadableStreamDefaultReaderRead=]([=this=], |readRequest|).
  1. Return |promise|.
 </div>
 
@@ -1304,7 +1304,7 @@ to filling the [=readable stream=]'s [=internal queue=] or changing its state. I
  for="ReadableStreamDefaultReader">releaseLock()</dfn> method steps are:
 
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
- 1. Perform ! [$ReadableStreamDefaultReaderRelease$]([=this=]).
+ 1. Perform ! [=ReadableStreamDefaultReaderRelease=]([=this=]).
 </div>
 
 <h3 id="byob-reader-class">The {{ReadableStreamBYOBReader}} class</h3>
@@ -1440,7 +1440,7 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
  lt="ReadableStreamBYOBReader(stream)">new ReadableStreamBYOBReader(|stream|)</dfn> constructor
  steps are:
 
- 1. Perform ? [$SetUpReadableStreamBYOBReader$]([=this=], |stream|).
+ 1. Perform ? [=SetUpReadableStreamBYOBReader=]([=this=], |stream|).
 </div>
 
 <div algorithm>
@@ -1475,7 +1475,7 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
   : [=read-into request/error steps=], given |e|
   ::
    1. [=Reject=] |promise| with |e|.
- 1. Perform ! [$ReadableStreamBYOBReaderRead$]([=this=], |view|, |options|["{{ReadableStreamBYOBReaderReadOptions/min}}"], |readIntoRequest|).
+ 1. Perform ! [=ReadableStreamBYOBReaderRead=]([=this=], |view|, |options|["{{ReadableStreamBYOBReaderReadOptions/min}}"], |readIntoRequest|).
  1. Return |promise|.
 </div>
 
@@ -1484,7 +1484,7 @@ value: newViewOnSameMemory, done: true }</code> for closed streams. If the strea
  for="ReadableStreamBYOBReader">releaseLock()</dfn> method steps are:
 
  1. If [=this=].[=ReadableStreamGenericReader/[[stream]]=] is undefined, return.
- 1. Perform ! [$ReadableStreamBYOBReaderRelease$]([=this=]).
+ 1. Perform ! [=ReadableStreamBYOBReaderRelease=]([=this=]).
 </div>
 
 <h3 id="rs-default-controller-class">The {{ReadableStreamDefaultController}} class</h3>
@@ -1598,32 +1598,32 @@ the following table:
  The <dfn id="rs-default-controller-desired-size" attribute
  for="ReadableStreamDefaultController">desiredSize</dfn> getter steps are:
 
- 1. Return ! [$ReadableStreamDefaultControllerGetDesiredSize$]([=this=]).
+ 1. Return ! [=ReadableStreamDefaultControllerGetDesiredSize=]([=this=]).
 </div>
 
 <div algorithm>
  The <dfn id="rs-default-controller-close" method
  for="ReadableStreamDefaultController">close()</dfn> method steps are:
 
- 1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$]([=this=]) is false, throw a
+ 1. If ! [=ReadableStreamDefaultControllerCanCloseOrEnqueue=]([=this=]) is false, throw a
     {{TypeError}} exception.
- 1. Perform ! [$ReadableStreamDefaultControllerClose$]([=this=]).
+ 1. Perform ! [=ReadableStreamDefaultControllerClose=]([=this=]).
 </div>
 
 <div algorithm>
  The <dfn id="rs-default-controller-enqueue" method
  for="ReadableStreamDefaultController">enqueue(|chunk|)</dfn> method steps are:
 
- 1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$]([=this=]) is false, throw a
+ 1. If ! [=ReadableStreamDefaultControllerCanCloseOrEnqueue=]([=this=]) is false, throw a
     {{TypeError}} exception.
- 1. Perform ? [$ReadableStreamDefaultControllerEnqueue$]([=this=], |chunk|).
+ 1. Perform ? [=ReadableStreamDefaultControllerEnqueue=]([=this=], |chunk|).
 </div>
 
 <div algorithm>
  The <dfn id="rs-default-controller-error" method
  for="ReadableStreamDefaultController">error(|e|)</dfn> method steps are:
 
- 1. Perform ! [$ReadableStreamDefaultControllerError$]([=this=], |e|).
+ 1. Perform ! [=ReadableStreamDefaultControllerError=]([=this=], |e|).
 </div>
 
 <h4 id="rs-default-controller-internal-methods">Internal methods</h4>
@@ -1637,10 +1637,10 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
  id="rs-default-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
- 1. Perform ! [$ResetQueue$]([=this=]).
+ 1. Perform ! [=ResetQueue=]([=this=]).
  1. Let |result| be the result of performing
     [=this=].[=ReadableStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
- 1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$]([=this=]).
+ 1. Perform ! [=ReadableStreamDefaultControllerClearAlgorithms=]([=this=]).
  1. Return |result|.
 </div>
 
@@ -1651,16 +1651,16 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
 
  1. Let |stream| be [=this=].[=ReadableStreamDefaultController/[[stream]]=].
  1. If [=this=].[=ReadableStreamDefaultController/[[queue]]=] is not [=list/is empty|empty=],
-  1. Let |chunk| be ! [$DequeueValue$]([=this=]).
+  1. Let |chunk| be ! [=DequeueValue=]([=this=]).
   1. If [=this=].[=ReadableStreamDefaultController/[[closeRequested]]=] is true and
      [=this=].[=ReadableStreamDefaultController/[[queue]]=] [=list/is empty=],
-   1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$]([=this=]).
-   1. Perform ! [$ReadableStreamClose$](|stream|).
-  1. Otherwise, perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$]([=this=]).
+   1. Perform ! [=ReadableStreamDefaultControllerClearAlgorithms=]([=this=]).
+   1. Perform ! [=ReadableStreamClose=](|stream|).
+  1. Otherwise, perform ! [=ReadableStreamDefaultControllerCallPullIfNeeded=]([=this=]).
   1. Perform |readRequest|'s [=read request/chunk steps=], given |chunk|.
  1. Otherwise,
-  1. Perform ! [$ReadableStreamAddReadRequest$](|stream|, |readRequest|).
-  1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$]([=this=]).
+  1. Perform ! [=ReadableStreamAddReadRequest=](|stream|, |readRequest|).
+  1. Perform ! [=ReadableStreamDefaultControllerCallPullIfNeeded=]([=this=]).
 </div>
 
 <div algorithm>
@@ -1852,14 +1852,14 @@ has the following [=struct/items=]:
  The <dfn id="rbs-controller-byob-request" attribute
  for="ReadableByteStreamController">byobRequest</dfn> getter steps are:
 
- 1. Return ! [$ReadableByteStreamControllerGetBYOBRequest$]([=this=]).
+ 1. Return ! [=ReadableByteStreamControllerGetBYOBRequest=]([=this=]).
 </div>
 
 <div algorithm>
  The <dfn id="rbs-controller-desired-size" attribute
  for="ReadableByteStreamController">desiredSize</dfn> getter steps are:
 
- 1. Return ! [$ReadableByteStreamControllerGetDesiredSize$]([=this=]).
+ 1. Return ! [=ReadableByteStreamControllerGetDesiredSize=]([=this=]).
 </div>
 
 <div algorithm>
@@ -1870,7 +1870,7 @@ has the following [=struct/items=]:
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
- 1. Perform ? [$ReadableByteStreamControllerClose$]([=this=]).
+ 1. Perform ? [=ReadableByteStreamControllerClose=]([=this=]).
 </div>
 
 <div algorithm>
@@ -1884,14 +1884,14 @@ for="ReadableByteStreamController">enqueue(|chunk|)</dfn> method steps are:
     exception.
  1. If [=this=].[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=] is not
     "`readable`", throw a {{TypeError}} exception.
- 1. Return ? [$ReadableByteStreamControllerEnqueue$]([=this=], |chunk|).
+ 1. Return ? [=ReadableByteStreamControllerEnqueue=]([=this=], |chunk|).
 </div>
 
 <div algorithm>
  The <dfn id="rbs-controller-error" method for="ReadableByteStreamController">error(|e|)</dfn>
  method steps are:
 
- 1. Perform ! [$ReadableByteStreamControllerError$]([=this=], |e|).
+ 1. Perform ! [=ReadableByteStreamControllerError=]([=this=], |e|).
 </div>
 
 <h4 id="rbs-controller-internal-methods">Internal methods</h4>
@@ -1905,11 +1905,11 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  id="rbs-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
- 1. Perform ! [$ReadableByteStreamControllerClearPendingPullIntos$]([=this=]).
- 1. Perform ! [$ResetQueue$]([=this=]).
+ 1. Perform ! [=ReadableByteStreamControllerClearPendingPullIntos=]([=this=]).
+ 1. Perform ! [=ResetQueue=]([=this=]).
  1. Let |result| be the result of performing
     [=this=].[=ReadableByteStreamController/[[cancelAlgorithm]]=], passing in |reason|.
- 1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$]([=this=]).
+ 1. Perform ! [=ReadableByteStreamControllerClearAlgorithms=]([=this=]).
  1. Return |result|.
 </div>
 
@@ -1919,15 +1919,15 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
  1. Let |stream| be [=this=].[=ReadableByteStreamController/[[stream]]=].
- 1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
+ 1. Assert: ! [=ReadableStreamHasDefaultReader=](|stream|) is true.
  1. If [=this=].[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
-  1. Assert: ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0.
-  1. Perform ! [$ReadableByteStreamControllerFillReadRequestFromQueue$]([=this=], |readRequest|).
+  1. Assert: ! [=ReadableStreamGetNumReadRequests=](|stream|) is 0.
+  1. Perform ! [=ReadableByteStreamControllerFillReadRequestFromQueue=]([=this=], |readRequest|).
   1. Return.
  1. Let |autoAllocateChunkSize| be
     [=this=].[=ReadableByteStreamController/[[autoAllocateChunkSize]]=].
  1. If |autoAllocateChunkSize| is not undefined,
-  1. Let |buffer| be [$Construct$]({{%ArrayBuffer%}}, « |autoAllocateChunkSize| »).
+  1. Let |buffer| be [=Construct=]({{%ArrayBuffer%}}, « |autoAllocateChunkSize| »).
   1. If |buffer| is an abrupt completion,
    1. Perform |readRequest|'s [=read request/error steps=], given |buffer|.\[[Value]].
    1. Return.
@@ -1962,8 +1962,8 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
      </dl>
   1. [=list/Append=] |pullIntoDescriptor| to
      [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=].
- 1. Perform ! [$ReadableStreamAddReadRequest$](|stream|, |readRequest|).
- 1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$]([=this=]).
+ 1. Perform ! [=ReadableStreamAddReadRequest=](|stream|, |readRequest|).
+ 1. Perform ! [=ReadableByteStreamControllerCallPullIfNeeded=]([=this=]).
 </div>
 
 <div algorithm>
@@ -2069,7 +2069,7 @@ following table:
  1. Assert: [=this=].[=ReadableStreamBYOBRequest/[[view]]=].\[[ViewedArrayBuffer]].\[[ByteLength]]
     &gt; 0.
  1. Perform ?
-    [$ReadableByteStreamControllerRespond$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
+    [=ReadableByteStreamControllerRespond=]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
     |bytesWritten|).
 </div>
 
@@ -2082,7 +2082,7 @@ following table:
  1. If ! [$IsDetachedBuffer$](|view|.\[[ViewedArrayBuffer]]) is true,
     throw a {{TypeError}} exception.
  1. Return ?
-    [$ReadableByteStreamControllerRespondWithNewView$]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
+    [=ReadableByteStreamControllerRespondWithNewView=]([=this=].[=ReadableStreamBYOBRequest/[[controller]]=],
     |view|).
 </div>
 
@@ -2093,37 +2093,37 @@ following table:
 The following abstract operations operate on {{ReadableStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op lt="AcquireReadableStreamBYOBReader"
+ <dfn lt="AcquireReadableStreamBYOBReader"
  id="acquire-readable-stream-byob-reader">AcquireReadableStreamBYOBReader(|stream|)</dfn> performs
  the following steps:
 
  1. Let |reader| be a [=new=] {{ReadableStreamBYOBReader}}.
- 1. Perform ? [$SetUpReadableStreamBYOBReader$](|reader|, |stream|).
+ 1. Perform ? [=SetUpReadableStreamBYOBReader=](|reader|, |stream|).
  1. Return |reader|.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="AcquireReadableStreamDefaultReader"
+ <dfn lt="AcquireReadableStreamDefaultReader"
  id="acquire-readable-stream-reader">AcquireReadableStreamDefaultReader(|stream|)</dfn> performs the
  following steps:
 
   1. Let |reader| be a [=new=] {{ReadableStreamDefaultReader}}.
-  1. Perform ? [$SetUpReadableStreamDefaultReader$](|reader|, |stream|).
+  1. Perform ? [=SetUpReadableStreamDefaultReader=](|reader|, |stream|).
   1. Return |reader|.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateReadableStream"
+ <dfn lt="CreateReadableStream"
  id="create-readable-stream">CreateReadableStream(|startAlgorithm|, |pullAlgorithm|,
  |cancelAlgorithm|[, |highWaterMark|, [, |sizeAlgorithm|]])</dfn> performs the following steps:
 
  1. If |highWaterMark| was not passed, set it to 1.
  1. If |sizeAlgorithm| was not passed, set it to an algorithm that returns 1.
- 1. Assert: ! [$IsNonNegativeNumber$](|highWaterMark|) is true.
+ 1. Assert: ! [=IsNonNegativeNumber=](|highWaterMark|) is true.
  1. Let |stream| be a [=new=] {{ReadableStream}}.
- 1. Perform ! [$InitializeReadableStream$](|stream|).
+ 1. Perform ! [=InitializeReadableStream=](|stream|).
  1. Let |controller| be a [=new=] {{ReadableStreamDefaultController}}.
- 1. Perform ? [$SetUpReadableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ? [=SetUpReadableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|, |sizeAlgorithm|).
  1. Return |stream|.
 
@@ -2132,13 +2132,13 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
+ <dfn lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
  |pullAlgorithm|, |cancelAlgorithm|)</dfn> performs the following steps:
 
  1. Let |stream| be a [=new=] {{ReadableStream}}.
- 1. Perform ! [$InitializeReadableStream$](|stream|).
+ 1. Perform ! [=InitializeReadableStream=](|stream|).
  1. Let |controller| be a [=new=] {{ReadableByteStreamController}}.
- 1. Perform ? [$SetUpReadableByteStreamController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ? [=SetUpReadableByteStreamController=](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, 0, undefined).
  1. Return |stream|.
 
@@ -2147,7 +2147,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="InitializeReadableStream"
+ <dfn lt="InitializeReadableStream"
  id="initialize-readable-stream">InitializeReadableStream(|stream|)</dfn> performs the following
  steps:
 
@@ -2158,7 +2158,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="IsReadableStreamLocked"
+ <dfn lt="IsReadableStreamLocked"
  id="is-readable-stream-locked">IsReadableStreamLocked(|stream|)</dfn> performs the following steps:
 
  1. If |stream|.[=ReadableStream/[[reader]]=] is undefined, return false.
@@ -2166,7 +2166,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamFromIterable" id="readable-stream-from-iterable">
+ <dfn lt="ReadableStreamFromIterable" id="readable-stream-from-iterable">
  ReadableStreamFromIterable(|asyncIterable|)</dfn> performs the following steps:
 
  1. Let |stream| be undefined.
@@ -2182,10 +2182,10 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. If |iterResult| [=is not an Object=], throw a {{TypeError}}.
    1. Let |done| be ? [$IteratorComplete$](|iterResult|).
    1. If |done| is true:
-    1. Perform ! [$ReadableStreamDefaultControllerClose$](|stream|.[=ReadableStream/[[controller]]=]).
+    1. Perform ! [=ReadableStreamDefaultControllerClose=](|stream|.[=ReadableStream/[[controller]]=]).
    1. Otherwise:
     1. Let |value| be ? [$IteratorValue$](|iterResult|).
-    1. Perform ! [$ReadableStreamDefaultControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=],
+    1. Perform ! [=ReadableStreamDefaultControllerEnqueue=](|stream|.[=ReadableStream/[[controller]]=],
        |value|).
        <!-- TODO (future): If we allow changing the queuing strategy, this Enqueue might throw.
              We'll then need to catch the error and close the async iterator. -->
@@ -2203,13 +2203,13 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
      given |iterResult|:
    1. If |iterResult| [=is not an Object=], throw a {{TypeError}}.
    1. Return undefined.
- 1. Set |stream| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|,
+ 1. Set |stream| to ! [=CreateReadableStream=](|startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|,
     0).
  1. Return |stream|.
 </div>
 
 <div algorithm="ReadableStreamPipeTo">
- <dfn abstract-op lt="ReadableStreamPipeTo"
+ <dfn lt="ReadableStreamPipeTo"
  id="readable-stream-pipe-to">ReadableStreamPipeTo(|source|, |dest|, |preventClose|, |preventAbort|,
  |preventCancel|[, |signal|])</dfn> performs the following steps:
 
@@ -2218,13 +2218,13 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
  1. Assert: |preventClose|, |preventAbort|, and |preventCancel| are all booleans.
  1. If |signal| was not given, let |signal| be undefined.
  1. Assert: either |signal| is undefined, or |signal| [=implements=] {{AbortSignal}}.
- 1. Assert: ! [$IsReadableStreamLocked$](|source|) is false.
- 1. Assert: ! [$IsWritableStreamLocked$](|dest|) is false.
+ 1. Assert: ! [=IsReadableStreamLocked=](|source|) is false.
+ 1. Assert: ! [=IsWritableStreamLocked=](|dest|) is false.
  1. If |source|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
-    let |reader| be either ! [$AcquireReadableStreamBYOBReader$](|source|) or !
-    [$AcquireReadableStreamDefaultReader$](|source|), at the user agent's discretion.
- 1. Otherwise, let |reader| be ! [$AcquireReadableStreamDefaultReader$](|source|).
- 1. Let |writer| be ! [$AcquireWritableStreamDefaultWriter$](|dest|).
+    let |reader| be either ! [=AcquireReadableStreamBYOBReader=](|source|) or !
+    [=AcquireReadableStreamDefaultReader=](|source|), at the user agent's discretion.
+ 1. Otherwise, let |reader| be ! [=AcquireReadableStreamDefaultReader=](|source|).
+ 1. Let |writer| be ! [=AcquireWritableStreamDefaultWriter=](|dest|).
  1. Set |source|.[=ReadableStream/[[disturbed]]=] to true.
  1. Let |shuttingDown| be false.
  1. Let |promise| be [=a new promise=].
@@ -2234,11 +2234,11 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. Let |actions| be an empty [=ordered set=].
    1. If |preventAbort| is false, [=set/append=] the following action to |actions|:
      1. If |dest|.[=WritableStream/[[state]]=] is "`writable`", return !
-        [$WritableStreamAbort$](|dest|, |error|).
+        [=WritableStreamAbort=](|dest|, |error|).
      1. Otherwise, return [=a promise resolved with=] undefined.
    1. If |preventCancel| is false, [=set/append=] the following action action to |actions|:
      1. If |source|.[=ReadableStream/[[state]]=] is "`readable`", return !
-        [$ReadableStreamCancel$](|source|, |error|).
+        [=ReadableStreamCancel=](|source|, |error|).
      1. Otherwise, return [=a promise resolved with=] undefined.
    1. [=Shutdown with an action=] consisting of [=getting a promise to wait for all=] of the actions
       in |actions|, and with |error|.
@@ -2255,9 +2255,9 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
     on the appropriate prototypes) must not be used. Instead, the streams must be manipulated
     directly.
   * <strong>Backpressure must be enforced:</strong>
-   * While [$WritableStreamDefaultWriterGetDesiredSize$](|writer|) is ≤ 0 or is null, the user
+   * While [=WritableStreamDefaultWriterGetDesiredSize=](|writer|) is ≤ 0 or is null, the user
      agent must not read from |reader|.
-   * If |reader| is a [=BYOB reader=], [$WritableStreamDefaultWriterGetDesiredSize$](|writer|)
+   * If |reader| is a [=BYOB reader=], [=WritableStreamDefaultWriterGetDesiredSize=](|writer|)
      should be used as a basis to determine the size of the chunks read from |reader|.
      <p class="note">It's frequently inefficient to read chunks that are too small or too large.
      Other information might be factored in to determine the optimal chunk size.
@@ -2274,28 +2274,28 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
     applied in order.
    1. <strong>Errors must be propagated forward:</strong> if |source|.[=ReadableStream/[[state]]=]
       is or becomes "`errored`", then
-    1. If |preventAbort| is false, [=shutdown with an action=] of ! [$WritableStreamAbort$](|dest|,
+    1. If |preventAbort| is false, [=shutdown with an action=] of ! [=WritableStreamAbort=](|dest|,
        |source|.[=ReadableStream/[[storedError]]=]) and with
        |source|.[=ReadableStream/[[storedError]]=].
     1. Otherwise, [=shutdown=] with |source|.[=ReadableStream/[[storedError]]=].
    1. <strong>Errors must be propagated backward:</strong> if |dest|.[=WritableStream/[[state]]=]
       is or becomes "`errored`", then
     1. If |preventCancel| is false, [=shutdown with an action=] of !
-       [$ReadableStreamCancel$](|source|, |dest|.[=WritableStream/[[storedError]]=]) and with
+       [=ReadableStreamCancel=](|source|, |dest|.[=WritableStream/[[storedError]]=]) and with
        |dest|.[=WritableStream/[[storedError]]=].
     1. Otherwise, [=shutdown=] with |dest|.[=WritableStream/[[storedError]]=].
    1. <strong>Closing must be propagated forward:</strong> if |source|.[=ReadableStream/[[state]]=]
       is or becomes "`closed`", then
     1. If |preventClose| is false, [=shutdown with an action=] of !
-       [$WritableStreamDefaultWriterCloseWithErrorPropagation$](|writer|).
+       [=WritableStreamDefaultWriterCloseWithErrorPropagation=](|writer|).
     1. Otherwise, [=shutdown=].
    1. <strong>Closing must be propagated backward:</strong> if !
-      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is true or |dest|.[=WritableStream/[[state]]=]
+      [=WritableStreamCloseQueuedOrInFlight=](|dest|) is true or |dest|.[=WritableStream/[[state]]=]
       is "`closed`", then
     1. Assert: no [=chunks=] have been read or written.
     1. Let |destClosed| be a new {{TypeError}}.
     1. If |preventCancel| is false, [=shutdown with an action=] of !
-       [$ReadableStreamCancel$](|source|, |destClosed|) and with |destClosed|.
+       [=ReadableStreamCancel=](|source|, |destClosed|) and with |destClosed|.
     1. Otherwise, [=shutdown=] with |destClosed|.
   * <dfn id="rs-pipeTo-shutdown-with-action"><i>Shutdown with an action</i></dfn>: if any of the
     above requirements ask to shutdown with an action |action|, optionally with an error
@@ -2303,7 +2303,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
    1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
-      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
+      [=WritableStreamCloseQueuedOrInFlight=](|dest|) is false,
      1. If any [=chunks=] have been read but not yet written, write them to |dest|.
      1. Wait until every [=chunk=] that has been read has been written (i.e. the corresponding
         promises have settled).
@@ -2315,17 +2315,17 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
    1. If |shuttingDown| is true, abort these substeps.
    1. Set |shuttingDown| to true.
    1. If |dest|.[=WritableStream/[[state]]=] is "`writable`" and !
-      [$WritableStreamCloseQueuedOrInFlight$](|dest|) is false,
+      [=WritableStreamCloseQueuedOrInFlight=](|dest|) is false,
     1. If any [=chunks=] have been read but not yet written, write them to |dest|.
     1. Wait until every [=chunk=] that has been read has been written (i.e. the corresponding
        promises have settled).
    1. [=Finalize=], passing along |error| if it was given.
   * <dfn id="rs-pipeTo-finalize"><i>Finalize</i></dfn>: both forms of shutdown will eventually ask
     to finalize, optionally with an error |error|, which means to perform the following steps:
-   1. Perform ! [$WritableStreamDefaultWriterRelease$](|writer|).
+   1. Perform ! [=WritableStreamDefaultWriterRelease=](|writer|).
    1. If |reader| [=implements=] {{ReadableStreamBYOBReader}}, perform
-      ! [$ReadableStreamBYOBReaderRelease$](|reader|).
-   1. Otherwise, perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
+      ! [=ReadableStreamBYOBReaderRelease=](|reader|).
+   1. Otherwise, perform ! [=ReadableStreamDefaultReaderRelease=](|reader|).
    1. If |signal| is not undefined, [=AbortSignal/remove=] |abortAlgorithm| from |signal|.
    1. If |error| was given, [=reject=] |promise| with |error|.
    1. Otherwise, [=resolve=] |promise| with undefined.
@@ -2338,7 +2338,7 @@ of the locking, none of these objects can be observed by author code. As such, t
 create them does not matter.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamTee" id="readable-stream-tee">ReadableStreamTee(|stream|,
+ <dfn lt="ReadableStreamTee" id="readable-stream-tee">ReadableStreamTee(|stream|,
  |cloneForBranch2|)</dfn> will [=tee a readable stream|tee=] a given readable stream.
 
  The second argument, |cloneForBranch2|, governs whether or not the data from the original stream
@@ -2359,17 +2359,17 @@ create them does not matter.
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |cloneForBranch2| is a boolean.
  1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
-    return ? [$ReadableByteStreamTee$](|stream|).
- 1. Return ? [$ReadableStreamDefaultTee$](|stream|, |cloneForBranch2|).
+    return ? [=ReadableByteStreamTee=](|stream|).
+ 1. Return ? [=ReadableStreamDefaultTee=](|stream|, |cloneForBranch2|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultTee">ReadableStreamDefaultTee(|stream|,
+ <dfn lt="ReadableStreamDefaultTee">ReadableStreamDefaultTee(|stream|,
  |cloneForBranch2|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |cloneForBranch2| is a boolean.
- 1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
+ 1. Let |reader| be ? [=AcquireReadableStreamDefaultReader=](|stream|).
  1. Let |reading| be false.
  1. Let |readAgain| be false.
  1. Let |canceled1| be false.
@@ -2391,18 +2391,18 @@ create them does not matter.
      1. Set |readAgain| to false.
      1. Let |chunk1| and |chunk2| be |chunk|.
      1. If |canceled2| is false and |cloneForBranch2| is true,
-      1. Let |cloneResult| be [$StructuredClone$](|chunk2|).
+      1. Let |cloneResult| be [=StructuredClone=](|chunk2|).
       1. If |cloneResult| is an abrupt completion,
-       1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
-       1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
-       1. [=Resolve=] |cancelPromise| with ! [$ReadableStreamCancel$](|stream|, |cloneResult|.\[[Value]]).
+       1. Perform ! [=ReadableStreamDefaultControllerError=](|branch1|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. Perform ! [=ReadableStreamDefaultControllerError=](|branch2|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. [=Resolve=] |cancelPromise| with ! [=ReadableStreamCancel=](|stream|, |cloneResult|.\[[Value]]).
        1. Return.
       1. Otherwise, set |chunk2| to |cloneResult|.\[[Value]].
      1. If |canceled1| is false, perform !
-        [$ReadableStreamDefaultControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+        [=ReadableStreamDefaultControllerEnqueue=](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
      1. If |canceled2| is false, perform !
-        [$ReadableStreamDefaultControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+        [=ReadableStreamDefaultControllerEnqueue=](|branch2|.[=ReadableStream/[[controller]]=],
         |chunk2|).
      1. Set |reading| to false.
      1. If |readAgain| is true, perform |pullAlgorithm|.
@@ -2416,22 +2416,22 @@ create them does not matter.
    ::
     1. Set |reading| to false.
     1. If |canceled1| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+       [=ReadableStreamDefaultControllerClose=](|branch1|.[=ReadableStream/[[controller]]=]).
     1. If |canceled2| is false, perform !
-       [$ReadableStreamDefaultControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+       [=ReadableStreamDefaultControllerClose=](|branch2|.[=ReadableStream/[[controller]]=]).
     1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read request/error steps=]
    ::
     1. Set |reading| to false.
-  1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
+  1. Perform ! [=ReadableStreamDefaultReaderRead=](|reader|, |readRequest|).
   1. Return [=a promise resolved with=] undefined.
  1. Let |cancel1Algorithm| be the following steps, taking a |reason| argument:
   1. Set |canceled1| to true.
   1. Set |reason1| to |reason|.
   1. If |canceled2| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
-   1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
+   1. Let |cancelResult| be ! [=ReadableStreamCancel=](|stream|, |compositeReason|).
    1. [=Resolve=] |cancelPromise| with |cancelResult|.
   1. Return |cancelPromise|.
  1. Let |cancel2Algorithm| be the following steps, taking a |reason| argument:
@@ -2439,32 +2439,32 @@ create them does not matter.
   1. Set |reason2| to |reason|.
   1. If |canceled1| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
-   1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
+   1. Let |cancelResult| be ! [=ReadableStreamCancel=](|stream|, |compositeReason|).
    1. [=Resolve=] |cancelPromise| with |cancelResult|.
   1. Return |cancelPromise|.
  1. Let |startAlgorithm| be an algorithm that returns undefined.
- 1. Set |branch1| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
+ 1. Set |branch1| to ! [=CreateReadableStream=](|startAlgorithm|, |pullAlgorithm|,
     |cancel1Algorithm|).
- 1. Set |branch2| to ! [$CreateReadableStream$](|startAlgorithm|, |pullAlgorithm|,
+ 1. Set |branch2| to ! [=CreateReadableStream=](|startAlgorithm|, |pullAlgorithm|,
     |cancel2Algorithm|).
  1. [=Upon rejection=] of |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
     |r|,
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
+  1. Perform ! [=ReadableStreamDefaultControllerError=](|branch1|.[=ReadableStream/[[controller]]=],
      |r|).
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
+  1. Perform ! [=ReadableStreamDefaultControllerError=](|branch2|.[=ReadableStream/[[controller]]=],
      |r|).
   1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
  1. Return « |branch1|, |branch2| ».
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamTee">ReadableByteStreamTee(|stream|)</dfn>
+ <dfn lt="ReadableByteStreamTee">ReadableByteStreamTee(|stream|)</dfn>
  performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] [=implements=]
     {{ReadableByteStreamController}}.
- 1. Let |reader| be ? [$AcquireReadableStreamDefaultReader$](|stream|).
+ 1. Let |reader| be ? [=AcquireReadableStreamDefaultReader=](|stream|).
  1. Let |reading| be false.
  1. Let |readAgainForBranch1| be false.
  1. Let |readAgainForBranch2| be false.
@@ -2479,16 +2479,16 @@ create them does not matter.
   1. [=Upon rejection=] of |thisReader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with reason
      |r|,
    1. If |thisReader| is not |reader|, return.
-   1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=],
+   1. Perform ! [=ReadableByteStreamControllerError=](|branch1|.[=ReadableStream/[[controller]]=],
       |r|).
-   1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=],
+   1. Perform ! [=ReadableByteStreamControllerError=](|branch2|.[=ReadableStream/[[controller]]=],
       |r|).
    1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
  1. Let |pullWithDefaultReader| be the following steps:
   1. If |reader| [=implements=] {{ReadableStreamBYOBReader}},
    1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is [=list/is empty|empty=].
-   1. Perform ! [$ReadableStreamBYOBReaderRelease$](|reader|).
-   1. Set |reader| to ! [$AcquireReadableStreamDefaultReader$](|stream|).
+   1. Perform ! [=ReadableStreamBYOBReaderRelease=](|reader|).
+   1. Set |reader| to ! [=AcquireReadableStreamDefaultReader=](|stream|).
    1. Perform |forwardReaderError|, given |reader|.
   1. Let |readRequest| be a [=read request=] with the following [=struct/items=]:
    : [=read request/chunk steps=], given |chunk|
@@ -2498,18 +2498,18 @@ create them does not matter.
      1. Set |readAgainForBranch2| to false.
      1. Let |chunk1| and |chunk2| be |chunk|.
      1. If |canceled1| is false and |canceled2| is false,
-      1. Let |cloneResult| be [$CloneAsUint8Array$](|chunk|).
+      1. Let |cloneResult| be [=CloneAsUint8Array=](|chunk|).
       1. If |cloneResult| is an abrupt completion,
-       1. Perform ! [$ReadableByteStreamControllerError$](|branch1|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
-       1. Perform ! [$ReadableByteStreamControllerError$](|branch2|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
-       1. [=Resolve=] |cancelPromise| with ! [$ReadableStreamCancel$](|stream|, |cloneResult|.\[[Value]]).
+       1. Perform ! [=ReadableByteStreamControllerError=](|branch1|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. Perform ! [=ReadableByteStreamControllerError=](|branch2|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. [=Resolve=] |cancelPromise| with ! [=ReadableStreamCancel=](|stream|, |cloneResult|.\[[Value]]).
        1. Return.
       1. Otherwise, set |chunk2| to |cloneResult|.\[[Value]].
      1. If |canceled1| is false, perform !
-        [$ReadableByteStreamControllerEnqueue$](|branch1|.[=ReadableStream/[[controller]]=],
+        [=ReadableByteStreamControllerEnqueue=](|branch1|.[=ReadableStream/[[controller]]=],
         |chunk1|).
      1. If |canceled2| is false, perform !
-        [$ReadableByteStreamControllerEnqueue$](|branch2|.[=ReadableStream/[[controller]]=],
+        [=ReadableByteStreamControllerEnqueue=](|branch2|.[=ReadableStream/[[controller]]=],
         |chunk2|).
      1. Set |reading| to false.
      1. If |readAgainForBranch1| is true, perform |pull1Algorithm|.
@@ -2524,26 +2524,26 @@ create them does not matter.
    ::
     1. Set |reading| to false.
     1. If |canceled1| is false, perform !
-       [$ReadableByteStreamControllerClose$](|branch1|.[=ReadableStream/[[controller]]=]).
+       [=ReadableByteStreamControllerClose=](|branch1|.[=ReadableStream/[[controller]]=]).
     1. If |canceled2| is false, perform !
-       [$ReadableByteStreamControllerClose$](|branch2|.[=ReadableStream/[[controller]]=]).
+       [=ReadableByteStreamControllerClose=](|branch2|.[=ReadableStream/[[controller]]=]).
     1. If |branch1|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
        is not [=list/is empty|empty=], perform !
-       [$ReadableByteStreamControllerRespond$](|branch1|.[=ReadableStream/[[controller]]=], 0).
+       [=ReadableByteStreamControllerRespond=](|branch1|.[=ReadableStream/[[controller]]=], 0).
     1. If |branch2|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
        is not [=list/is empty|empty=], perform !
-       [$ReadableByteStreamControllerRespond$](|branch2|.[=ReadableStream/[[controller]]=], 0).
+       [=ReadableByteStreamControllerRespond=](|branch2|.[=ReadableStream/[[controller]]=], 0).
     1. If |canceled1| is false or |canceled2| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read request/error steps=]
    ::
     1. Set |reading| to false.
-  1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
+  1. Perform ! [=ReadableStreamDefaultReaderRead=](|reader|, |readRequest|).
  1. Let |pullWithBYOBReader| be the following steps, given |view| and |forBranch2|:
   1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
    1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is [=list/is empty|empty=].
-   1. Perform ! [$ReadableStreamDefaultReaderRelease$](|reader|).
-   1. Set |reader| to ! [$AcquireReadableStreamBYOBReader$](|stream|).
+   1. Perform ! [=ReadableStreamDefaultReaderRelease=](|reader|).
+   1. Set |reader| to ! [=AcquireReadableStreamBYOBReader=](|stream|).
    1. Perform |forwardReaderError|, given |reader|.
   1. Let |byobBranch| be |branch2| if |forBranch2| is true, and |branch1| otherwise.
   1. Let |otherBranch| be |branch2| if |forBranch2| is false, and |branch1| otherwise.
@@ -2556,20 +2556,20 @@ create them does not matter.
      1. Let |byobCanceled| be |canceled2| if |forBranch2| is true, and |canceled1| otherwise.
      1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
      1. If |otherCanceled| is false,
-      1. Let |cloneResult| be [$CloneAsUint8Array$](|chunk|).
+      1. Let |cloneResult| be [=CloneAsUint8Array=](|chunk|).
       1. If |cloneResult| is an abrupt completion,
-       1. Perform ! [$ReadableByteStreamControllerError$](|byobBranch|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
-       1. Perform ! [$ReadableByteStreamControllerError$](|otherBranch|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
-       1. [=Resolve=] |cancelPromise| with ! [$ReadableStreamCancel$](|stream|, |cloneResult|.\[[Value]]).
+       1. Perform ! [=ReadableByteStreamControllerError=](|byobBranch|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. Perform ! [=ReadableByteStreamControllerError=](|otherBranch|.[=ReadableStream/[[controller]]=], |cloneResult|.\[[Value]]).
+       1. [=Resolve=] |cancelPromise| with ! [=ReadableStreamCancel=](|stream|, |cloneResult|.\[[Value]]).
        1. Return.
       1. Otherwise, let |clonedChunk| be |cloneResult|.\[[Value]].
       1. If |byobCanceled| is false, perform !
-         [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+         [=ReadableByteStreamControllerRespondWithNewView=](|byobBranch|.[=ReadableStream/[[controller]]=],
          |chunk|).
-      1. Perform ! [$ReadableByteStreamControllerEnqueue$](|otherBranch|.[=ReadableStream/[[controller]]=],
+      1. Perform ! [=ReadableByteStreamControllerEnqueue=](|otherBranch|.[=ReadableStream/[[controller]]=],
          |clonedChunk|).
      1. Otherwise, if |byobCanceled| is false, perform !
-        [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+        [=ReadableByteStreamControllerRespondWithNewView=](|byobBranch|.[=ReadableStream/[[controller]]=],
         |chunk|).
      1. Set |reading| to false.
      1. If |readAgainForBranch1| is true, perform |pull1Algorithm|.
@@ -2586,30 +2586,30 @@ create them does not matter.
     1. Let |byobCanceled| be |canceled2| if |forBranch2| is true, and |canceled1| otherwise.
     1. Let |otherCanceled| be |canceled2| if |forBranch2| is false, and |canceled1| otherwise.
     1. If |byobCanceled| is false, perform !
-       [$ReadableByteStreamControllerClose$](|byobBranch|.[=ReadableStream/[[controller]]=]).
+       [=ReadableByteStreamControllerClose=](|byobBranch|.[=ReadableStream/[[controller]]=]).
     1. If |otherCanceled| is false, perform !
-       [$ReadableByteStreamControllerClose$](|otherBranch|.[=ReadableStream/[[controller]]=]).
+       [=ReadableByteStreamControllerClose=](|otherBranch|.[=ReadableStream/[[controller]]=]).
     1. If |chunk| is not undefined,
      1. Assert: |chunk|.\[[ByteLength]] is 0.
      1. If |byobCanceled| is false, perform !
-        [$ReadableByteStreamControllerRespondWithNewView$](|byobBranch|.[=ReadableStream/[[controller]]=],
+        [=ReadableByteStreamControllerRespondWithNewView=](|byobBranch|.[=ReadableStream/[[controller]]=],
         |chunk|).
      1. If |otherCanceled| is false and
         |otherBranch|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
         is not [=list/is empty|empty=], perform !
-        [$ReadableByteStreamControllerRespond$](|otherBranch|.[=ReadableStream/[[controller]]=], 0).
+        [=ReadableByteStreamControllerRespond=](|otherBranch|.[=ReadableStream/[[controller]]=], 0).
     1. If |byobCanceled| is false or |otherCanceled| is false, [=resolve=] |cancelPromise| with undefined.
 
    : [=read-into request/error steps=]
    ::
     1. Set |reading| to false.
-  1. Perform ! [$ReadableStreamBYOBReaderRead$](|reader|, |view|, 1, |readIntoRequest|).
+  1. Perform ! [=ReadableStreamBYOBReaderRead=](|reader|, |view|, 1, |readIntoRequest|).
  1. Let |pull1Algorithm| be the following steps:
   1. If |reading| is true,
    1. Set |readAgainForBranch1| to true.
    1. Return [=a promise resolved with=] undefined.
   1. Set |reading| to true.
-  1. Let |byobRequest| be ! [$ReadableByteStreamControllerGetBYOBRequest$](|branch1|.[=ReadableStream/[[controller]]=]).
+  1. Let |byobRequest| be ! [=ReadableByteStreamControllerGetBYOBRequest=](|branch1|.[=ReadableStream/[[controller]]=]).
   1. If |byobRequest| is null, perform |pullWithDefaultReader|.
   1. Otherwise, perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and false.
   1. Return [=a promise resolved with=] undefined.
@@ -2618,7 +2618,7 @@ create them does not matter.
    1. Set |readAgainForBranch2| to true.
    1. Return [=a promise resolved with=] undefined.
   1. Set |reading| to true.
-  1. Let |byobRequest| be ! [$ReadableByteStreamControllerGetBYOBRequest$](|branch2|.[=ReadableStream/[[controller]]=]).
+  1. Let |byobRequest| be ! [=ReadableByteStreamControllerGetBYOBRequest=](|branch2|.[=ReadableStream/[[controller]]=]).
   1. If |byobRequest| is null, perform |pullWithDefaultReader|.
   1. Otherwise, perform |pullWithBYOBReader|, given |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=] and true.
   1. Return [=a promise resolved with=] undefined.
@@ -2627,7 +2627,7 @@ create them does not matter.
   1. Set |reason1| to |reason|.
   1. If |canceled2| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
-   1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
+   1. Let |cancelResult| be ! [=ReadableStreamCancel=](|stream|, |compositeReason|).
    1. [=Resolve=] |cancelPromise| with |cancelResult|.
   1. Return |cancelPromise|.
  1. Let |cancel2Algorithm| be the following steps, taking a |reason| argument:
@@ -2635,13 +2635,13 @@ create them does not matter.
   1. Set |reason2| to |reason|.
   1. If |canceled1| is true,
    1. Let |compositeReason| be ! [$CreateArrayFromList$](« |reason1|, |reason2| »).
-   1. Let |cancelResult| be ! [$ReadableStreamCancel$](|stream|, |compositeReason|).
+   1. Let |cancelResult| be ! [=ReadableStreamCancel=](|stream|, |compositeReason|).
    1. [=Resolve=] |cancelPromise| with |cancelResult|.
   1. Return |cancelPromise|.
  1. Let |startAlgorithm| be an algorithm that returns undefined.
- 1. Set |branch1| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pull1Algorithm|,
+ 1. Set |branch1| to ! [=CreateReadableByteStream=](|startAlgorithm|, |pull1Algorithm|,
     |cancel1Algorithm|).
- 1. Set |branch2| to ! [$CreateReadableByteStream$](|startAlgorithm|, |pull2Algorithm|,
+ 1. Set |branch2| to ! [=CreateReadableByteStream=](|startAlgorithm|, |pull2Algorithm|,
     |cancel2Algorithm|).
  1. Perform |forwardReaderError|, given |reader|.
  1. Return « |branch1|, |branch2| ».
@@ -2686,7 +2686,7 @@ translates internal state changes of the controller into developer-facing result
 the {{ReadableStream}}'s public API.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamAddReadIntoRequest"
+ <dfn lt="ReadableStreamAddReadIntoRequest"
  id="readable-stream-add-read-into-request">ReadableStreamAddReadIntoRequest(|stream|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -2697,7 +2697,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamAddReadRequest"
+ <dfn lt="ReadableStreamAddReadRequest"
  id="readable-stream-add-read-request">ReadableStreamAddReadRequest(|stream|, |readRequest|)</dfn>
  performs the following steps:
 
@@ -2708,7 +2708,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamCancel"
+ <dfn lt="ReadableStreamCancel"
  id="readable-stream-cancel">ReadableStreamCancel(|stream|, |reason|)</dfn> performs the following
  steps:
 
@@ -2717,7 +2717,7 @@ the {{ReadableStream}}'s public API.
     undefined.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", return [=a promise rejected with=]
     |stream|.[=ReadableStream/[[storedError]]=].
- 1. Perform ! [$ReadableStreamClose$](|stream|).
+ 1. Perform ! [=ReadableStreamClose=](|stream|).
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. If |reader| is not undefined and |reader| [=implements=] {{ReadableStreamBYOBReader}},
   1. Let |readIntoRequests| be |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=].
@@ -2731,7 +2731,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamClose"
+ <dfn lt="ReadableStreamClose"
  id="readable-stream-close">ReadableStreamClose(|stream|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
@@ -2747,7 +2747,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamError" id="readable-stream-error">ReadableStreamError(|stream|,
+ <dfn lt="ReadableStreamError" id="readable-stream-error">ReadableStreamError(|stream|,
  |e|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
@@ -2758,18 +2758,18 @@ the {{ReadableStream}}'s public API.
  1. [=Reject=] |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=] with |e|.
  1. Set |reader|.[=ReadableStreamGenericReader/[[closedPromise]]=].\[[PromiseIsHandled]] to true.
  1. If |reader| [=implements=] {{ReadableStreamDefaultReader}},
-  1. Perform ! [$ReadableStreamDefaultReaderErrorReadRequests$](|reader|, |e|).
+  1. Perform ! [=ReadableStreamDefaultReaderErrorReadRequests=](|reader|, |e|).
  1. Otherwise,
   1. Assert: |reader| [=implements=] {{ReadableStreamBYOBReader}}.
-  1. Perform ! [$ReadableStreamBYOBReaderErrorReadIntoRequests$](|reader|, |e|).
+  1. Perform ! [=ReadableStreamBYOBReaderErrorReadIntoRequests=](|reader|, |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamFulfillReadIntoRequest"
+ <dfn lt="ReadableStreamFulfillReadIntoRequest"
  id="readable-stream-fulfill-read-into-request">ReadableStreamFulfillReadIntoRequest(|stream|,
  |chunk|, |done|)</dfn> performs the following steps:
 
- 1. Assert: ! [$ReadableStreamHasBYOBReader$](|stream|) is true.
+ 1. Assert: ! [=ReadableStreamHasBYOBReader=](|stream|) is true.
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. Assert: |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] is not [=list/is
     empty|empty=].
@@ -2781,11 +2781,11 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamFulfillReadRequest"
+ <dfn lt="ReadableStreamFulfillReadRequest"
  id="readable-stream-fulfill-read-request">ReadableStreamFulfillReadRequest(|stream|, |chunk|,
  |done|)</dfn> performs the following steps:
 
- 1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
+ 1. Assert: ! [=ReadableStreamHasDefaultReader=](|stream|) is true.
  1. Let |reader| be |stream|.[=ReadableStream/[[reader]]=].
  1. Assert: |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] is not [=list/is
     empty|empty=].
@@ -2796,28 +2796,28 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamGetNumReadIntoRequests"
+ <dfn lt="ReadableStreamGetNumReadIntoRequests"
  id="readable-stream-get-num-read-into-requests">ReadableStreamGetNumReadIntoRequests(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: ! [$ReadableStreamHasBYOBReader$](|stream|) is true.
+ 1. Assert: ! [=ReadableStreamHasBYOBReader=](|stream|) is true.
  1. Return
     |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamBYOBReader/[[readIntoRequests]]=]'s
     [=list/size=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamGetNumReadRequests"
+ <dfn lt="ReadableStreamGetNumReadRequests"
  id="readable-stream-get-num-read-requests">ReadableStreamGetNumReadRequests(|stream|)</dfn>
  performs the following steps:
 
- 1. Assert: ! [$ReadableStreamHasDefaultReader$](|stream|) is true.
+ 1. Assert: ! [=ReadableStreamHasDefaultReader=](|stream|) is true.
  1. Return |stream|.[=ReadableStream/[[reader]]=].[=ReadableStreamDefaultReader/[[readRequests]]=]'s
     [=list/size=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamHasBYOBReader"
+ <dfn lt="ReadableStreamHasBYOBReader"
  id="readable-stream-has-byob-reader">ReadableStreamHasBYOBReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2828,7 +2828,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamHasDefaultReader"
+ <dfn lt="ReadableStreamHasDefaultReader"
  id="readable-stream-has-default-reader">ReadableStreamHasDefaultReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2844,17 +2844,17 @@ The following abstract operations support the implementation and manipulation of
 {{ReadableStreamDefaultReader}} and {{ReadableStreamBYOBReader}} instances.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamReaderGenericCancel"
+ <dfn lt="ReadableStreamReaderGenericCancel"
  id="readable-stream-reader-generic-cancel">ReadableStreamReaderGenericCancel(|reader|,
  |reason|)</dfn> performs the following steps:
 
  1. Let |stream| be |reader|.[=ReadableStreamGenericReader/[[stream]]=].
  1. Assert: |stream| is not undefined.
- 1. Return ! [$ReadableStreamCancel$](|stream|, |reason|).
+ 1. Return ! [=ReadableStreamCancel=](|stream|, |reason|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamReaderGenericInitialize"
+ <dfn lt="ReadableStreamReaderGenericInitialize"
  id="readable-stream-reader-generic-initialize">ReadableStreamReaderGenericInitialize(|reader|,
  |stream|)</dfn> performs the following steps:
 
@@ -2873,7 +2873,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamReaderGenericRelease"
+ <dfn lt="ReadableStreamReaderGenericRelease"
  id="readable-stream-reader-generic-release">ReadableStreamReaderGenericRelease(|reader|)</dfn>
  performs the following steps:
 
@@ -2891,7 +2891,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn
  lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
@@ -2902,7 +2902,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamBYOBReaderRead"
+ <dfn lt="ReadableStreamBYOBReaderRead"
  id="readable-stream-byob-reader-read">ReadableStreamBYOBReaderRead(|reader|, |view|, |min|,
  |readIntoRequest|)</dfn> performs the following steps:
 
@@ -2911,21 +2911,21 @@ The following abstract operations support the implementation and manipulation of
  1. Set |stream|.[=ReadableStream/[[disturbed]]=] to true.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`errored`", perform |readIntoRequest|'s [=read-into
     request/error steps=] given |stream|.[=ReadableStream/[[storedError]]=].
- 1. Otherwise, perform ! [$ReadableByteStreamControllerPullInto$](|stream|.[=ReadableStream/[[controller]]=],
+ 1. Otherwise, perform ! [=ReadableByteStreamControllerPullInto=](|stream|.[=ReadableStream/[[controller]]=],
     |view|, |min|, |readIntoRequest|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamBYOBReaderRelease">ReadableStreamBYOBReaderRelease(|reader|)</dfn>
+ <dfn lt="ReadableStreamBYOBReaderRelease">ReadableStreamBYOBReaderRelease(|reader|)</dfn>
  performs the following steps:
 
- 1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+ 1. Perform ! [=ReadableStreamReaderGenericRelease=](|reader|).
  1. Let |e| be a new {{TypeError}} exception.
- 1. Perform ! [$ReadableStreamBYOBReaderErrorReadIntoRequests$](|reader|, |e|).
+ 1. Perform ! [=ReadableStreamBYOBReaderErrorReadIntoRequests=](|reader|, |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn
  lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
@@ -2936,7 +2936,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultReaderRead"
+ <dfn lt="ReadableStreamDefaultReaderRead"
  id="readable-stream-default-reader-read">ReadableStreamDefaultReaderRead(|reader|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -2954,33 +2954,33 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultReaderRelease">ReadableStreamDefaultReaderRelease(|reader|)</dfn>
+ <dfn lt="ReadableStreamDefaultReaderRelease">ReadableStreamDefaultReaderRelease(|reader|)</dfn>
  performs the following steps:
 
- 1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
+ 1. Perform ! [=ReadableStreamReaderGenericRelease=](|reader|).
  1. Let |e| be a new {{TypeError}} exception.
- 1. Perform ! [$ReadableStreamDefaultReaderErrorReadRequests$](|reader|, |e|).
+ 1. Perform ! [=ReadableStreamDefaultReaderErrorReadRequests=](|reader|, |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamBYOBReader"
+ <dfn lt="SetUpReadableStreamBYOBReader"
  id="set-up-readable-stream-byob-reader">SetUpReadableStreamBYOBReader(|reader|, |stream|)</dfn>
  performs the following steps:
 
- 1. If ! [$IsReadableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
+ 1. If ! [=IsReadableStreamLocked=](|stream|) is true, throw a {{TypeError}} exception.
  1. If |stream|.[=ReadableStream/[[controller]]=] does not [=implement=]
     {{ReadableByteStreamController}}, throw a {{TypeError}} exception.
- 1. Perform ! [$ReadableStreamReaderGenericInitialize$](|reader|, |stream|).
+ 1. Perform ! [=ReadableStreamReaderGenericInitialize=](|reader|, |stream|).
  1. Set |reader|.[=ReadableStreamBYOBReader/[[readIntoRequests]]=] to a new empty [=list=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamDefaultReader"
+ <dfn lt="SetUpReadableStreamDefaultReader"
  id="set-up-readable-stream-default-reader">SetUpReadableStreamDefaultReader(|reader|,
  |stream|)</dfn> performs the following steps:
 
- 1. If ! [$IsReadableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
- 1. Perform ! [$ReadableStreamReaderGenericInitialize$](|reader|, |stream|).
+ 1. If ! [=IsReadableStreamLocked=](|stream|) is true, throw a {{TypeError}} exception.
+ 1. Perform ! [=ReadableStreamReaderGenericInitialize=](|reader|, |stream|).
  1. Set |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=] to a new empty [=list=].
 </div>
 
@@ -2990,11 +2990,11 @@ The following abstract operations support the implementation of the
 {{ReadableStreamDefaultController}} class.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerCallPullIfNeeded"
+ <dfn lt="ReadableStreamDefaultControllerCallPullIfNeeded"
  id="readable-stream-default-controller-call-pull-if-needed">ReadableStreamDefaultControllerCallPullIfNeeded(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |shouldPull| be ! [$ReadableStreamDefaultControllerShouldCallPull$](|controller|).
+ 1. Let |shouldPull| be ! [=ReadableStreamDefaultControllerShouldCallPull=](|controller|).
  1. If |shouldPull| is false, return.
  1. If |controller|.[=ReadableStreamDefaultController/[[pulling]]=] is true,
   1. Set |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] to true.
@@ -3007,29 +3007,29 @@ The following abstract operations support the implementation of the
   1. Set |controller|.[=ReadableStreamDefaultController/[[pulling]]=] to false.
   1. If |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is true,
    1. Set |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] to false.
-   1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
+   1. Perform ! [=ReadableStreamDefaultControllerCallPullIfNeeded=](|controller|).
  1. [=Upon rejection=] of |pullPromise| with reason |e|,
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |e|).
+  1. Perform ! [=ReadableStreamDefaultControllerError=](|controller|, |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerShouldCallPull"
+ <dfn lt="ReadableStreamDefaultControllerShouldCallPull"
  id="readable-stream-default-controller-should-call-pull">ReadableStreamDefaultControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
  1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
- 1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return false.
+ 1. If ! [=ReadableStreamDefaultControllerCanCloseOrEnqueue=](|controller|) is false, return false.
  1. If |controller|.[=ReadableStreamDefaultController/[[started]]=] is false, return false.
- 1. If ! [$IsReadableStreamLocked$](|stream|) is true and !
-    [$ReadableStreamGetNumReadRequests$](|stream|) > 0, return true.
- 1. Let |desiredSize| be ! [$ReadableStreamDefaultControllerGetDesiredSize$](|controller|).
+ 1. If ! [=IsReadableStreamLocked=](|stream|) is true and !
+    [=ReadableStreamGetNumReadRequests=](|stream|) > 0, return true.
+ 1. Let |desiredSize| be ! [=ReadableStreamDefaultControllerGetDesiredSize=](|controller|).
  1. Assert: |desiredSize| is not null.
  1. If |desiredSize| > 0, return true.
  1. Return false.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerClearAlgorithms"
+ <dfn lt="ReadableStreamDefaultControllerClearAlgorithms"
  id="readable-stream-default-controller-clear-algorithms">ReadableStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying source=] object to be garbage
@@ -3048,57 +3048,57 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerClose"
+ <dfn lt="ReadableStreamDefaultControllerClose"
  id="readable-stream-default-controller-close">ReadableStreamDefaultControllerClose(|controller|)</dfn>
  performs the following steps:
 
- 1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
+ 1. If ! [=ReadableStreamDefaultControllerCanCloseOrEnqueue=](|controller|) is false, return.
  1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
  1. Set |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=] to true.
  1. If |controller|.[=ReadableStreamDefaultController/[[queue]]=] [=list/is empty=],
-  1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
-  1. Perform ! [$ReadableStreamClose$](|stream|).
+  1. Perform ! [=ReadableStreamDefaultControllerClearAlgorithms=](|controller|).
+  1. Perform ! [=ReadableStreamClose=](|stream|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerEnqueue"
+ <dfn lt="ReadableStreamDefaultControllerEnqueue"
  id="readable-stream-default-controller-enqueue">ReadableStreamDefaultControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
- 1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|controller|) is false, return.
+ 1. If ! [=ReadableStreamDefaultControllerCanCloseOrEnqueue=](|controller|) is false, return.
  1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
- 1. If ! [$IsReadableStreamLocked$](|stream|) is true and !
-    [$ReadableStreamGetNumReadRequests$](|stream|) > 0, perform !
-    [$ReadableStreamFulfillReadRequest$](|stream|, |chunk|, false).
+ 1. If ! [=IsReadableStreamLocked=](|stream|) is true and !
+    [=ReadableStreamGetNumReadRequests=](|stream|) > 0, perform !
+    [=ReadableStreamFulfillReadRequest=](|stream|, |chunk|, false).
  1. Otherwise,
   1. Let |result| be the result of performing
      |controller|.[=ReadableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in |chunk|,
      and interpreting the result as a [=completion record=].
   1. If |result| is an abrupt completion,
-   1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |result|.\[[Value]]).
+   1. Perform ! [=ReadableStreamDefaultControllerError=](|controller|, |result|.\[[Value]]).
    1. Return |result|.
   1. Let |chunkSize| be |result|.\[[Value]].
-  1. Let |enqueueResult| be [$EnqueueValueWithSize$](|controller|, |chunk|, |chunkSize|).
+  1. Let |enqueueResult| be [=EnqueueValueWithSize=](|controller|, |chunk|, |chunkSize|).
   1. If |enqueueResult| is an abrupt completion,
-   1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |enqueueResult|.\[[Value]]).
+   1. Perform ! [=ReadableStreamDefaultControllerError=](|controller|, |enqueueResult|.\[[Value]]).
    1. Return |enqueueResult|.
- 1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
+ 1. Perform ! [=ReadableStreamDefaultControllerCallPullIfNeeded=](|controller|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerError"
+ <dfn lt="ReadableStreamDefaultControllerError"
  id="readable-stream-default-controller-error">ReadableStreamDefaultControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.[=ReadableStreamDefaultController/[[stream]]=].
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
- 1. Perform ! [$ResetQueue$](|controller|).
- 1. Perform ! [$ReadableStreamDefaultControllerClearAlgorithms$](|controller|).
- 1. Perform ! [$ReadableStreamError$](|stream|, |e|).
+ 1. Perform ! [=ResetQueue=](|controller|).
+ 1. Perform ! [=ReadableStreamDefaultControllerClearAlgorithms=](|controller|).
+ 1. Perform ! [=ReadableStreamError=](|stream|, |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerGetDesiredSize"
+ <dfn lt="ReadableStreamDefaultControllerGetDesiredSize"
  id="readable-stream-default-controller-get-desired-size">ReadableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -3111,16 +3111,16 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerHasBackpressure"
+ <dfn lt="ReadableStreamDefaultControllerHasBackpressure"
  id="rs-default-controller-has-backpressure">ReadableStreamDefaultControllerHasBackpressure(|controller|)</dfn>
  is used in the implementation of {{TransformStream}}. It performs the following steps:
 
- 1. If ! [$ReadableStreamDefaultControllerShouldCallPull$](|controller|) is true, return false.
+ 1. If ! [=ReadableStreamDefaultControllerShouldCallPull=](|controller|) is true, return false.
  1. Otherwise, return true.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerCanCloseOrEnqueue"
+ <dfn lt="ReadableStreamDefaultControllerCanCloseOrEnqueue"
  id="readable-stream-default-controller-can-close-or-enqueue">ReadableStreamDefaultControllerCanCloseOrEnqueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3139,14 +3139,14 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamDefaultController"
+ <dfn lt="SetUpReadableStreamDefaultController"
  id="set-up-readable-stream-default-controller">SetUpReadableStreamDefaultController(|stream|,
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |sizeAlgorithm|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] is undefined.
  1. Set |controller|.[=ReadableStreamDefaultController/[[stream]]=] to |stream|.
- 1. Perform ! [$ResetQueue$](|controller|).
+ 1. Perform ! [=ResetQueue=](|controller|).
  1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=],
     |controller|.[=ReadableStreamDefaultController/[[closeRequested]]=],
     |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=], and
@@ -3163,13 +3163,13 @@ The following abstract operations support the implementation of the
   1. Set |controller|.[=ReadableStreamDefaultController/[[started]]=] to true.
   1. Assert: |controller|.[=ReadableStreamDefaultController/[[pulling]]=] is false.
   1. Assert: |controller|.[=ReadableStreamDefaultController/[[pullAgain]]=] is false.
-  1. Perform ! [$ReadableStreamDefaultControllerCallPullIfNeeded$](|controller|).
+  1. Perform ! [=ReadableStreamDefaultControllerCallPullIfNeeded=](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |r|).
+  1. Perform ! [=ReadableStreamDefaultControllerError=](|controller|, |r|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
+ <dfn lt="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
  id="set-up-readable-stream-default-controller-from-underlying-source">SetUpReadableStreamDefaultControllerFromUnderlyingSource(|stream|,
  |underlyingSource|, |underlyingSourceDict|, |highWaterMark|, |sizeAlgorithm|)</dfn>
  performs the following steps:
@@ -3190,18 +3190,18 @@ The following abstract operations support the implementation of the
     |cancelAlgorithm| to an algorithm which takes an argument |reason| and returns the result of
     [=invoking=] |underlyingSourceDict|["{{UnderlyingSource/cancel}}"] with argument list
     «&nbsp;|reason|&nbsp;» and [=callback this value=] |underlyingSource|.
- 1. Perform ? [$SetUpReadableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ? [=SetUpReadableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|, |sizeAlgorithm|).
 </div>
 
 <h4 id="rbs-controller-abstract-ops">Byte stream controllers</h4>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerCallPullIfNeeded"
+ <dfn lt="ReadableByteStreamControllerCallPullIfNeeded"
  id="readable-byte-stream-controller-call-pull-if-needed">ReadableByteStreamControllerCallPullIfNeeded(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |shouldPull| be ! [$ReadableByteStreamControllerShouldCallPull$](|controller|).
+ 1. Let |shouldPull| be ! [=ReadableByteStreamControllerShouldCallPull=](|controller|).
  1. If |shouldPull| is false, return.
  1. If |controller|.[=ReadableByteStreamController/[[pulling]]=] is true,
   1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] to true.
@@ -3214,13 +3214,13 @@ The following abstract operations support the implementation of the
   1. Set |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
   1. If |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is true,
    1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] to false.
-   1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
+   1. Perform ! [=ReadableByteStreamControllerCallPullIfNeeded=](|controller|).
  1. [=Upon rejection=] of |pullPromise| with reason |e|,
-  1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
+  1. Perform ! [=ReadableByteStreamControllerError=](|controller|, |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerClearAlgorithms"
+ <dfn lt="ReadableByteStreamControllerClearAlgorithms"
  id="readable-byte-stream-controller-clear-algorithms">ReadableByteStreamControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying byte source=] object to be garbage
@@ -3238,16 +3238,16 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerClearPendingPullIntos"
+ <dfn lt="ReadableByteStreamControllerClearPendingPullIntos"
  id="readable-byte-stream-controller-clear-pending-pull-intos">ReadableByteStreamControllerClearPendingPullIntos(|controller|)</dfn>
  performs the following steps:
 
- 1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
+ 1. Perform ! [=ReadableByteStreamControllerInvalidateBYOBRequest=](|controller|).
  1. Set |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] to a new empty [=list=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerClose"
+ <dfn lt="ReadableByteStreamControllerClose"
  id="readable-byte-stream-controller-close">ReadableByteStreamControllerClose(|controller|)</dfn>
  performs the following steps:
 
@@ -3263,14 +3263,14 @@ The following abstract operations support the implementation of the
   1. If the remainder after dividing |firstPendingPullInto|'s [=pull-into descriptor/bytes filled=]
      by |firstPendingPullInto|'s [=pull-into descriptor/element size=] is not 0,
    1. Let |e| be a new {{TypeError}} exception.
-   1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
+   1. Perform ! [=ReadableByteStreamControllerError=](|controller|, |e|).
    1. Throw |e|.
- 1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
- 1. Perform ! [$ReadableStreamClose$](|stream|).
+ 1. Perform ! [=ReadableByteStreamControllerClearAlgorithms=](|controller|).
+ 1. Perform ! [=ReadableStreamClose=](|stream|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerCommitPullIntoDescriptor"
+ <dfn lt="ReadableByteStreamControllerCommitPullIntoDescriptor"
  id="readable-byte-stream-controller-commit-pull-into-descriptor">ReadableByteStreamControllerCommitPullIntoDescriptor(|stream|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3282,16 +3282,16 @@ The following abstract operations support the implementation of the
      by |pullIntoDescriptor|'s [=pull-into descriptor/element size=] is 0.
   1. Set |done| to true.
  1. Let |filledView| be !
-    [$ReadableByteStreamControllerConvertPullIntoDescriptor$](|pullIntoDescriptor|).
+    [=ReadableByteStreamControllerConvertPullIntoDescriptor=](|pullIntoDescriptor|).
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`default`",
-  1. Perform ! [$ReadableStreamFulfillReadRequest$](|stream|, |filledView|, |done|).
+  1. Perform ! [=ReadableStreamFulfillReadRequest=](|stream|, |filledView|, |done|).
  1. Otherwise,
   1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`byob`".
-  1. Perform ! [$ReadableStreamFulfillReadIntoRequest$](|stream|, |filledView|, |done|).
+  1. Perform ! [=ReadableStreamFulfillReadIntoRequest=](|stream|, |filledView|, |done|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerConvertPullIntoDescriptor"
+ <dfn lt="ReadableByteStreamControllerConvertPullIntoDescriptor"
  id="readable-byte-stream-controller-convert-pull-into-descriptor">ReadableByteStreamControllerConvertPullIntoDescriptor(|pullIntoDescriptor|)</dfn>
  performs the following steps:
 
@@ -3299,14 +3299,14 @@ The following abstract operations support the implementation of the
  1. Let |elementSize| be |pullIntoDescriptor|'s [=pull-into descriptor/element size=].
  1. Assert: |bytesFilled| ≤ |pullIntoDescriptor|'s [=pull-into descriptor/byte length=].
  1. Assert: the remainder after dividing |bytesFilled| by |elementSize| is 0.
- 1. Let |buffer| be ! [$TransferArrayBuffer$](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]).
- 1. Return ! [$Construct$](|pullIntoDescriptor|'s [=pull-into descriptor/view constructor=], «
+ 1. Let |buffer| be ! [=TransferArrayBuffer=](|pullIntoDescriptor|'s [=pull-into descriptor/buffer=]).
+ 1. Return ! [=Construct=](|pullIntoDescriptor|'s [=pull-into descriptor/view constructor=], «
     |buffer|, |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=],
     |bytesFilled| ÷ |elementSize| »).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerEnqueue"
+ <dfn lt="ReadableByteStreamControllerEnqueue"
  id="readable-byte-stream-controller-enqueue">ReadableByteStreamControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -3317,25 +3317,25 @@ The following abstract operations support the implementation of the
  1. Let |byteOffset| be |chunk|.\[[ByteOffset]].
  1. Let |byteLength| be |chunk|.\[[ByteLength]].
  1. If ! [$IsDetachedBuffer$](|buffer|) is true, throw a {{TypeError}} exception.
- 1. Let |transferredBuffer| be ? [$TransferArrayBuffer$](|buffer|).
+ 1. Let |transferredBuffer| be ? [=TransferArrayBuffer=](|buffer|).
  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not
     [=list/is empty|empty=],
   1. Let |firstPendingPullInto| be
      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
   1. If ! [$IsDetachedBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=])
      is true, throw a {{TypeError}} exception.
-  1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
+  1. Perform ! [=ReadableByteStreamControllerInvalidateBYOBRequest=](|controller|).
   1. Set |firstPendingPullInto|'s [=pull-into descriptor/buffer=] to !
-     [$TransferArrayBuffer$](|firstPendingPullInto|'s [=pull-into descriptor/buffer=]).
+     [=TransferArrayBuffer=](|firstPendingPullInto|'s [=pull-into descriptor/buffer=]).
   1. If |firstPendingPullInto|'s [=pull-into descriptor/reader type=] is "`none`",
-     perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
+     perform ? [=ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue=](|controller|,
      |firstPendingPullInto|).
- 1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true,
-  1. Perform ! [$ReadableByteStreamControllerProcessReadRequestsUsingQueue$](|controller|).
-  1. If ! [$ReadableStreamGetNumReadRequests$](|stream|) is 0,
+ 1. If ! [=ReadableStreamHasDefaultReader=](|stream|) is true,
+  1. Perform ! [=ReadableByteStreamControllerProcessReadRequestsUsingQueue=](|controller|).
+  1. If ! [=ReadableStreamGetNumReadRequests=](|stream|) is 0,
    1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is
       [=list/is empty|empty=].
-   1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
+   1. Perform ! [=ReadableByteStreamControllerEnqueueChunkToQueue=](|controller|,
       |transferredBuffer|, |byteOffset|, |byteLength|).
   1. Otherwise,
    1. Assert: |controller|.[=ReadableByteStreamController/[[queue]]=] [=list/is empty=].
@@ -3343,27 +3343,27 @@ The following abstract operations support the implementation of the
       [=list/is empty|empty=],
     1. Assert: |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0]'s [=pull-into
        descriptor/reader type=] is "`default`".
-    1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
-   1. Let |transferredView| be ! [$Construct$]({{%Uint8Array%}}, « |transferredBuffer|,
+    1. Perform ! [=ReadableByteStreamControllerShiftPendingPullInto=](|controller|).
+   1. Let |transferredView| be ! [=Construct=]({{%Uint8Array%}}, « |transferredBuffer|,
       |byteOffset|, |byteLength| »).
-   1. Perform ! [$ReadableStreamFulfillReadRequest$](|stream|, |transferredView|, false).
- 1. Otherwise, if ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
-  1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
+   1. Perform ! [=ReadableStreamFulfillReadRequest=](|stream|, |transferredView|, false).
+ 1. Otherwise, if ! [=ReadableStreamHasBYOBReader=](|stream|) is true,
+  1. Perform ! [=ReadableByteStreamControllerEnqueueChunkToQueue=](|controller|,
      |transferredBuffer|, |byteOffset|, |byteLength|).
   1. Let |filledPullIntos| be the result of performing
-     ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+     ! [=ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue=](|controller|).
   1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
     1. Perform !
-       [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|stream|, |filledPullInto|).
+       [=ReadableByteStreamControllerCommitPullIntoDescriptor=](|stream|, |filledPullInto|).
  1. Otherwise,
-  1. Assert: ! [$IsReadableStreamLocked$](|stream|) is false.
-  1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
+  1. Assert: ! [=IsReadableStreamLocked=](|stream|) is false.
+  1. Perform ! [=ReadableByteStreamControllerEnqueueChunkToQueue=](|controller|,
      |transferredBuffer|, |byteOffset|, |byteLength|).
- 1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
+ 1. Perform ! [=ReadableByteStreamControllerCallPullIfNeeded=](|controller|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerEnqueueChunkToQueue"
+ <dfn lt="ReadableByteStreamControllerEnqueueChunkToQueue"
  id="readable-byte-stream-controller-enqueue-chunk-to-queue">ReadableByteStreamControllerEnqueueChunkToQueue(|controller|,
  |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
 
@@ -3376,46 +3376,46 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn
  lt="ReadableByteStreamControllerEnqueueClonedChunkToQueue">ReadableByteStreamControllerEnqueueClonedChunkToQueue(|controller|,
  |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
 
  1. Let |cloneResult| be [$CloneArrayBuffer$](|buffer|, |byteOffset|, |byteLength|, {{%ArrayBuffer%}}).
  1. If |cloneResult| is an abrupt completion,
-  1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |cloneResult|.\[[Value]]).
+  1. Perform ! [=ReadableByteStreamControllerError=](|controller|, |cloneResult|.\[[Value]]).
   1. Return |cloneResult|.
- 1. Perform ! [$ReadableByteStreamControllerEnqueueChunkToQueue$](|controller|,
+ 1. Perform ! [=ReadableByteStreamControllerEnqueueChunkToQueue=](|controller|,
     |cloneResult|.\[[Value]], 0, |byteLength|).
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn
  lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
  1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`none`".
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] > 0, perform ?
-    [$ReadableByteStreamControllerEnqueueClonedChunkToQueue$](|controller|, |pullIntoDescriptor|'s
+    [=ReadableByteStreamControllerEnqueueClonedChunkToQueue=](|controller|, |pullIntoDescriptor|'s
     [=pull-into descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into  descriptor/byte offset=],
     |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=]).
- 1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
+ 1. Perform ! [=ReadableByteStreamControllerShiftPendingPullInto=](|controller|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerError"
+ <dfn lt="ReadableByteStreamControllerError"
  id="readable-byte-stream-controller-error">ReadableByteStreamControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return.
- 1. Perform ! [$ReadableByteStreamControllerClearPendingPullIntos$](|controller|).
- 1. Perform ! [$ResetQueue$](|controller|).
- 1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
- 1. Perform ! [$ReadableStreamError$](|stream|, |e|).
+ 1. Perform ! [=ReadableByteStreamControllerClearPendingPullIntos=](|controller|).
+ 1. Perform ! [=ResetQueue=](|controller|).
+ 1. Perform ! [=ReadableByteStreamControllerClearAlgorithms=](|controller|).
+ 1. Perform ! [=ReadableStreamError=](|stream|, |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerFillHeadPullIntoDescriptor"
+ <dfn lt="ReadableByteStreamControllerFillHeadPullIntoDescriptor"
  id="readable-byte-stream-controller-fill-head-pull-into-descriptor">ReadableByteStreamControllerFillHeadPullIntoDescriptor(|controller|,
  |size|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3428,7 +3428,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerFillPullIntoDescriptorFromQueue"
+ <dfn lt="ReadableByteStreamControllerFillPullIntoDescriptorFromQueue"
  id="readable-byte-stream-controller-fill-pull-into-descriptor-from-queue">ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(|controller|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3462,7 +3462,7 @@ The following abstract operations support the implementation of the
   1. Let |descriptorBuffer| be |pullIntoDescriptor|'s [=pull-into descriptor/buffer=].
   1. Let |queueBuffer| be |headOfQueue|'s [=readable byte stream queue entry/buffer=].
   1. Let |queueByteOffset| be |headOfQueue|'s [=readable byte stream queue entry/byte offset=].
-  1. Assert: ! [$CanCopyDataBlockBytes$](|descriptorBuffer|, |destStart|, |queueBuffer|,
+  1. Assert: ! [=CanCopyDataBlockBytes=](|descriptorBuffer|, |destStart|, |queueBuffer|,
      |queueByteOffset|, |bytesToCopy|) is true.
      <p class="warning">If this assertion were to fail (due to a bug in this specification or
      its implementation), then the next step may read from or write to potentially invalid memory.
@@ -3480,7 +3480,7 @@ The following abstract operations support the implementation of the
       [=readable byte stream queue entry/byte length=] − |bytesToCopy|.
   1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to
      |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] − |bytesToCopy|.
-  1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
+  1. Perform ! [=ReadableByteStreamControllerFillHeadPullIntoDescriptor=](|controller|,
      |bytesToCopy|, |pullIntoDescriptor|).
   1. Set |totalBytesToCopyRemaining| to |totalBytesToCopyRemaining| − |bytesToCopy|.
  1. If |ready| is false,
@@ -3492,7 +3492,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn
  lt="ReadableByteStreamControllerFillReadRequestFromQueue">ReadableByteStreamControllerFillReadRequestFromQueue(|controller|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -3502,22 +3502,22 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] to
     |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] − |entry|'s [=readable byte stream
     queue entry/byte length=].
- 1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$](|controller|).
- 1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |entry|'s [=readable byte stream queue
+ 1. Perform ! [=ReadableByteStreamControllerHandleQueueDrain=](|controller|).
+ 1. Let |view| be ! [=Construct=]({{%Uint8Array%}}, « |entry|'s [=readable byte stream queue
     entry/buffer=], |entry|'s [=readable byte stream queue entry/byte offset=], |entry|'s
     [=readable byte stream queue entry/byte length=] »).
  1. Perform |readRequest|'s [=read request/chunk steps=], given |view|.
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn
  lt="ReadableByteStreamControllerGetBYOBRequest">ReadableByteStreamControllerGetBYOBRequest(|controller|)</dfn> performs
  the following steps:
 
  1. If |controller|.[=ReadableByteStreamController/[[byobRequest]]=] is null and
     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. Let |view| be ! [$Construct$]({{%Uint8Array%}}, « |firstDescriptor|'s [=pull-into
+  1. Let |view| be ! [=Construct=]({{%Uint8Array%}}, « |firstDescriptor|'s [=pull-into
      descriptor/buffer=], |firstDescriptor|'s [=pull-into descriptor/byte offset=] +
      |firstDescriptor|'s [=pull-into descriptor/bytes filled=], |firstDescriptor|'s [=pull-into
      descriptor/byte length=] − |firstDescriptor|'s [=pull-into descriptor/bytes filled=] »).
@@ -3529,7 +3529,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerGetDesiredSize"
+ <dfn lt="ReadableByteStreamControllerGetDesiredSize"
  id="readable-byte-stream-controller-get-desired-size">ReadableByteStreamControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -3541,7 +3541,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerHandleQueueDrain"
+ <dfn lt="ReadableByteStreamControllerHandleQueueDrain"
  id="readable-byte-stream-controller-handle-queue-drain">ReadableByteStreamControllerHandleQueueDrain(|controller|)</dfn>
  performs the following steps:
 
@@ -3549,14 +3549,14 @@ The following abstract operations support the implementation of the
     "`readable`".
  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0 and
     |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
-  1. Perform ! [$ReadableByteStreamControllerClearAlgorithms$](|controller|).
-  1. Perform ! [$ReadableStreamClose$](|controller|.[=ReadableByteStreamController/[[stream]]=]).
+  1. Perform ! [=ReadableByteStreamControllerClearAlgorithms=](|controller|).
+  1. Perform ! [=ReadableStreamClose=](|controller|.[=ReadableByteStreamController/[[stream]]=]).
  1. Otherwise,
-  1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
+  1. Perform ! [=ReadableByteStreamControllerCallPullIfNeeded=](|controller|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerInvalidateBYOBRequest"
+ <dfn lt="ReadableByteStreamControllerInvalidateBYOBRequest"
  id="readable-byte-stream-controller-invalidate-byob-request">ReadableByteStreamControllerInvalidateBYOBRequest(|controller|)</dfn>
  performs the following steps:
 
@@ -3571,7 +3571,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue"
+ <dfn lt="ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue"
  id="readable-byte-stream-controller-process-pull-into-descriptors-using-queue">ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3582,15 +3582,15 @@ The following abstract operations support the implementation of the
   1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, then [=iteration/break=].
   1. Let |pullIntoDescriptor| be
      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
-  1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
+  1. If ! [=ReadableByteStreamControllerFillPullIntoDescriptorFromQueue=](|controller|,
      |pullIntoDescriptor|) is true,
-   1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
+   1. Perform ! [=ReadableByteStreamControllerShiftPendingPullInto=](|controller|).
    1. [=list/Append=] |pullIntoDescriptor| to |filledPullIntos|.
  1. Return |filledPullIntos|.
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn
  lt="ReadableByteStreamControllerProcessReadRequestsUsingQueue">ReadableByteStreamControllerProcessReadRequestsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3600,11 +3600,11 @@ The following abstract operations support the implementation of the
   1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] is 0, return.
   1. Let |readRequest| be |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=][0].
   1. [=list/Remove=] |readRequest| from |reader|.[=ReadableStreamDefaultReader/[[readRequests]]=].
-  1. Perform ! [$ReadableByteStreamControllerFillReadRequestFromQueue$](|controller|, |readRequest|).
+  1. Perform ! [=ReadableByteStreamControllerFillReadRequestFromQueue=](|controller|, |readRequest|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerPullInto"
+ <dfn lt="ReadableByteStreamControllerPullInto"
  id="readable-byte-stream-controller-pull-into">ReadableByteStreamControllerPullInto(|controller|,
  |view|, |min|, |readIntoRequest|)</dfn> performs the following steps:
 
@@ -3621,7 +3621,7 @@ The following abstract operations support the implementation of the
  1. Assert: the remainder after dividing |minimumFill| by |elementSize| is 0.
  1. Let |byteOffset| be |view|.\[[ByteOffset]].
  1. Let |byteLength| be |view|.\[[ByteLength]].
- 1. Let |bufferResult| be [$TransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]).
+ 1. Let |bufferResult| be [=TransferArrayBuffer=](|view|.\[[ViewedArrayBuffer]]).
  1. If |bufferResult| is an abrupt completion,
   1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |bufferResult|.\[[Value]].
   1. Return.
@@ -3658,34 +3658,34 @@ The following abstract operations support the implementation of the
  1. If |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=] is not empty,
   1. [=list/Append=] |pullIntoDescriptor| to
      |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
-  1. Perform ! [$ReadableStreamAddReadIntoRequest$](|stream|, |readIntoRequest|).
+  1. Perform ! [=ReadableStreamAddReadIntoRequest=](|stream|, |readIntoRequest|).
   1. Return.
  1. If |stream|.[=ReadableStream/[[state]]=] is "`closed`",
-  1. Let |emptyView| be ! [$Construct$](|ctor|, « |pullIntoDescriptor|'s [=pull-into
+  1. Let |emptyView| be ! [=Construct=](|ctor|, « |pullIntoDescriptor|'s [=pull-into
      descriptor/buffer=], |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=], 0 »).
   1. Perform |readIntoRequest|'s [=read-into request/close steps=], given |emptyView|.
   1. Return.
  1. If |controller|.[=ReadableByteStreamController/[[queueTotalSize]]=] > 0,
-  1. If ! [$ReadableByteStreamControllerFillPullIntoDescriptorFromQueue$](|controller|,
+  1. If ! [=ReadableByteStreamControllerFillPullIntoDescriptorFromQueue=](|controller|,
      |pullIntoDescriptor|) is true,
    1. Let |filledView| be !
-      [$ReadableByteStreamControllerConvertPullIntoDescriptor$](|pullIntoDescriptor|).
-   1. Perform ! [$ReadableByteStreamControllerHandleQueueDrain$](|controller|).
+      [=ReadableByteStreamControllerConvertPullIntoDescriptor=](|pullIntoDescriptor|).
+   1. Perform ! [=ReadableByteStreamControllerHandleQueueDrain=](|controller|).
    1. Perform |readIntoRequest|'s [=read-into request/chunk steps=], given |filledView|.
    1. Return.
   1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true,
    1. Let |e| be a {{TypeError}} exception.
-   1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |e|).
+   1. Perform ! [=ReadableByteStreamControllerError=](|controller|, |e|).
    1. Perform |readIntoRequest|'s [=read-into request/error steps=], given |e|.
    1. Return.
  1. [=list/Append=] |pullIntoDescriptor| to
     |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=].
- 1. Perform ! [$ReadableStreamAddReadIntoRequest$](|stream|, |readIntoRequest|).
- 1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
+ 1. Perform ! [=ReadableStreamAddReadIntoRequest=](|stream|, |readIntoRequest|).
+ 1. Perform ! [=ReadableByteStreamControllerCallPullIfNeeded=](|controller|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespond"
+ <dfn lt="ReadableByteStreamControllerRespond"
  id="readable-byte-stream-controller-respond">ReadableByteStreamControllerRespond(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
@@ -3701,49 +3701,49 @@ The following abstract operations support the implementation of the
   1. If |firstDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| >
      |firstDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
  1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to !
-    [$TransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]).
- 1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |bytesWritten|).
+    [=TransferArrayBuffer=](|firstDescriptor|'s [=pull-into descriptor/buffer=]).
+ 1. Perform ? [=ReadableByteStreamControllerRespondInternal=](|controller|, |bytesWritten|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondInClosedState"
+ <dfn lt="ReadableByteStreamControllerRespondInClosedState"
  id="readable-byte-stream-controller-respond-in-closed-state">ReadableByteStreamControllerRespondInClosedState(|controller|,
  |firstDescriptor|)</dfn> performs the following steps:
 
  1. Assert: the remainder after dividing |firstDescriptor|'s [=pull-into descriptor/bytes filled=]
     by |firstDescriptor|'s [=pull-into descriptor/element size=] is 0.
  1. If |firstDescriptor|'s [=pull-into descriptor/reader type=] is "`none`",
-    perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
+    perform ! [=ReadableByteStreamControllerShiftPendingPullInto=](|controller|).
  1. Let |stream| be |controller|.[=ReadableByteStreamController/[[stream]]=].
- 1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true,
+ 1. If ! [=ReadableStreamHasBYOBReader=](|stream|) is true,
   1. Let |filledPullIntos| be a new empty [=list=].
   1. [=While=] |filledPullIntos|'s [=list/size=] < !
-     [$ReadableStreamGetNumReadIntoRequests$](|stream|),
+     [=ReadableStreamGetNumReadIntoRequests=](|stream|),
    1. Let |pullIntoDescriptor| be !
-      [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
+      [=ReadableByteStreamControllerShiftPendingPullInto=](|controller|).
    1. [=list/Append=] |pullIntoDescriptor| to |filledPullIntos|.
   1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
-   1. Perform ! [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|stream|,
+   1. Perform ! [=ReadableByteStreamControllerCommitPullIntoDescriptor=](|stream|,
       |filledPullInto|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondInReadableState"
+ <dfn lt="ReadableByteStreamControllerRespondInReadableState"
  id="readable-byte-stream-controller-respond-in-readable-state">ReadableByteStreamControllerRespondInReadableState(|controller|,
  |bytesWritten|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
  1. Assert: |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] + |bytesWritten| ≤
     |pullIntoDescriptor|'s [=pull-into descriptor/byte length=].
- 1. Perform ! [$ReadableByteStreamControllerFillHeadPullIntoDescriptor$](|controller|,
+ 1. Perform ! [=ReadableByteStreamControllerFillHeadPullIntoDescriptor=](|controller|,
     |bytesWritten|, |pullIntoDescriptor|).
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/reader type=] is "`none`",
-  1. Perform ? [$ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue$](|controller|,
+  1. Perform ? [=ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue=](|controller|,
      |pullIntoDescriptor|).
   1. Let |filledPullIntos| be the result of performing
-     ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+     ! [=ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue=](|controller|).
   1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
     1. Perform !
-       [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+       [=ReadableByteStreamControllerCommitPullIntoDescriptor=](|controller|.[=ReadableByteStreamController/[[stream]]=],
        |filledPullInto|).
   1. Return.
  1. If |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] &lt; |pullIntoDescriptor|'s
@@ -3751,52 +3751,52 @@ The following abstract operations support the implementation of the
     <p class="note">A descriptor for a {{ReadableStreamBYOBReader/read()}} request
     that is not yet filled up to its minimum length will stay at the head of the queue, so the
     [=underlying source=] can keep filling it.
- 1. Perform ! [$ReadableByteStreamControllerShiftPendingPullInto$](|controller|).
+ 1. Perform ! [=ReadableByteStreamControllerShiftPendingPullInto=](|controller|).
  1. Let |remainderSize| be the remainder after dividing |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] by |pullIntoDescriptor|'s [=pull-into descriptor/element size=].
  1. If |remainderSize| > 0,
    1. Let |end| be |pullIntoDescriptor|'s [=pull-into descriptor/byte offset=] +
       |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=].
-   1. Perform ? [$ReadableByteStreamControllerEnqueueClonedChunkToQueue$](|controller|,
+   1. Perform ? [=ReadableByteStreamControllerEnqueueClonedChunkToQueue=](|controller|,
       |pullIntoDescriptor|'s [=pull-into descriptor/buffer=], |end| − |remainderSize|,
       |remainderSize|).
  1. Set |pullIntoDescriptor|'s [=pull-into descriptor/bytes filled=] to |pullIntoDescriptor|'s
     [=pull-into descriptor/bytes filled=] − |remainderSize|.
  1. Let |filledPullIntos| be the result of performing
-    ! [$ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue$](|controller|).
+    ! [=ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue=](|controller|).
  1. Perform !
-    [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+    [=ReadableByteStreamControllerCommitPullIntoDescriptor=](|controller|.[=ReadableByteStreamController/[[stream]]=],
     |pullIntoDescriptor|).
  1. [=list/For each=] |filledPullInto| of |filledPullIntos|,
    1. Perform !
-      [$ReadableByteStreamControllerCommitPullIntoDescriptor$](|controller|.[=ReadableByteStreamController/[[stream]]=],
+      [=ReadableByteStreamControllerCommitPullIntoDescriptor=](|controller|.[=ReadableByteStreamController/[[stream]]=],
       |filledPullInto|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondInternal"
+ <dfn lt="ReadableByteStreamControllerRespondInternal"
  id="readable-byte-stream-controller-respond-internal">ReadableByteStreamControllerRespondInternal(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
  1. Let |firstDescriptor| be |controller|.[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
- 1. Assert: ! [$CanTransferArrayBuffer$](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true.
- 1. Perform ! [$ReadableByteStreamControllerInvalidateBYOBRequest$](|controller|).
+ 1. Assert: ! [=CanTransferArrayBuffer=](|firstDescriptor|'s [=pull-into descriptor/buffer=]) is true.
+ 1. Perform ! [=ReadableByteStreamControllerInvalidateBYOBRequest=](|controller|).
  1. Let |state| be
     |controller|.[=ReadableByteStreamController/[[stream]]=].[=ReadableStream/[[state]]=].
  1. If |state| is "`closed`",
   1. Assert: |bytesWritten| is 0.
-  1. Perform ! [$ReadableByteStreamControllerRespondInClosedState$](|controller|,
+  1. Perform ! [=ReadableByteStreamControllerRespondInClosedState=](|controller|,
      |firstDescriptor|).
  1. Otherwise,
   1. Assert: |state| is "`readable`".
   1. Assert: |bytesWritten| > 0.
-  1. Perform ? [$ReadableByteStreamControllerRespondInReadableState$](|controller|, |bytesWritten|,
+  1. Perform ? [=ReadableByteStreamControllerRespondInReadableState=](|controller|, |bytesWritten|,
      |firstDescriptor|).
- 1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
+ 1. Perform ! [=ReadableByteStreamControllerCallPullIfNeeded=](|controller|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondWithNewView"
+ <dfn lt="ReadableByteStreamControllerRespondWithNewView"
  id="readable-byte-stream-controller-respond-with-new-view">ReadableByteStreamControllerRespondWithNewView(|controller|,
  |view|)</dfn> performs the following steps:
 
@@ -3819,12 +3819,12 @@ The following abstract operations support the implementation of the
     |firstDescriptor|'s [=pull-into descriptor/byte length=], throw a {{RangeError}} exception.
  1. Let |viewByteLength| be |view|.\[[ByteLength]].
  1. Set |firstDescriptor|'s [=pull-into descriptor/buffer=] to ?
-    [$TransferArrayBuffer$](|view|.\[[ViewedArrayBuffer]]).
- 1. Perform ? [$ReadableByteStreamControllerRespondInternal$](|controller|, |viewByteLength|).
+    [=TransferArrayBuffer=](|view|.\[[ViewedArrayBuffer]]).
+ 1. Perform ? [=ReadableByteStreamControllerRespondInternal=](|controller|, |viewByteLength|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerShiftPendingPullInto"
+ <dfn lt="ReadableByteStreamControllerShiftPendingPullInto"
  id="readable-byte-stream-controller-shift-pending-pull-into">ReadableByteStreamControllerShiftPendingPullInto(|controller|)</dfn>
  performs the following steps:
 
@@ -3836,7 +3836,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerShouldCallPull"
+ <dfn lt="ReadableByteStreamControllerShouldCallPull"
  id="readable-byte-stream-controller-should-call-pull">ReadableByteStreamControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
@@ -3844,18 +3844,18 @@ The following abstract operations support the implementation of the
  1. If |stream|.[=ReadableStream/[[state]]=] is not "`readable`", return false.
  1. If |controller|.[=ReadableByteStreamController/[[closeRequested]]=] is true, return false.
  1. If |controller|.[=ReadableByteStreamController/[[started]]=] is false, return false.
- 1. If ! [$ReadableStreamHasDefaultReader$](|stream|) is true and !
-    [$ReadableStreamGetNumReadRequests$](|stream|) > 0, return true.
- 1. If ! [$ReadableStreamHasBYOBReader$](|stream|) is true and !
-    [$ReadableStreamGetNumReadIntoRequests$](|stream|) > 0, return true.
- 1. Let |desiredSize| be  ! [$ReadableByteStreamControllerGetDesiredSize$](|controller|).
+ 1. If ! [=ReadableStreamHasDefaultReader=](|stream|) is true and !
+    [=ReadableStreamGetNumReadRequests=](|stream|) > 0, return true.
+ 1. If ! [=ReadableStreamHasBYOBReader=](|stream|) is true and !
+    [=ReadableStreamGetNumReadIntoRequests=](|stream|) > 0, return true.
+ 1. Let |desiredSize| be  ! [=ReadableByteStreamControllerGetDesiredSize=](|controller|).
  1. Assert: |desiredSize| is not null.
  1. If |desiredSize| > 0, return true.
  1. Return false.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableByteStreamController"
+ <dfn lt="SetUpReadableByteStreamController"
  id="set-up-readable-byte-stream-controller">SetUpReadableByteStreamController(|stream|,
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |autoAllocateChunkSize|)</dfn> performs the following steps:
@@ -3868,7 +3868,7 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=ReadableByteStreamController/[[pullAgain]]=] and
     |controller|.[=ReadableByteStreamController/[[pulling]]=] to false.
  1. Set |controller|.[=ReadableByteStreamController/[[byobRequest]]=] to null.
- 1. Perform ! [$ResetQueue$](|controller|).
+ 1. Perform ! [=ResetQueue=](|controller|).
  1. Set |controller|.[=ReadableByteStreamController/[[closeRequested]]=] and
     |controller|.[=ReadableByteStreamController/[[started]]=] to false.
  1. Set |controller|.[=ReadableByteStreamController/[[strategyHWM]]=] to |highWaterMark|.
@@ -3884,13 +3884,13 @@ The following abstract operations support the implementation of the
    1. Set |controller|.[=ReadableByteStreamController/[[started]]=] to true.
    1. Assert: |controller|.[=ReadableByteStreamController/[[pulling]]=] is false.
    1. Assert: |controller|.[=ReadableByteStreamController/[[pullAgain]]=] is false.
-   1. Perform ! [$ReadableByteStreamControllerCallPullIfNeeded$](|controller|).
+   1. Perform ! [=ReadableByteStreamControllerCallPullIfNeeded=](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
-   1. Perform ! [$ReadableByteStreamControllerError$](|controller|, |r|).
+   1. Perform ! [=ReadableByteStreamControllerError=](|controller|, |r|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableByteStreamControllerFromUnderlyingSource"
+ <dfn lt="SetUpReadableByteStreamControllerFromUnderlyingSource"
  id="set-up-readable-byte-stream-controller-from-underlying-source">SetUpReadableByteStreamControllerFromUnderlyingSource(|stream|,
  |underlyingSource|, |underlyingSourceDict|, |highWaterMark|)</dfn> performs the following steps:
 
@@ -3914,7 +3914,7 @@ The following abstract operations support the implementation of the
     |underlyingSourceDict|["{{UnderlyingSource/autoAllocateChunkSize}}"], if it [=map/exists=], or
     undefined otherwise.
  1. If |autoAllocateChunkSize| is 0, then throw a {{TypeError}} exception.
- 1. Perform ? [$SetUpReadableByteStreamController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ? [=SetUpReadableByteStreamController=](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|, |autoAllocateChunkSize|).
 </div>
 <h2 id="ws">Writable streams</h2>
@@ -4137,12 +4137,12 @@ A <dfn>pending abort request</dfn> is a [=struct=] used to track a request to ab
 before that request is finally processed. It has the following [=struct/items=]:
 
 : <dfn for="pending abort request">promise</dfn>
-:: A promise returned from [$WritableStreamAbort$]
+:: A promise returned from [=WritableStreamAbort=]
 : <dfn for="pending abort request">reason</dfn>
-:: A JavaScript value that was passed as the abort reason to [$WritableStreamAbort$]
+:: A JavaScript value that was passed as the abort reason to [=WritableStreamAbort=]
 : <dfn for="pending abort request">was already erroring</dfn>
 :: A boolean indicating whether or not the stream was in the "`erroring`" state when
-   [$WritableStreamAbort$] was called, which impacts the outcome of the abort request
+   [=WritableStreamAbort=] was called, which impacts the outcome of the abort request
 
 <h4 id="underlying-sink-api">The underlying sink API</h4>
 
@@ -4321,41 +4321,41 @@ as seen for example in [[#example-ws-no-backpressure]].
     exception.
     <p class="note">This is to allow us to add new potential types in the future, without
     backward-compatibility concerns.
- 1. Perform ! [$InitializeWritableStream$]([=this=]).
- 1. Let |sizeAlgorithm| be ! [$ExtractSizeAlgorithm$](|strategy|).
- 1. Let |highWaterMark| be ? [$ExtractHighWaterMark$](|strategy|, 1).
- 1. Perform ? [$SetUpWritableStreamDefaultControllerFromUnderlyingSink$]([=this=], |underlyingSink|,
+ 1. Perform ! [=InitializeWritableStream=]([=this=]).
+ 1. Let |sizeAlgorithm| be ! [=ExtractSizeAlgorithm=](|strategy|).
+ 1. Let |highWaterMark| be ? [=ExtractHighWaterMark=](|strategy|, 1).
+ 1. Perform ? [=SetUpWritableStreamDefaultControllerFromUnderlyingSink=]([=this=], |underlyingSink|,
     |underlyingSinkDict|, |highWaterMark|, |sizeAlgorithm|).
 </div>
 
 <div algorithm>
  The <dfn id="ws-locked" attribute for="WritableStream">locked</dfn> getter steps are:
 
- 1. Return ! [$IsWritableStreamLocked$]([=this=]).
+ 1. Return ! [=IsWritableStreamLocked=]([=this=]).
 </div>
 
 <div algorithm>
  The <dfn id="ws-abort" method for="WritableStream">abort(|reason|)</dfn> method steps are:
 
- 1. If ! [$IsWritableStreamLocked$]([=this=]) is true, return [=a promise rejected with=] a
+ 1. If ! [=IsWritableStreamLocked=]([=this=]) is true, return [=a promise rejected with=] a
     {{TypeError}} exception.
- 1. Return ! [$WritableStreamAbort$]([=this=], |reason|).
+ 1. Return ! [=WritableStreamAbort=]([=this=], |reason|).
 </div>
 
 <div algorithm>
  The <dfn id="ws-close" method for="WritableStream">close()</dfn> method steps are:
 
- 1. If ! [$IsWritableStreamLocked$]([=this=]) is true, return [=a promise rejected with=] a
+ 1. If ! [=IsWritableStreamLocked=]([=this=]) is true, return [=a promise rejected with=] a
     {{TypeError}} exception.
- 1. If ! [$WritableStreamCloseQueuedOrInFlight$]([=this=]) is true, return [=a promise rejected
+ 1. If ! [=WritableStreamCloseQueuedOrInFlight=]([=this=]) is true, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. Return ! [$WritableStreamClose$]([=this=]).
+ 1. Return ! [=WritableStreamClose=]([=this=]).
 </div>
 
 <div algorithm>
  The <dfn id="ws-get-writer" method for="WritableStream">getWriter()</dfn> method steps are:
 
- 1. Return ? [$AcquireWritableStreamDefaultWriter$]([=this=]).
+ 1. Return ? [=AcquireWritableStreamDefaultWriter=]([=this=]).
 </div>
 
 <h4 id="ws-transfer">Transfer via `postMessage()`</h4>
@@ -4374,13 +4374,13 @@ as seen for example in [[#example-ws-no-backpressure]].
  {{WritableStream}} objects are [=transferable objects=]. Their [=transfer steps=], given |value|
  and |dataHolder|, are:
 
- 1. If ! [$IsWritableStreamLocked$](|value|) is true, throw a "{{DataCloneError}}" {{DOMException}}.
+ 1. If ! [=IsWritableStreamLocked=](|value|) is true, throw a "{{DataCloneError}}" {{DOMException}}.
  1. Let |port1| be a [=new=] {{MessagePort}} in [=the current Realm=].
  1. Let |port2| be a [=new=] {{MessagePort}} in [=the current Realm=].
  1. [=Entangle=] |port1| and |port2|.
  1. Let |readable| be a [=new=] {{ReadableStream}} in [=the current Realm=].
- 1. Perform ! [$SetUpCrossRealmTransformReadable$](|readable|, |port1|).
- 1. Let |promise| be ! [$ReadableStreamPipeTo$](|readable|, |value|, false, false, false).
+ 1. Perform ! [=SetUpCrossRealmTransformReadable=](|readable|, |port1|).
+ 1. Let |promise| be ! [=ReadableStreamPipeTo=](|readable|, |value|, false, false, false).
  1. Set |promise|.\[[PromiseIsHandled]] to true.
  1. Set |dataHolder|.\[[port]] to ! [$StructuredSerializeWithTransfer$](|port2|, « |port2| »).
 </div>
@@ -4391,7 +4391,7 @@ as seen for example in [[#example-ws-no-backpressure]].
  1. Let |deserializedRecord| be ! [$StructuredDeserializeWithTransfer$](|dataHolder|.\[[port]],
     [=the current Realm=]).
  1. Let |port| be a |deserializedRecord|.\[[Deserialized]].
- 1. Perform ! [$SetUpCrossRealmTransformWritable$](|value|, |port|).
+ 1. Perform ! [=SetUpCrossRealmTransformWritable=](|value|, |port|).
 </div>
 
 <h3 id="default-writer-class">The {{WritableStreamDefaultWriter}} class</h3>
@@ -4523,7 +4523,7 @@ following table:
  lt="WritableStreamDefaultWriter(stream)">new WritableStreamDefaultWriter(|stream|)</dfn>
  constructor steps are:
 
- 1. Perform ? [$SetUpWritableStreamDefaultWriter$]([=this=], |stream|).
+ 1. Perform ? [=SetUpWritableStreamDefaultWriter=]([=this=], |stream|).
 </div>
 
 <div algorithm>
@@ -4539,7 +4539,7 @@ following table:
 
  1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, throw a {{TypeError}}
     exception.
- 1. Return ! [$WritableStreamDefaultWriterGetDesiredSize$]([=this=]).
+ 1. Return ! [=WritableStreamDefaultWriterGetDesiredSize=]([=this=]).
 </div>
 
 <div algorithm>
@@ -4555,7 +4555,7 @@ following table:
 
  1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. Return ! [$WritableStreamDefaultWriterAbort$]([=this=], |reason|).
+ 1. Return ! [=WritableStreamDefaultWriterAbort=]([=this=], |reason|).
 </div>
 
 <div algorithm>
@@ -4564,9 +4564,9 @@ following table:
 
  1. Let |stream| be [=this=].[=WritableStreamDefaultWriter/[[stream]]=].
  1. If |stream| is undefined, return [=a promise rejected with=] a {{TypeError}} exception.
- 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true, return [=a promise rejected
+ 1. If ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is true, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. Return ! [$WritableStreamDefaultWriterClose$]([=this=]).
+ 1. Return ! [=WritableStreamDefaultWriterClose=]([=this=]).
 </div>
 
 <div algorithm>
@@ -4576,7 +4576,7 @@ following table:
  1. Let |stream| be [=this=].[=WritableStreamDefaultWriter/[[stream]]=].
  1. If |stream| is undefined, return.
  1. Assert: |stream|.[=WritableStream/[[writer]]=] is not undefined.
- 1. Perform ! [$WritableStreamDefaultWriterRelease$]([=this=]).
+ 1. Perform ! [=WritableStreamDefaultWriterRelease=]([=this=]).
 </div>
 
 <div algorithm>
@@ -4585,7 +4585,7 @@ following table:
 
  1. If [=this=].[=WritableStreamDefaultWriter/[[stream]]=] is undefined, return [=a promise rejected
     with=] a {{TypeError}} exception.
- 1. Return ! [$WritableStreamDefaultWriterWrite$]([=this=], |chunk|).
+ 1. Return ! [=WritableStreamDefaultWriterWrite=]([=this=], |chunk|).
 </div>
 
 <h3 id="ws-default-controller-class">The {{WritableStreamDefaultController}} class</h3>
@@ -4694,7 +4694,7 @@ closed. It is only used internally, and is never exposed to web developers.
 
  1. Let |state| be [=this=].[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=].
  1. If |state| is not "`writable`", return.
- 1. Perform ! [$WritableStreamDefaultControllerError$]([=this=], |e|).
+ 1. Perform ! [=WritableStreamDefaultControllerError=]([=this=], |e|).
 </div>
 
 <h4 id="ws-default-controller-internal-methods">Internal methods</h4>
@@ -4717,7 +4717,7 @@ as such the counterpart internal methods are used polymorphically.
 
  1. Let |result| be the result of performing
     [=this=].[=WritableStreamDefaultController/[[abortAlgorithm]]=], passing |reason|.
- 1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$]([=this=]).
+ 1. Perform ! [=WritableStreamDefaultControllerClearAlgorithms=]([=this=]).
  1. Return |result|.
 </div>
 
@@ -4726,7 +4726,7 @@ as such the counterpart internal methods are used polymorphically.
  id="ws-default-controller-private-error">\[[ErrorSteps]]()</dfn> implements the
  [$WritableStreamController/[[ErrorSteps]]$] contract. It performs the following steps:
 
- 1. Perform ! [$ResetQueue$]([=this=]).
+ 1. Perform ! [=ResetQueue=]([=this=]).
 </div>
 
 <h3 id="ws-all-abstract-ops">Abstract operations</h3>
@@ -4736,26 +4736,26 @@ as such the counterpart internal methods are used polymorphically.
 The following abstract operations operate on {{WritableStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op lt="AcquireWritableStreamDefaultWriter"
+ <dfn lt="AcquireWritableStreamDefaultWriter"
  id="acquire-writable-stream-default-writer">AcquireWritableStreamDefaultWriter(|stream|)</dfn>
  performs the following steps:
 
  1. Let |writer| be a [=new=] {{WritableStreamDefaultWriter}}.
- 1. Perform ? [$SetUpWritableStreamDefaultWriter$](|writer|, |stream|).
+ 1. Perform ? [=SetUpWritableStreamDefaultWriter=](|writer|, |stream|).
  1. Return |writer|.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateWritableStream"
+ <dfn lt="CreateWritableStream"
  id="create-writable-stream">CreateWritableStream(|startAlgorithm|, |writeAlgorithm|,
  |closeAlgorithm|, |abortAlgorithm|, |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following
  steps:
 
- 1. Assert: ! [$IsNonNegativeNumber$](|highWaterMark|) is true.
+ 1. Assert: ! [=IsNonNegativeNumber=](|highWaterMark|) is true.
  1. Let |stream| be a [=new=] {{WritableStream}}.
- 1. Perform ! [$InitializeWritableStream$](|stream|).
+ 1. Perform ! [=InitializeWritableStream=](|stream|).
  1. Let |controller| be a [=new=] {{WritableStreamDefaultController}}.
- 1. Perform ? [$SetUpWritableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ? [=SetUpWritableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|, |highWaterMark|, |sizeAlgorithm|).
  1. Return |stream|.
 
@@ -4764,7 +4764,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="InitializeWritableStream"
+ <dfn lt="InitializeWritableStream"
  id="initialize-writable-stream">InitializeWritableStream(|stream|)</dfn> performs the following
  steps:
 
@@ -4780,7 +4780,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="IsWritableStreamLocked"
+ <dfn lt="IsWritableStreamLocked"
  id="is-writable-stream-locked">IsWritableStreamLocked(|stream|)</dfn> performs the following steps:
 
  1. If |stream|.[=WritableStream/[[writer]]=] is undefined, return false.
@@ -4788,16 +4788,16 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpWritableStreamDefaultWriter"
+ <dfn lt="SetUpWritableStreamDefaultWriter"
  id="set-up-writable-stream-default-writer">SetUpWritableStreamDefaultWriter(|writer|,
  |stream|)</dfn> performs the following steps:
 
- 1. If ! [$IsWritableStreamLocked$](|stream|) is true, throw a {{TypeError}} exception.
+ 1. If ! [=IsWritableStreamLocked=](|stream|) is true, throw a {{TypeError}} exception.
  1. Set |writer|.[=WritableStreamDefaultWriter/[[stream]]=] to |stream|.
  1. Set |stream|.[=WritableStream/[[writer]]=] to |writer|.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
-  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and
+  1. If ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is false and
      |stream|.[=WritableStream/[[backpressure]]=] is true, set
      |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a new promise=].
   1. Otherwise, set |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=] to [=a promise
@@ -4825,7 +4825,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamAbort"
+ <dfn lt="WritableStreamAbort"
  id="writable-stream-abort">WritableStreamAbort(|stream|, |reason|)</dfn> performs the following
  steps:
 
@@ -4849,26 +4849,26 @@ The following abstract operations operate on {{WritableStream}} instances at a h
  1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to a new [=pending abort request=] whose
     [=pending abort request/promise=] is |promise|, [=pending abort request/reason=] is |reason|,
     and [=pending abort request/was already erroring=] is |wasAlreadyErroring|.
- 1. If |wasAlreadyErroring| is false, perform ! [$WritableStreamStartErroring$](|stream|, |reason|).
+ 1. If |wasAlreadyErroring| is false, perform ! [=WritableStreamStartErroring=](|stream|, |reason|).
  1. Return |promise|.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamClose"
+ <dfn lt="WritableStreamClose"
  id="writable-stream-close">WritableStreamClose(|stream|)</dfn> performs the following steps:
 
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`closed`" or "`errored`", return [=a promise rejected with=] a {{TypeError}}
     exception.
  1. Assert: |state| is "`writable`" or "`erroring`".
- 1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
+ 1. Assert: ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is false.
  1. Let |promise| be [=a new promise=].
  1. Set |stream|.[=WritableStream/[[closeRequest]]=] to |promise|.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined, and |stream|.[=WritableStream/[[backpressure]]=] is true, and
     |state| is "`writable`", [=resolve=] |writer|.[=WritableStreamDefaultWriter/[[readyPromise]]=]
     with undefined.
- 1. Perform ! [$WritableStreamDefaultControllerClose$](|stream|.[=WritableStream/[[controller]]=]).
+ 1. Perform ! [=WritableStreamDefaultControllerClose=](|stream|.[=WritableStream/[[controller]]=]).
  1. Return |promise|.
 </div>
 
@@ -4904,11 +4904,11 @@ translates internal state changes of the controllerinto developer-facing results
 the {{WritableStream}}'s public API.
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamAddWriteRequest"
+ <dfn lt="WritableStreamAddWriteRequest"
  id="writable-stream-add-write-request">WritableStreamAddWriteRequest(|stream|)</dfn> performs the
  following steps:
 
- 1. Assert: ! [$IsWritableStreamLocked$](|stream|) is true.
+ 1. Assert: ! [=IsWritableStreamLocked=](|stream|) is true.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
  1. Let |promise| be [=a new promise=].
  1. [=list/Append=] |promise| to |stream|.[=WritableStream/[[writeRequests]]=].
@@ -4916,7 +4916,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamCloseQueuedOrInFlight"
+ <dfn lt="WritableStreamCloseQueuedOrInFlight"
  id="writable-stream-close-queued-or-in-flight">WritableStreamCloseQueuedOrInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -4926,25 +4926,25 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDealWithRejection"
+ <dfn lt="WritableStreamDealWithRejection"
  id="writable-stream-deal-with-rejection">WritableStreamDealWithRejection(|stream|, |error|)</dfn>
  performs the following steps:
 
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`writable`",
-  1. Perform ! [$WritableStreamStartErroring$](|stream|, |error|).
+  1. Perform ! [=WritableStreamStartErroring=](|stream|, |error|).
   1. Return.
  1. Assert: |state| is "`erroring`".
- 1. Perform ! [$WritableStreamFinishErroring$](|stream|).
+ 1. Perform ! [=WritableStreamFinishErroring=](|stream|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishErroring"
+ <dfn lt="WritableStreamFinishErroring"
  id="writable-stream-finish-erroring">WritableStreamFinishErroring(|stream|)</dfn>
  performs the following steps:
 
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`erroring`".
- 1. Assert: ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false.
+ 1. Assert: ! [=WritableStreamHasOperationMarkedInFlight=](|stream|) is false.
  1. Set |stream|.[=WritableStream/[[state]]=] to "`errored`".
  1. Perform !
     |stream|.[=WritableStream/[[controller]]=].[$WritableStreamController/[[ErrorSteps]]$]().
@@ -4953,27 +4953,27 @@ the {{WritableStream}}'s public API.
   1. [=Reject=] |writeRequest| with |storedError|.
  1. Set |stream|.[=WritableStream/[[writeRequests]]=] to an empty [=list=].
  1. If |stream|.[=WritableStream/[[pendingAbortRequest]]=] is undefined,
-  1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
+  1. Perform ! [=WritableStreamRejectCloseAndClosedPromiseIfNeeded=](|stream|).
   1. Return.
  1. Let |abortRequest| be |stream|.[=WritableStream/[[pendingAbortRequest]]=].
  1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
  1. If |abortRequest|'s [=pending abort request/was already erroring=] is true,
   1. [=Reject=] |abortRequest|'s [=pending abort request/promise=] with |storedError|.
-  1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
+  1. Perform ! [=WritableStreamRejectCloseAndClosedPromiseIfNeeded=](|stream|).
   1. Return.
  1. Let |promise| be !
     |stream|.[=WritableStream/[[controller]]=].[$WritableStreamController/[[AbortSteps]]$](|abortRequest|'s
     [=pending abort request/reason=]).
  1. [=Upon fulfillment=] of |promise|,
   1. [=Resolve=] |abortRequest|'s [=pending abort request/promise=] with undefined.
-  1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
+  1. Perform ! [=WritableStreamRejectCloseAndClosedPromiseIfNeeded=](|stream|).
  1. [=Upon rejection=] of |promise| with reason |reason|,
   1. [=Reject=] |abortRequest|'s [=pending abort request/promise=] with |reason|.
-  1. Perform ! [$WritableStreamRejectCloseAndClosedPromiseIfNeeded$](|stream|).
+  1. Perform ! [=WritableStreamRejectCloseAndClosedPromiseIfNeeded=](|stream|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightClose"
+ <dfn lt="WritableStreamFinishInFlightClose"
  id="writable-stream-finish-in-flight-close">WritableStreamFinishInFlightClose(|stream|)</dfn>
  performs the following steps:
 
@@ -4997,7 +4997,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightCloseWithError"
+ <dfn lt="WritableStreamFinishInFlightCloseWithError"
  id="writable-stream-finish-in-flight-close-with-error">WritableStreamFinishInFlightCloseWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
@@ -5009,11 +5009,11 @@ the {{WritableStream}}'s public API.
   1. [=Reject=] |stream|.[=WritableStream/[[pendingAbortRequest]]=]'s [=pending abort
      request/promise=] with |error|.
   1. Set |stream|.[=WritableStream/[[pendingAbortRequest]]=] to undefined.
- 1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |error|).
+ 1. Perform ! [=WritableStreamDealWithRejection=](|stream|, |error|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightWrite"
+ <dfn lt="WritableStreamFinishInFlightWrite"
  id="writable-stream-finish-in-flight-write">WritableStreamFinishInFlightWrite(|stream|)</dfn>
  performs the following steps:
 
@@ -5023,7 +5023,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightWriteWithError"
+ <dfn lt="WritableStreamFinishInFlightWriteWithError"
  id="writable-stream-finish-in-flight-write-with-error">WritableStreamFinishInFlightWriteWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
@@ -5031,11 +5031,11 @@ the {{WritableStream}}'s public API.
  1. [=Reject=] |stream|.[=WritableStream/[[inFlightWriteRequest]]=] with |error|.
  1. Set |stream|.[=WritableStream/[[inFlightWriteRequest]]=] to undefined.
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
- 1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |error|).
+ 1. Perform ! [=WritableStreamDealWithRejection=](|stream|, |error|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamHasOperationMarkedInFlight"
+ <dfn lt="WritableStreamHasOperationMarkedInFlight"
  id="writable-stream-has-operation-marked-in-flight">WritableStreamHasOperationMarkedInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5045,7 +5045,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamMarkCloseRequestInFlight"
+ <dfn lt="WritableStreamMarkCloseRequestInFlight"
  id="writable-stream-mark-close-request-in-flight">WritableStreamMarkCloseRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5057,7 +5057,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamMarkFirstWriteRequestInFlight"
+ <dfn lt="WritableStreamMarkFirstWriteRequestInFlight"
  id="writable-stream-mark-first-write-request-in-flight">WritableStreamMarkFirstWriteRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5069,7 +5069,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamRejectCloseAndClosedPromiseIfNeeded"
+ <dfn lt="WritableStreamRejectCloseAndClosedPromiseIfNeeded"
  id="writable-stream-reject-close-and-closed-promise-if-needed">WritableStreamRejectCloseAndClosedPromiseIfNeeded(|stream|)</dfn>
  performs the following steps:
 
@@ -5087,7 +5087,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamStartErroring"
+ <dfn lt="WritableStreamStartErroring"
  id="writable-stream-start-erroring">WritableStreamStartErroring(|stream|, |reason|)</dfn>
  performs the following steps:
 
@@ -5099,19 +5099,19 @@ the {{WritableStream}}'s public API.
  1. Set |stream|.[=WritableStream/[[storedError]]=] to |reason|.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined, perform !
-    [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |reason|).
- 1. If ! [$WritableStreamHasOperationMarkedInFlight$](|stream|) is false and
+    [=WritableStreamDefaultWriterEnsureReadyPromiseRejected=](|writer|, |reason|).
+ 1. If ! [=WritableStreamHasOperationMarkedInFlight=](|stream|) is false and
     |controller|.[=WritableStreamDefaultController/[[started]]=] is true, perform !
-    [$WritableStreamFinishErroring$](|stream|).
+    [=WritableStreamFinishErroring=](|stream|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamUpdateBackpressure"
+ <dfn lt="WritableStreamUpdateBackpressure"
  id="writable-stream-update-backpressure">WritableStreamUpdateBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
- 1. Assert: ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false.
+ 1. Assert: ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is false.
  1. Let |writer| be |stream|.[=WritableStream/[[writer]]=].
  1. If |writer| is not undefined and |backpressure| is not
     |stream|.[=WritableStream/[[backpressure]]=],
@@ -5129,46 +5129,46 @@ The following abstract operations support the implementation and manipulation of
 {{WritableStreamDefaultWriter}} instances.
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterAbort"
+ <dfn lt="WritableStreamDefaultWriterAbort"
  id="writable-stream-default-writer-abort">WritableStreamDefaultWriterAbort(|writer|,
  |reason|)</dfn> performs the following steps:
 
  1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
- 1. Return ! [$WritableStreamAbort$](|stream|, |reason|).
+ 1. Return ! [=WritableStreamAbort=](|stream|, |reason|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterClose"
+ <dfn lt="WritableStreamDefaultWriterClose"
  id="writable-stream-default-writer-close">WritableStreamDefaultWriterClose(|writer|)</dfn> performs
  the following steps:
 
  1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
- 1. Return ! [$WritableStreamClose$](|stream|).
+ 1. Return ! [=WritableStreamClose=](|stream|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterCloseWithErrorPropagation"
+ <dfn lt="WritableStreamDefaultWriterCloseWithErrorPropagation"
  id="writable-stream-default-writer-close-with-error-propagation">WritableStreamDefaultWriterCloseWithErrorPropagation(|writer|)</dfn>
  performs the following steps:
 
  1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
- 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
+ 1. If ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is true or |state| is "`closed`", return
     [=a promise resolved with=] undefined.
  1. If |state| is "`errored`", return [=a promise rejected with=]
     |stream|.[=WritableStream/[[storedError]]=].
  1. Assert: |state| is "`writable`" or "`erroring`".
- 1. Return ! [$WritableStreamDefaultWriterClose$](|writer|).
+ 1. Return ! [=WritableStreamDefaultWriterClose=](|writer|).
 
  <p class="note">This abstract operation helps implement the error propagation semantics of
  {{ReadableStream}}'s {{ReadableStream/pipeTo()}}.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterEnsureClosedPromiseRejected"
+ <dfn lt="WritableStreamDefaultWriterEnsureClosedPromiseRejected"
  id="writable-stream-default-writer-ensure-closed-promise-rejected">WritableStreamDefaultWriterEnsureClosedPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
@@ -5180,7 +5180,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterEnsureReadyPromiseRejected"
+ <dfn lt="WritableStreamDefaultWriterEnsureReadyPromiseRejected"
  id="writable-stream-default-writer-ensure-ready-promise-rejected">WritableStreamDefaultWriterEnsureReadyPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
@@ -5192,7 +5192,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterGetDesiredSize"
+ <dfn lt="WritableStreamDefaultWriterGetDesiredSize"
  id="writable-stream-default-writer-get-desired-size">WritableStreamDefaultWriterGetDesiredSize(|writer|)</dfn>
  performs the following steps:
 
@@ -5201,11 +5201,11 @@ The following abstract operations support the implementation and manipulation of
  1. If |state| is "`errored`" or "`erroring`", return null.
  1. If |state| is "`closed`", return 0.
  1. Return !
-    [$WritableStreamDefaultControllerGetDesiredSize$](|stream|.[=WritableStream/[[controller]]=]).
+    [=WritableStreamDefaultControllerGetDesiredSize=](|stream|.[=WritableStream/[[controller]]=]).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterRelease"
+ <dfn lt="WritableStreamDefaultWriterRelease"
  id="writable-stream-default-writer-release">WritableStreamDefaultWriterRelease(|writer|)</dfn>
  performs the following steps:
 
@@ -5213,34 +5213,34 @@ The following abstract operations support the implementation and manipulation of
  1. Assert: |stream| is not undefined.
  1. Assert: |stream|.[=WritableStream/[[writer]]=] is |writer|.
  1. Let |releasedError| be a new {{TypeError}}.
- 1. Perform ! [$WritableStreamDefaultWriterEnsureReadyPromiseRejected$](|writer|, |releasedError|).
- 1. Perform ! [$WritableStreamDefaultWriterEnsureClosedPromiseRejected$](|writer|, |releasedError|).
+ 1. Perform ! [=WritableStreamDefaultWriterEnsureReadyPromiseRejected=](|writer|, |releasedError|).
+ 1. Perform ! [=WritableStreamDefaultWriterEnsureClosedPromiseRejected=](|writer|, |releasedError|).
  1. Set |stream|.[=WritableStream/[[writer]]=] to undefined.
  1. Set |writer|.[=WritableStreamDefaultWriter/[[stream]]=] to undefined.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterWrite"
+ <dfn lt="WritableStreamDefaultWriterWrite"
  id="writable-stream-default-writer-write">WritableStreamDefaultWriterWrite(|writer|, |chunk|)</dfn>
  performs the following steps:
 
  1. Let |stream| be |writer|.[=WritableStreamDefaultWriter/[[stream]]=].
  1. Assert: |stream| is not undefined.
  1. Let |controller| be |stream|.[=WritableStream/[[controller]]=].
- 1. Let |chunkSize| be ! [$WritableStreamDefaultControllerGetChunkSize$](|controller|, |chunk|).
+ 1. Let |chunkSize| be ! [=WritableStreamDefaultControllerGetChunkSize=](|controller|, |chunk|).
  1. If |stream| is not equal to |writer|.[=WritableStreamDefaultWriter/[[stream]]=], return [=a
     promise rejected with=] a {{TypeError}} exception.
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. If |state| is "`errored`", return [=a promise rejected with=]
     |stream|.[=WritableStream/[[storedError]]=].
- 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is true or |state| is "`closed`", return
+ 1. If ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is true or |state| is "`closed`", return
     [=a promise rejected with=] a {{TypeError}} exception indicating that the stream is closing or
     closed.
  1. If |state| is "`erroring`", return [=a promise rejected with=]
     |stream|.[=WritableStream/[[storedError]]=].
  1. Assert: |state| is "`writable`".
- 1. Let |promise| be ! [$WritableStreamAddWriteRequest$](|stream|).
- 1. Perform ! [$WritableStreamDefaultControllerWrite$](|controller|, |chunk|, |chunkSize|).
+ 1. Let |promise| be ! [=WritableStreamAddWriteRequest=](|stream|).
+ 1. Perform ! [=WritableStreamDefaultControllerWrite=](|controller|, |chunk|, |chunkSize|).
  1. Return |promise|.
 </div>
 
@@ -5251,7 +5251,7 @@ The following abstract operations support the implementation of the
 
 
 <div algorithm>
- <dfn abstract-op lt="SetUpWritableStreamDefaultController"
+ <dfn lt="SetUpWritableStreamDefaultController"
  id="set-up-writable-stream-default-controller">SetUpWritableStreamDefaultController(|stream|,
  |controller|, |startAlgorithm|, |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|,
  |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following steps:
@@ -5260,7 +5260,7 @@ The following abstract operations support the implementation of the
  1. Assert: |stream|.[=WritableStream/[[controller]]=] is undefined.
  1. Set |controller|.[=WritableStreamDefaultController/[[stream]]=] to |stream|.
  1. Set |stream|.[=WritableStream/[[controller]]=] to |controller|.
- 1. Perform ! [$ResetQueue$](|controller|).
+ 1. Perform ! [=ResetQueue=](|controller|).
  1. Set |controller|.[=WritableStreamDefaultController/[[abortController]]=] to a new
     {{AbortController}}.
  1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to false.
@@ -5270,22 +5270,22 @@ The following abstract operations support the implementation of the
  1. Set |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=] to |writeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=] to |closeAlgorithm|.
  1. Set |controller|.[=WritableStreamDefaultController/[[abortAlgorithm]]=] to |abortAlgorithm|.
- 1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
- 1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
+ 1. Let |backpressure| be ! [=WritableStreamDefaultControllerGetBackpressure=](|controller|).
+ 1. Perform ! [=WritableStreamUpdateBackpressure=](|stream|, |backpressure|).
  1. Let |startResult| be the result of performing |startAlgorithm|. (This may throw an exception.)
  1. Let |startPromise| be [=a promise resolved with=] |startResult|.
  1. [=Upon fulfillment=] of |startPromise|,
   1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
   1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to true.
-  1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
+  1. Perform ! [=WritableStreamDefaultControllerAdvanceQueueIfNeeded=](|controller|).
  1. [=Upon rejection=] of |startPromise| with reason |r|,
   1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`" or "`erroring`".
   1. Set |controller|.[=WritableStreamDefaultController/[[started]]=] to true.
-  1. Perform ! [$WritableStreamDealWithRejection$](|stream|, |r|).
+  1. Perform ! [=WritableStreamDealWithRejection=](|stream|, |r|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpWritableStreamDefaultControllerFromUnderlyingSink"
+ <dfn lt="SetUpWritableStreamDefaultControllerFromUnderlyingSink"
  id="set-up-writable-stream-default-controller-from-underlying-sink">SetUpWritableStreamDefaultControllerFromUnderlyingSink(|stream|,
  |underlyingSink|, |underlyingSinkDict|, |highWaterMark|, |sizeAlgorithm|)</dfn> performs the
  following steps:
@@ -5311,12 +5311,12 @@ The following abstract operations support the implementation of the
     an algorithm which takes an argument |reason| and returns the result of [=invoking=]
     |underlyingSinkDict|["{{UnderlyingSink/abort}}"] with argument list «&nbsp;|reason|&nbsp;» and
     [=callback this value=] |underlyingSink|.
- 1. Perform ? [$SetUpWritableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ? [=SetUpWritableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|, |highWaterMark|, |sizeAlgorithm|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
+ <dfn lt="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
  id="writable-stream-default-controller-advance-queue-if-needed">WritableStreamDefaultControllerAdvanceQueueIfNeeded(|controller|)</dfn>
  performs the following steps:
 
@@ -5326,18 +5326,18 @@ The following abstract operations support the implementation of the
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
  1. Assert: |state| is not "`closed`" or "`errored`".
  1. If |state| is "`erroring`",
-  1. Perform ! [$WritableStreamFinishErroring$](|stream|).
+  1. Perform ! [=WritableStreamFinishErroring=](|stream|).
   1. Return.
  1. If |controller|.[=WritableStreamDefaultController/[[queue]]=] is empty, return.
- 1. Let |value| be ! [$PeekQueueValue$](|controller|).
+ 1. Let |value| be ! [=PeekQueueValue=](|controller|).
  1. If |value| is the [=close sentinel=], perform !
-    [$WritableStreamDefaultControllerProcessClose$](|controller|).
- 1. Otherwise, perform ! [$WritableStreamDefaultControllerProcessWrite$](|controller|,
+    [=WritableStreamDefaultControllerProcessClose=](|controller|).
+ 1. Otherwise, perform ! [=WritableStreamDefaultControllerProcessWrite=](|controller|,
     |value|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerClearAlgorithms"
+ <dfn lt="WritableStreamDefaultControllerClearAlgorithms"
  id="writable-stream-default-controller-clear-algorithms">WritableStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying sink=] object to be garbage
@@ -5360,45 +5360,45 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerClose"
+ <dfn lt="WritableStreamDefaultControllerClose"
  id="writable-stream-default-controller-close">WritableStreamDefaultControllerClose(|controller|)</dfn>
  performs the following steps:
 
- 1. Perform ! [$EnqueueValueWithSize$](|controller|, [=close sentinel=], 0).
- 1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
+ 1. Perform ! [=EnqueueValueWithSize=](|controller|, [=close sentinel=], 0).
+ 1. Perform ! [=WritableStreamDefaultControllerAdvanceQueueIfNeeded=](|controller|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerError"
+ <dfn lt="WritableStreamDefaultControllerError"
  id="writable-stream-default-controller-error">WritableStreamDefaultControllerError(|controller|,
  |error|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
  1. Assert: |stream|.[=WritableStream/[[state]]=] is "`writable`".
- 1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
- 1. Perform ! [$WritableStreamStartErroring$](|stream|, |error|).
+ 1. Perform ! [=WritableStreamDefaultControllerClearAlgorithms=](|controller|).
+ 1. Perform ! [=WritableStreamStartErroring=](|stream|, |error|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerErrorIfNeeded"
+ <dfn lt="WritableStreamDefaultControllerErrorIfNeeded"
  id="writable-stream-default-controller-error-if-needed">WritableStreamDefaultControllerErrorIfNeeded(|controller|,
  |error|)</dfn> performs the following steps:
 
  1. If |controller|.[=WritableStreamDefaultController/[[stream]]=].[=WritableStream/[[state]]=] is
-    "`writable`", perform ! [$WritableStreamDefaultControllerError$](|controller|, |error|).
+    "`writable`", perform ! [=WritableStreamDefaultControllerError=](|controller|, |error|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerGetBackpressure"
+ <dfn lt="WritableStreamDefaultControllerGetBackpressure"
  id="writable-stream-default-controller-get-backpressure">WritableStreamDefaultControllerGetBackpressure(|controller|)</dfn>
  performs the following steps:
 
- 1. Let |desiredSize| be ! [$WritableStreamDefaultControllerGetDesiredSize$](|controller|).
+ 1. Let |desiredSize| be ! [=WritableStreamDefaultControllerGetDesiredSize=](|controller|).
  1. Return true if |desiredSize| ≤ 0, or false otherwise.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerGetChunkSize"
+ <dfn lt="WritableStreamDefaultControllerGetChunkSize"
  id="writable-stream-default-controller-get-chunk-size">WritableStreamDefaultControllerGetChunkSize(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -5410,14 +5410,14 @@ The following abstract operations support the implementation of the
     |controller|.[=WritableStreamDefaultController/[[strategySizeAlgorithm]]=], passing in |chunk|,
     and interpreting the result as a [=completion record=].
  1. If |returnValue| is an abrupt completion,
-  1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|,
+  1. Perform ! [=WritableStreamDefaultControllerErrorIfNeeded=](|controller|,
      |returnValue|.\[[Value]]).
   1. Return 1.
  1. Return |returnValue|.\[[Value]].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerGetDesiredSize"
+ <dfn lt="WritableStreamDefaultControllerGetDesiredSize"
  id="writable-stream-default-controller-get-desired-size">WritableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -5426,63 +5426,63 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerProcessClose"
+ <dfn lt="WritableStreamDefaultControllerProcessClose"
  id="writable-stream-default-controller-process-close">WritableStreamDefaultControllerProcessClose(|controller|)</dfn>
  performs the following steps:
 
  1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
- 1. Perform ! [$WritableStreamMarkCloseRequestInFlight$](|stream|).
- 1. Perform ! [$DequeueValue$](|controller|).
+ 1. Perform ! [=WritableStreamMarkCloseRequestInFlight=](|stream|).
+ 1. Perform ! [=DequeueValue=](|controller|).
  1. Assert: |controller|.[=WritableStreamDefaultController/[[queue]]=] is empty.
  1. Let |sinkClosePromise| be the result of performing
     |controller|.[=WritableStreamDefaultController/[[closeAlgorithm]]=].
- 1. Perform ! [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
+ 1. Perform ! [=WritableStreamDefaultControllerClearAlgorithms=](|controller|).
  1. [=Upon fulfillment=] of |sinkClosePromise|,
-  1. Perform ! [$WritableStreamFinishInFlightClose$](|stream|).
+  1. Perform ! [=WritableStreamFinishInFlightClose=](|stream|).
  1. [=Upon rejection=] of |sinkClosePromise| with reason |reason|,
-  1. Perform ! [$WritableStreamFinishInFlightCloseWithError$](|stream|, |reason|).
+  1. Perform ! [=WritableStreamFinishInFlightCloseWithError=](|stream|, |reason|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerProcessWrite"
+ <dfn lt="WritableStreamDefaultControllerProcessWrite"
  id="writable-stream-default-controller-process-write">WritableStreamDefaultControllerProcessWrite(|controller|,
  |chunk|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
- 1. Perform ! [$WritableStreamMarkFirstWriteRequestInFlight$](|stream|).
+ 1. Perform ! [=WritableStreamMarkFirstWriteRequestInFlight=](|stream|).
  1. Let |sinkWritePromise| be the result of performing
     |controller|.[=WritableStreamDefaultController/[[writeAlgorithm]]=], passing in |chunk|.
  1. [=Upon fulfillment=] of |sinkWritePromise|,
-  1. Perform ! [$WritableStreamFinishInFlightWrite$](|stream|).
+  1. Perform ! [=WritableStreamFinishInFlightWrite=](|stream|).
   1. Let |state| be |stream|.[=WritableStream/[[state]]=].
   1. Assert: |state| is "`writable`" or "`erroring`".
-  1. Perform ! [$DequeueValue$](|controller|).
-  1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and |state| is "`writable`",
-   1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
-   1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
-  1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
+  1. Perform ! [=DequeueValue=](|controller|).
+  1. If ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is false and |state| is "`writable`",
+   1. Let |backpressure| be ! [=WritableStreamDefaultControllerGetBackpressure=](|controller|).
+   1. Perform ! [=WritableStreamUpdateBackpressure=](|stream|, |backpressure|).
+  1. Perform ! [=WritableStreamDefaultControllerAdvanceQueueIfNeeded=](|controller|).
  1. [=Upon rejection=] of |sinkWritePromise| with |reason|,
   1. If |stream|.[=WritableStream/[[state]]=] is "`writable`", perform !
-     [$WritableStreamDefaultControllerClearAlgorithms$](|controller|).
-  1. Perform ! [$WritableStreamFinishInFlightWriteWithError$](|stream|, |reason|).
+     [=WritableStreamDefaultControllerClearAlgorithms=](|controller|).
+  1. Perform ! [=WritableStreamFinishInFlightWriteWithError=](|stream|, |reason|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerWrite"
+ <dfn lt="WritableStreamDefaultControllerWrite"
  id="writable-stream-default-controller-write">WritableStreamDefaultControllerWrite(|controller|,
  |chunk|, |chunkSize|)</dfn> performs the following steps:
 
- 1. Let |enqueueResult| be [$EnqueueValueWithSize$](|controller|, |chunk|, |chunkSize|).
+ 1. Let |enqueueResult| be [=EnqueueValueWithSize=](|controller|, |chunk|, |chunkSize|).
  1. If |enqueueResult| is an abrupt completion,
-  1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|,
+  1. Perform ! [=WritableStreamDefaultControllerErrorIfNeeded=](|controller|,
      |enqueueResult|.\[[Value]]).
   1. Return.
  1. Let |stream| be |controller|.[=WritableStreamDefaultController/[[stream]]=].
- 1. If ! [$WritableStreamCloseQueuedOrInFlight$](|stream|) is false and
+ 1. If ! [=WritableStreamCloseQueuedOrInFlight=](|stream|) is false and
     |stream|.[=WritableStream/[[state]]=] is "`writable`",
-  1. Let |backpressure| be ! [$WritableStreamDefaultControllerGetBackpressure$](|controller|).
-  1. Perform ! [$WritableStreamUpdateBackpressure$](|stream|, |backpressure|).
- 1. Perform ! [$WritableStreamDefaultControllerAdvanceQueueIfNeeded$](|controller|).
+  1. Let |backpressure| be ! [=WritableStreamDefaultControllerGetBackpressure=](|controller|).
+  1. Perform ! [=WritableStreamUpdateBackpressure=](|stream|, |backpressure|).
+ 1. Perform ! [=WritableStreamDefaultControllerAdvanceQueueIfNeeded=](|controller|).
 </div>
 
 <h2 id="ts">Transform streams</h2>
@@ -5760,14 +5760,14 @@ The <code>controller</code> object passed to {{Transformer/start|start()}},
     exception.
  1. If |transformerDict|["{{Transformer/writableType}}"] [=map/exists=], throw a {{RangeError}}
     exception.
- 1. Let |readableHighWaterMark| be ? [$ExtractHighWaterMark$](|readableStrategy|, 0).
- 1. Let |readableSizeAlgorithm| be ! [$ExtractSizeAlgorithm$](|readableStrategy|).
- 1. Let |writableHighWaterMark| be ? [$ExtractHighWaterMark$](|writableStrategy|, 1).
- 1. Let |writableSizeAlgorithm| be ! [$ExtractSizeAlgorithm$](|writableStrategy|).
+ 1. Let |readableHighWaterMark| be ? [=ExtractHighWaterMark=](|readableStrategy|, 0).
+ 1. Let |readableSizeAlgorithm| be ! [=ExtractSizeAlgorithm=](|readableStrategy|).
+ 1. Let |writableHighWaterMark| be ? [=ExtractHighWaterMark=](|writableStrategy|, 1).
+ 1. Let |writableSizeAlgorithm| be ! [=ExtractSizeAlgorithm=](|writableStrategy|).
  1. Let |startPromise| be [=a new promise=].
- 1. Perform ! [$InitializeTransformStream$]([=this=], |startPromise|, |writableHighWaterMark|,
+ 1. Perform ! [=InitializeTransformStream=]([=this=], |startPromise|, |writableHighWaterMark|,
     |writableSizeAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
- 1. Perform ? [$SetUpTransformStreamDefaultControllerFromTransformer$]([=this=], |transformer|,
+ 1. Perform ? [=SetUpTransformStreamDefaultControllerFromTransformer=]([=this=], |transformer|,
     |transformerDict|).
  1. If |transformerDict|["{{Transformer/start}}"] [=map/exists=], then [=resolve=] |startPromise|
     with the result of [=invoking=] |transformerDict|["{{Transformer/start}}"] with argument list
@@ -5808,9 +5808,9 @@ The <code>controller</code> object passed to {{Transformer/start|start()}},
 
  1. Let |readable| be |value|.[=TransformStream/[[readable]]=].
  1. Let |writable| be |value|.[=TransformStream/[[writable]]=].
- 1. If ! [$IsReadableStreamLocked$](|readable|) is true, throw a "{{DataCloneError}}"
+ 1. If ! [=IsReadableStreamLocked=](|readable|) is true, throw a "{{DataCloneError}}"
     {{DOMException}}.
- 1. If ! [$IsWritableStreamLocked$](|writable|) is true, throw a "{{DataCloneError}}"
+ 1. If ! [=IsWritableStreamLocked=](|writable|) is true, throw a "{{DataCloneError}}"
     {{DOMException}}.
  1. Set |dataHolder|.\[[readable]] to ! [$StructuredSerializeWithTransfer$](|readable|,
     « |readable| »).
@@ -5923,28 +5923,28 @@ the following table:
  for="TransformStreamDefaultController">desiredSize</dfn> getter steps are:
 
  1. Let |readableController| be [=this=].[=TransformStreamDefaultController/[[stream]]=].[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
- 1. Return ! [$ReadableStreamDefaultControllerGetDesiredSize$](|readableController|).
+ 1. Return ! [=ReadableStreamDefaultControllerGetDesiredSize=](|readableController|).
 </div>
 
 <div algorithm>
  The <dfn id="ts-default-controller-enqueue" method
  for="TransformStreamDefaultController">enqueue(|chunk|)</dfn> method steps are:
 
- 1. Perform ? [$TransformStreamDefaultControllerEnqueue$]([=this=], |chunk|).
+ 1. Perform ? [=TransformStreamDefaultControllerEnqueue=]([=this=], |chunk|).
 </div>
 
 <div algorithm>
  The <dfn id="ts-default-controller-error" method
  for="TransformStreamDefaultController">error(|e|)</dfn> method steps are:
 
- 1. Perform ? [$TransformStreamDefaultControllerError$]([=this=], |e|).
+ 1. Perform ? [=TransformStreamDefaultControllerError=]([=this=], |e|).
 </div>
 
 <div algorithm>
  The <dfn id="ts-default-controller-terminate" method
  for="TransformStreamDefaultController">terminate()</dfn> method steps are:
 
- 1. Perform ? [$TransformStreamDefaultControllerTerminate$]([=this=]).
+ 1. Perform ? [=TransformStreamDefaultControllerTerminate=]([=this=]).
 </div>
 
 <h3 id="ts-all-abstract-ops">Abstract operations</h3>
@@ -5954,44 +5954,44 @@ the following table:
 The following abstract operations operate on {{TransformStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op lt="InitializeTransformStream"
+ <dfn lt="InitializeTransformStream"
  id="initialize-transform-stream">InitializeTransformStream(|stream|, |startPromise|,
  |writableHighWaterMark|, |writableSizeAlgorithm|, |readableHighWaterMark|,
  |readableSizeAlgorithm|)</dfn> performs the following steps:
 
  1. Let |startAlgorithm| be an algorithm that returns |startPromise|.
  1. Let |writeAlgorithm| be the following steps, taking a |chunk| argument:
-  1. Return ! [$TransformStreamDefaultSinkWriteAlgorithm$](|stream|, |chunk|).
+  1. Return ! [=TransformStreamDefaultSinkWriteAlgorithm=](|stream|, |chunk|).
  1. Let |abortAlgorithm| be the following steps, taking a |reason| argument:
-  1. Return ! [$TransformStreamDefaultSinkAbortAlgorithm$](|stream|, |reason|).
+  1. Return ! [=TransformStreamDefaultSinkAbortAlgorithm=](|stream|, |reason|).
  1. Let |closeAlgorithm| be the following steps:
-  1. Return ! [$TransformStreamDefaultSinkCloseAlgorithm$](|stream|).
- 1. Set |stream|.[=TransformStream/[[writable]]=] to ! [$CreateWritableStream$](|startAlgorithm|,
+  1. Return ! [=TransformStreamDefaultSinkCloseAlgorithm=](|stream|).
+ 1. Set |stream|.[=TransformStream/[[writable]]=] to ! [=CreateWritableStream=](|startAlgorithm|,
     |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|, |writableHighWaterMark|,
     |writableSizeAlgorithm|).
  1. Let |pullAlgorithm| be the following steps:
-  1. Return ! [$TransformStreamDefaultSourcePullAlgorithm$](|stream|).
+  1. Return ! [=TransformStreamDefaultSourcePullAlgorithm=](|stream|).
  1. Let |cancelAlgorithm| be the following steps, taking a |reason| argument:
-  1. Return ! [$TransformStreamDefaultSourceCancelAlgorithm$](|stream|, |reason|).
- 1. Set |stream|.[=TransformStream/[[readable]]=] to ! [$CreateReadableStream$](|startAlgorithm|,
+  1. Return ! [=TransformStreamDefaultSourceCancelAlgorithm=](|stream|, |reason|).
+ 1. Set |stream|.[=TransformStream/[[readable]]=] to ! [=CreateReadableStream=](|startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
  1. Set |stream|.[=TransformStream/[[backpressure]]=] and
     |stream|.[=TransformStream/[[backpressureChangePromise]]=] to undefined.
     <p class="note">The [=TransformStream/[[backpressure]]=] slot is set to undefined so that it can
-    be initialized by [$TransformStreamSetBackpressure$]. Alternatively, implementations can use a
+    be initialized by [=TransformStreamSetBackpressure=]. Alternatively, implementations can use a
     strictly boolean value for [=TransformStream/[[backpressure]]=] and change the way it is
     initialized. This will not be visible to user code so long as the initialization is correctly
     completed before the transformer's {{Transformer/start|start()}} method is called.
- 1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
+ 1. Perform ! [=TransformStreamSetBackpressure=](|stream|, true).
  1. Set |stream|.[=TransformStream/[[controller]]=] to undefined.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamError"
+ <dfn lt="TransformStreamError"
  id="transform-stream-error">TransformStreamError(|stream|, |e|)</dfn> performs the following steps:
 
- 1. Perform ! [$ReadableStreamDefaultControllerError$](|stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=], |e|).
- 1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |e|).
+ 1. Perform ! [=ReadableStreamDefaultControllerError=](|stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=], |e|).
+ 1. Perform ! [=TransformStreamErrorWritableAndUnblockWrite=](|stream|, |e|).
 
  <p class="note">This operation works correctly when one or both sides are already errored. As a
  result, calling algorithms do not need to check stream states when responding to an error
@@ -5999,18 +5999,18 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamErrorWritableAndUnblockWrite"
+ <dfn lt="TransformStreamErrorWritableAndUnblockWrite"
  id="transform-stream-error-writable-and-unblock-write">TransformStreamErrorWritableAndUnblockWrite(|stream|,
  |e|)</dfn> performs the following steps:
 
- 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|stream|.[=TransformStream/[[controller]]=]).
+ 1. Perform ! [=TransformStreamDefaultControllerClearAlgorithms=](|stream|.[=TransformStream/[[controller]]=]).
  1. Perform !
-    [$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=TransformStream/[[writable]]=].[=WritableStream/[[controller]]=], |e|).
- 1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+    [=WritableStreamDefaultControllerErrorIfNeeded=](|stream|.[=TransformStream/[[writable]]=].[=WritableStream/[[controller]]=], |e|).
+ 1. Perform ! [=TransformStreamUnblockWrite=](|stream|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamSetBackpressure"
+ <dfn lt="TransformStreamSetBackpressure"
  id="transform-stream-set-backpressure">TransformStreamSetBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
@@ -6022,16 +6022,16 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamUnblockWrite"
+ <dfn lt="TransformStreamUnblockWrite"
  id="transform-stream-unblock-write">TransformStreamUnblockWrite(|stream|)</dfn> performs the
  following steps:
 
- 1. If |stream|.[=TransformStream/[[backpressure]]=] is true, perform ! [$TransformStreamSetBackpressure$](|stream|,
+ 1. If |stream|.[=TransformStream/[[backpressure]]=] is true, perform ! [=TransformStreamSetBackpressure=](|stream|,
     false).
 
- <p class="note">The [$TransformStreamDefaultSinkWriteAlgorithm$] abstract operation could be
+ <p class="note">The [=TransformStreamDefaultSinkWriteAlgorithm=] abstract operation could be
  waiting for the promise stored in the [=TransformStream/[[backpressureChangePromise]]=] slot to
- resolve. The call to [$TransformStreamSetBackpressure$] ensures that the promise always resolves.
+ resolve. The call to [=TransformStreamSetBackpressure=] ensures that the promise always resolves.
 </div>
 
 <h4 id="ts-default-controller-abstract-ops">Default controllers</h4>
@@ -6040,7 +6040,7 @@ The following abstract operations support the implementaiton of the
 {{TransformStreamDefaultController}} class.
 
 <div algorithm>
- <dfn abstract-op lt="SetUpTransformStreamDefaultController"
+ <dfn lt="SetUpTransformStreamDefaultController"
  id="set-up-transform-stream-default-controller">SetUpTransformStreamDefaultController(|stream|,
  |controller|, |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|)</dfn> performs the
  following steps:
@@ -6056,13 +6056,13 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpTransformStreamDefaultControllerFromTransformer"
+ <dfn lt="SetUpTransformStreamDefaultControllerFromTransformer"
  id="set-up-transform-stream-default-controller-from-transformer">SetUpTransformStreamDefaultControllerFromTransformer(|stream|,
  |transformer|, |transformerDict|)</dfn> performs the following steps:
 
  1. Let |controller| be a [=new=] {{TransformStreamDefaultController}}.
  1. Let |transformAlgorithm| be the following steps, taking a |chunk| argument:
-  1. Let |result| be [$TransformStreamDefaultControllerEnqueue$](|controller|, |chunk|).
+  1. Let |result| be [=TransformStreamDefaultControllerEnqueue=](|controller|, |chunk|).
   1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |flushAlgorithm| be an algorithm which returns [=a promise resolved with=] undefined.
@@ -6078,12 +6078,12 @@ The following abstract operations support the implementaiton of the
     algorithm which takes an argument |reason| and returns the result of [=invoking=]
     |transformerDict|["{{Transformer/cancel}}"] with argument list «&nbsp;|reason|&nbsp;» and
     [=callback this value=] |transformer|.
- 1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
+ 1. Perform ! [=SetUpTransformStreamDefaultController=](|stream|, |controller|,
     |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerClearAlgorithms"
+ <dfn lt="TransformStreamDefaultControllerClearAlgorithms"
  id="transform-stream-default-controller-clear-algorithms">TransformStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more.
  By removing the algorithm references it permits the [=transformer=] object to be garbage collected
@@ -6102,38 +6102,38 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerEnqueue"
+ <dfn lt="TransformStreamDefaultControllerEnqueue"
  id="transform-stream-default-controller-enqueue">TransformStreamDefaultControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
  1. Let |stream| be |controller|.[=TransformStreamDefaultController/[[stream]]=].
  1. Let |readableController| be
     |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
- 1. If ! [$ReadableStreamDefaultControllerCanCloseOrEnqueue$](|readableController|) is false, throw
+ 1. If ! [=ReadableStreamDefaultControllerCanCloseOrEnqueue=](|readableController|) is false, throw
     a {{TypeError}} exception.
- 1. Let |enqueueResult| be [$ReadableStreamDefaultControllerEnqueue$](|readableController|,
+ 1. Let |enqueueResult| be [=ReadableStreamDefaultControllerEnqueue=](|readableController|,
     |chunk|).
  1. If |enqueueResult| is an abrupt completion,
-   1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|,
+   1. Perform ! [=TransformStreamErrorWritableAndUnblockWrite=](|stream|,
       |enqueueResult|.\[[Value]]).
    1. Throw |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[storedError]]=].
  1. Let |backpressure| be !
-    [$ReadableStreamDefaultControllerHasBackpressure$](|readableController|).
+    [=ReadableStreamDefaultControllerHasBackpressure=](|readableController|).
  1. If |backpressure| is not |stream|.[=TransformStream/[[backpressure]]=],
    1. Assert: |backpressure| is true.
-   1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
+   1. Perform ! [=TransformStreamSetBackpressure=](|stream|, true).
 </div>
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerError"
+ <dfn lt="TransformStreamDefaultControllerError"
  id="transform-stream-default-controller-error">TransformStreamDefaultControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
- 1. Perform ! [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=],
+ 1. Perform ! [=TransformStreamError=](|controller|.[=TransformStreamDefaultController/[[stream]]=],
     |e|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerPerformTransform"
+ <dfn lt="TransformStreamDefaultControllerPerformTransform"
  id="transform-stream-default-controller-perform-transform">TransformStreamDefaultControllerPerformTransform(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6142,21 +6142,21 @@ The following abstract operations support the implementaiton of the
  1. Return the result of [=reacting=] to |transformPromise| with the following
     rejection steps given the argument |r|:
    1. Perform !
-      [$TransformStreamError$](|controller|.[=TransformStreamDefaultController/[[stream]]=], |r|).
+      [=TransformStreamError=](|controller|.[=TransformStreamDefaultController/[[stream]]=], |r|).
    1. Throw |r|.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerTerminate"
+ <dfn lt="TransformStreamDefaultControllerTerminate"
  id="transform-stream-default-controller-terminate">TransformStreamDefaultControllerTerminate(|controller|)</dfn>
  performs the following steps:
 
  1. Let |stream| be |controller|.[=TransformStreamDefaultController/[[stream]]=].
  1. Let |readableController| be
     |stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=].
- 1. Perform ! [$ReadableStreamDefaultControllerClose$](|readableController|).
+ 1. Perform ! [=ReadableStreamDefaultControllerClose=](|readableController|).
  1. Let |error| be a {{TypeError}} exception indicating that the stream has been terminated.
- 1. Perform ! [$TransformStreamErrorWritableAndUnblockWrite$](|stream|, |error|).
+ 1. Perform ! [=TransformStreamErrorWritableAndUnblockWrite=](|stream|, |error|).
 </div>
 
 <h4 id="ts-default-sink-abstract-ops">Default sinks</h4>
@@ -6165,7 +6165,7 @@ The following abstract operations are used to implement the [=underlying sink=] 
 side=] of [=transform streams=].
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSinkWriteAlgorithm"
+ <dfn lt="TransformStreamDefaultSinkWriteAlgorithm"
  id="transform-stream-default-sink-write-algorithm">TransformStreamDefaultSinkWriteAlgorithm(|stream|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6180,12 +6180,12 @@ side=] of [=transform streams=].
    1. Let |state| be |writable|.[=WritableStream/[[state]]=].
    1. If |state| is "`erroring`", throw |writable|.[=WritableStream/[[storedError]]=].
    1. Assert: |state| is "`writable`".
-   1. Return ! [$TransformStreamDefaultControllerPerformTransform$](|controller|, |chunk|).
- 1. Return ! [$TransformStreamDefaultControllerPerformTransform$](|controller|, |chunk|).
+   1. Return ! [=TransformStreamDefaultControllerPerformTransform=](|controller|, |chunk|).
+ 1. Return ! [=TransformStreamDefaultControllerPerformTransform=](|controller|, |chunk|).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSinkAbortAlgorithm"
+ <dfn lt="TransformStreamDefaultSinkAbortAlgorithm"
  id="transform-stream-default-sink-abort-algorithm">TransformStreamDefaultSinkAbortAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
@@ -6196,23 +6196,23 @@ side=] of [=transform streams=].
  1. Let |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] be a new promise.
  1. Let |cancelPromise| be the result of performing
     |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
- 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
+ 1. Perform ! [=TransformStreamDefaultControllerClearAlgorithms=](|controller|).
  1. [=React=] to |cancelPromise|:
   1. If |cancelPromise| was fulfilled, then:
    1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", [=reject=]
       |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with
       |readable|.[=ReadableStream/[[storedError]]=].
    1. Otherwise:
-    1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |reason|).
+    1. Perform ! [=ReadableStreamDefaultControllerError=](|readable|.[=ReadableStream/[[controller]]=], |reason|).
     1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
   1. If |cancelPromise| was rejected with reason |r|, then:
-   1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |r|).
+   1. Perform ! [=ReadableStreamDefaultControllerError=](|readable|.[=ReadableStream/[[controller]]=], |r|).
    1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
  1. Return |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSinkCloseAlgorithm"
+ <dfn lt="TransformStreamDefaultSinkCloseAlgorithm"
  id="transform-stream-default-sink-close-algorithm">TransformStreamDefaultSinkCloseAlgorithm(|stream|)</dfn>
  performs the following steps:
 
@@ -6223,17 +6223,17 @@ side=] of [=transform streams=].
  1. Let |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] be a new promise.
  1. Let |flushPromise| be the result of performing
     |controller|.[=TransformStreamDefaultController/[[flushAlgorithm]]=].
- 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
+ 1. Perform ! [=TransformStreamDefaultControllerClearAlgorithms=](|controller|).
  1. [=React=] to |flushPromise|:
   1. If |flushPromise| was fulfilled, then:
    1. If |readable|.[=ReadableStream/[[state]]=] is "`errored`", [=reject=]
       |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with
       |readable|.[=ReadableStream/[[storedError]]=].
    1. Otherwise:
-    1. Perform ! [$ReadableStreamDefaultControllerClose$](|readable|.[=ReadableStream/[[controller]]=]).
+    1. Perform ! [=ReadableStreamDefaultControllerClose=](|readable|.[=ReadableStream/[[controller]]=]).
     1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
   1. If |flushPromise| was rejected with reason |r|, then:
-   1. Perform ! [$ReadableStreamDefaultControllerError$](|readable|.[=ReadableStream/[[controller]]=], |r|).
+   1. Perform ! [=ReadableStreamDefaultControllerError=](|readable|.[=ReadableStream/[[controller]]=], |r|).
    1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
  1. Return |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
 </div>
@@ -6244,7 +6244,7 @@ The following abstract operation is used to implement the [=underlying source=] 
 side=] of [=transform streams=].
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSourceCancelAlgorithm"
+ <dfn lt="TransformStreamDefaultSourceCancelAlgorithm"
  id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
@@ -6255,31 +6255,31 @@ side=] of [=transform streams=].
  1. Let |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] be a new promise.
  1. Let |cancelPromise| be the result of performing
     |controller|.[=TransformStreamDefaultController/[[cancelAlgorithm]]=], passing |reason|.
- 1. Perform ! [$TransformStreamDefaultControllerClearAlgorithms$](|controller|).
+ 1. Perform ! [=TransformStreamDefaultControllerClearAlgorithms=](|controller|).
  1. [=React=] to |cancelPromise|:
   1. If |cancelPromise| was fulfilled, then:
    1. If |writable|.[=WritableStream/[[state]]=] is "`errored`", [=reject=]
       |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with
       |writable|.[=WritableStream/[[storedError]]=].
    1. Otherwise:
-    1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |reason|).
-    1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+    1. Perform ! [=WritableStreamDefaultControllerErrorIfNeeded=](|writable|.[=WritableStream/[[controller]]=], |reason|).
+    1. Perform ! [=TransformStreamUnblockWrite=](|stream|).
     1. [=Resolve=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with undefined.
   1. If |cancelPromise| was rejected with reason |r|, then:
-   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|writable|.[=WritableStream/[[controller]]=], |r|).
-   1. Perform ! [$TransformStreamUnblockWrite$](|stream|).
+   1. Perform ! [=WritableStreamDefaultControllerErrorIfNeeded=](|writable|.[=WritableStream/[[controller]]=], |r|).
+   1. Perform ! [=TransformStreamUnblockWrite=](|stream|).
    1. [=Reject=] |controller|.[=TransformStreamDefaultController/[[finishPromise]]=] with |r|.
  1. Return |controller|.[=TransformStreamDefaultController/[[finishPromise]]=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSourcePullAlgorithm"
+ <dfn lt="TransformStreamDefaultSourcePullAlgorithm"
  id="transform-stream-default-source-pull">TransformStreamDefaultSourcePullAlgorithm(|stream|)</dfn>
  performs the following steps:
 
  1. Assert: |stream|.[=TransformStream/[[backpressure]]=] is true.
  1. Assert: |stream|.[=TransformStream/[[backpressureChangePromise]]=] is not undefined.
- 1. Perform ! [$TransformStreamSetBackpressure$](|stream|, false).
+ 1. Perform ! [=TransformStreamSetBackpressure=](|stream|, false).
  1. Return |stream|.[=TransformStream/[[backpressureChangePromise]]=].
 </div>
 
@@ -6576,7 +6576,7 @@ The following algorithms are used by the stream constructors to extract the rele
 a {{QueuingStrategy}} dictionary.
 
 <div algorithm>
- <dfn abstract-op lt="ExtractHighWaterMark"
+ <dfn lt="ExtractHighWaterMark"
  id="validate-and-normalize-high-water-mark">ExtractHighWaterMark(|strategy|, |defaultHWM|)</dfn>
  performs the following steps:
 
@@ -6590,7 +6590,7 @@ a {{QueuingStrategy}} dictionary.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ExtractSizeAlgorithm"
+ <dfn lt="ExtractSizeAlgorithm"
  id="make-size-algorithm-from-size-function">ExtractSizeAlgorithm(|strategy|)</dfn>
  performs the following steps:
 
@@ -6627,7 +6627,7 @@ In what follows, a <dfn>value-with-size</dfn> is a [=struct=] with the two [=str
 for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 
 <div algorithm>
- <dfn abstract-op lt="DequeueValue" id="dequeue-value">DequeueValue(|container|)</dfn> performs the
+ <dfn lt="DequeueValue" id="dequeue-value">DequeueValue(|container|)</dfn> performs the
  following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
@@ -6642,12 +6642,12 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="EnqueueValueWithSize"
+ <dfn lt="EnqueueValueWithSize"
  id="enqueue-value-with-size">EnqueueValueWithSize(|container|, |value|, |size|)</dfn> performs the
  following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
- 1. If ! [$IsNonNegativeNumber$](|size|) is false, throw a {{RangeError}} exception.
+ 1. If ! [=IsNonNegativeNumber=](|size|) is false, throw a {{RangeError}} exception.
  1. If |size| is +∞, throw a {{RangeError}} exception.
  1. [=list/Append=] a new [=value-with-size=] with [=value-with-size/value=] |value| and
     [=value-with-size/size=] |size| to |container|.\[[queue]].
@@ -6655,7 +6655,7 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="PeekQueueValue" id="peek-queue-value">PeekQueueValue(|container|)</dfn>
+ <dfn lt="PeekQueueValue" id="peek-queue-value">PeekQueueValue(|container|)</dfn>
  performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
@@ -6665,7 +6665,7 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ResetQueue" id="reset-queue">ResetQueue(|container|)</dfn>
+ <dfn lt="ResetQueue" id="reset-queue">ResetQueue(|container|)</dfn>
  performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
@@ -6680,17 +6680,17 @@ Transferable streams are implemented using a special kind of identity transform 
 abstract operations are used to implement these "cross-realm transforms".
 
 <div algorithm>
- <dfn abstract-op lt="CrossRealmTransformSendError">CrossRealmTransformSendError(|port|,
+ <dfn lt="CrossRealmTransformSendError">CrossRealmTransformSendError(|port|,
  |error|)</dfn> performs the following steps:
 
- 1. Perform [$PackAndPostMessage$](|port|, "`error`", |error|), discarding the result.
+ 1. Perform [=PackAndPostMessage=](|port|, "`error`", |error|), discarding the result.
 
  <p class="note">As we are already in an errored state when this abstract operation is performed, we
  cannot handle further errors, so we just discard them.</p>
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="PackAndPostMessage">PackAndPostMessage(|port|, |type|, |value|)</dfn> performs
+ <dfn lt="PackAndPostMessage">PackAndPostMessage(|port|, |type|, |value|)</dfn> performs
  the following steps:
 
  1. Let |message| be [$OrdinaryObjectCreate$](null).
@@ -6706,20 +6706,20 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="PackAndPostMessageHandlingError">PackAndPostMessageHandlingError(|port|,
+ <dfn lt="PackAndPostMessageHandlingError">PackAndPostMessageHandlingError(|port|,
  |type|, |value|)</dfn> performs the following steps:
 
- 1. Let |result| be [$PackAndPostMessage$](|port|, |type|, |value|).
+ 1. Let |result| be [=PackAndPostMessage=](|port|, |type|, |value|).
  1. If |result| is an abrupt completion,
-  1. Perform ! [$CrossRealmTransformSendError$](|port|, |result|.\[[Value]]).
+  1. Perform ! [=CrossRealmTransformSendError=](|port|, |result|.\[[Value]]).
  1. Return |result| as a completion record.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpCrossRealmTransformReadable">SetUpCrossRealmTransformReadable(|stream|,
+ <dfn lt="SetUpCrossRealmTransformReadable">SetUpCrossRealmTransformReadable(|stream|,
  |port|)</dfn> performs the following steps:
 
- 1. Perform ! [$InitializeReadableStream$](|stream|).
+ 1. Perform ! [=InitializeReadableStream=](|stream|).
  1. Let |controller| be a [=new=] {{ReadableStreamDefaultController}}.
  1. Add a handler for |port|'s {{MessagePort/message}} event with the following steps:
   1. Let |data| be the data of the message.
@@ -6728,30 +6728,30 @@ abstract operations are used to implement these "cross-realm transforms".
   1. Let |value| be ! [$Get$](|data|, "`value`").
   1. Assert: |type| [=is a String=].
   1. If |type| is "`chunk`",
-   1. Perform ! [$ReadableStreamDefaultControllerEnqueue$](|controller|, |value|).
+   1. Perform ! [=ReadableStreamDefaultControllerEnqueue=](|controller|, |value|).
   1. Otherwise, if |type| is "`close`",
-    1. Perform ! [$ReadableStreamDefaultControllerClose$](|controller|).
+    1. Perform ! [=ReadableStreamDefaultControllerClose=](|controller|).
     1. Disentangle |port|.
   1. Otherwise, if |type| is "`error`",
-   1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |value|).
+   1. Perform ! [=ReadableStreamDefaultControllerError=](|controller|, |value|).
    1. Disentangle |port|.
  1. Add a handler for |port|'s {{MessagePort/messageerror}} event with the following steps:
   1. Let |error| be a new "{{DataCloneError}}" {{DOMException}}.
-  1. Perform ! [$CrossRealmTransformSendError$](|port|, |error|).
-  1. Perform ! [$ReadableStreamDefaultControllerError$](|controller|, |error|).
+  1. Perform ! [=CrossRealmTransformSendError=](|port|, |error|).
+  1. Perform ! [=ReadableStreamDefaultControllerError=](|controller|, |error|).
   1. Disentangle |port|.
  1. Enable |port|'s [=port message queue=].
  1. Let |startAlgorithm| be an algorithm that returns undefined.
  1. Let |pullAlgorithm| be the following steps:
-  1. Perform ! [$PackAndPostMessage$](|port|, "`pull`", undefined).
+  1. Perform ! [=PackAndPostMessage=](|port|, "`pull`", undefined).
   1. Return [=a promise resolved with=] undefined.
  1. Let |cancelAlgorithm| be the following steps, taking a |reason| argument:
-  1. Let |result| be [$PackAndPostMessageHandlingError$](|port|, "`error`", |reason|).
+  1. Let |result| be [=PackAndPostMessageHandlingError=](|port|, "`error`", |reason|).
   1. Disentangle |port|.
   1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |sizeAlgorithm| be an algorithm that returns 1.
- 1. Perform ! [$SetUpReadableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ! [=SetUpReadableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithm|, |cancelAlgorithm|, 0, |sizeAlgorithm|).
 
  <p class="note">Implementations are encouraged to explicitly handle failures from the asserts in
@@ -6760,10 +6760,10 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpCrossRealmTransformWritable">SetUpCrossRealmTransformWritable(|stream|,
+ <dfn lt="SetUpCrossRealmTransformWritable">SetUpCrossRealmTransformWritable(|stream|,
  |port|)</dfn> performs the following steps:
 
- 1. Perform ! [$InitializeWritableStream$](|stream|).
+ 1. Perform ! [=InitializeWritableStream=](|stream|).
  1. Let |controller| be a [=new=] {{WritableStreamDefaultController}}.
  1. Let |backpressurePromise| be [=a new promise=].
  1. Add a handler for |port|'s {{MessagePort/message}} event with the following steps:
@@ -6777,14 +6777,14 @@ abstract operations are used to implement these "cross-realm transforms".
     1. [=Resolve=] |backpressurePromise| with undefined.
     1. Set |backpressurePromise| to undefined.
   1. Otherwise, if |type| is "`error`",
-   1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|, |value|).
+   1. Perform ! [=WritableStreamDefaultControllerErrorIfNeeded=](|controller|, |value|).
    1. If |backpressurePromise| is not undefined,
     1. [=Resolve=] |backpressurePromise| with undefined.
     1. Set |backpressurePromise| to undefined.
  1. Add a handler for |port|'s {{MessagePort/messageerror}} event with the following steps:
   1. Let |error| be a new "{{DataCloneError}}" {{DOMException}}.
-  1. Perform ! [$CrossRealmTransformSendError$](|port|, |error|).
-  1. Perform ! [$WritableStreamDefaultControllerErrorIfNeeded$](|controller|, |error|).
+  1. Perform ! [=CrossRealmTransformSendError=](|port|, |error|).
+  1. Perform ! [=WritableStreamDefaultControllerErrorIfNeeded=](|controller|, |error|).
   1. Disentangle |port|.
  1. Enable |port|'s [=port message queue=].
  1. Let |startAlgorithm| be an algorithm that returns undefined.
@@ -6794,22 +6794,22 @@ abstract operations are used to implement these "cross-realm transforms".
   1. Return the result of [=reacting=] to |backpressurePromise| with the following
      fulfillment steps:
    1. Set |backpressurePromise| to [=a new promise=].
-   1. Let |result| be [$PackAndPostMessageHandlingError$](|port|, "`chunk`", |chunk|).
+   1. Let |result| be [=PackAndPostMessageHandlingError=](|port|, "`chunk`", |chunk|).
    1. If |result| is an abrupt completion,
     1. Disentangle |port|.
     1. Return [=a promise rejected with=] |result|.\[[Value]].
    1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |closeAlgorithm| be the following steps:
-  1. Perform ! [$PackAndPostMessage$](|port|, "`close`", undefined).
+  1. Perform ! [=PackAndPostMessage=](|port|, "`close`", undefined).
   1. Disentangle |port|.
   1. Return [=a promise resolved with=] undefined.
  1. Let |abortAlgorithm| be the following steps, taking a |reason| argument:
-  1. Let |result| be [$PackAndPostMessageHandlingError$](|port|, "`error`", |reason|).
+  1. Let |result| be [=PackAndPostMessageHandlingError=](|port|, "`error`", |reason|).
   1. Disentangle |port|.
   1. If |result| is an abrupt completion, return [=a promise rejected with=] |result|.\[[Value]].
   1. Otherwise, return [=a promise resolved with=] undefined.
  1. Let |sizeAlgorithm| be an algorithm that returns 1.
- 1. Perform ! [$SetUpWritableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ! [=SetUpWritableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|, 1, |sizeAlgorithm|).
 
  <p class="note">Implementations are encouraged to explicitly handle failures from the asserts in
@@ -6822,7 +6822,7 @@ abstract operations are used to implement these "cross-realm transforms".
 The following abstract operations are a grab-bag of utilities.
 
 <div algorithm>
- <dfn abstract-op lt="CanTransferArrayBuffer"
+ <dfn lt="CanTransferArrayBuffer"
  id="can-transfer-array-buffer">CanTransferArrayBuffer(|O|)</dfn> performs the following steps:
 
  1. Assert: |O| [=is an Object=].
@@ -6833,7 +6833,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="IsNonNegativeNumber"
+ <dfn lt="IsNonNegativeNumber"
  id="is-non-negative-number">IsNonNegativeNumber(|v|)</dfn> performs the following steps:
 
  1. If |v| [=is not a Number=], return false.
@@ -6843,7 +6843,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransferArrayBuffer"
+ <dfn lt="TransferArrayBuffer"
  id="transfer-array-buffer">TransferArrayBuffer(|O|)</dfn> performs the following steps:
 
  1. Assert: ! [$IsDetachedBuffer$](|O|) is false.
@@ -6859,26 +6859,26 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CloneAsUint8Array">CloneAsUint8Array(|O|)</dfn> performs the following steps:
+ <dfn lt="CloneAsUint8Array">CloneAsUint8Array(|O|)</dfn> performs the following steps:
 
  1. Assert: |O| [=is an Object=].
  1. Assert: |O| has an \[[ViewedArrayBuffer]] internal slot.
  1. Assert: ! [$IsDetachedBuffer$](|O|.\[[ViewedArrayBuffer]]) is false.
  1. Let |buffer| be ? [$CloneArrayBuffer$](|O|.\[[ViewedArrayBuffer]], |O|.\[[ByteOffset]],
     |O|.\[[ByteLength]], {{%ArrayBuffer%}}).
- 1. Let |array| be ! [$Construct$]({{%Uint8Array%}}, « |buffer| »).
+ 1. Let |array| be ! [=Construct=]({{%Uint8Array%}}, « |buffer| »).
  1. Return |array|.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="StructuredClone">StructuredClone(|v|)</dfn> performs the following steps:
+ <dfn lt="StructuredClone">StructuredClone(|v|)</dfn> performs the following steps:
 
  1. Let |serialized| be ? [$StructuredSerialize$](|v|).
  1. Return ? [$StructuredDeserialize$](|serialized|, [=the current Realm=]).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
+ <dfn lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
  |fromBuffer|, |fromIndex|, |count|)</dfn> performs the following steps:
 
  1. Assert: |toBuffer| [=is an Object=].
@@ -6935,9 +6935,9 @@ to grow organically as needed.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. If |sizeAlgorithm| was not given, then set it to an algorithm that returns 1.
- 1. Perform ! [$InitializeReadableStream$](|stream|).
+ 1. Perform ! [=InitializeReadableStream=](|stream|).
  1. Let |controller| be a [=new=] {{ReadableStreamDefaultController}}.
- 1. Perform ! [$SetUpReadableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ! [=SetUpReadableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithmWrapper|, |cancelAlgorithmWrapper|, |highWaterMark|, |sizeAlgorithm|).
 </div>
 
@@ -6962,9 +6962,9 @@ to grow organically as needed.
      null otherwise. If this throws an exception |e|, return [=a promise rejected with=] |e|.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
- 1. Perform ! [$InitializeReadableStream$](|stream|).
+ 1. Perform ! [=InitializeReadableStream=](|stream|).
  1. Let |controller| be a [=new=] {{ReadableByteStreamController}}.
- 1. Perform ! [$SetUpReadableByteStreamController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ! [=SetUpReadableByteStreamController=](|stream|, |controller|, |startAlgorithm|,
     |pullAlgorithmWrapper|, |cancelAlgorithmWrapper|, |highWaterMark|, undefined).
 </div>
 
@@ -6992,9 +6992,9 @@ e.g., on web-developer-created instances):
  1. If |stream| is not [=ReadableStream/readable=], then return 0.
  1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
     then return !
-    [$ReadableByteStreamControllerGetDesiredSize$](|stream|.[=ReadableStream/[[controller]]=]).
+    [=ReadableByteStreamControllerGetDesiredSize=](|stream|.[=ReadableStream/[[controller]]=]).
  1. Return !
-    [$ReadableStreamDefaultControllerGetDesiredSize$](|stream|.[=ReadableStream/[[controller]]=]).
+    [=ReadableStreamDefaultControllerGetDesiredSize=](|stream|.[=ReadableStream/[[controller]]=]).
 </div>
 
 <p algorithm>A {{ReadableStream}} <dfn export for="ReadableStream" lt="need more data|needs
@@ -7006,11 +7006,11 @@ mark=] is greater than zero.
 
  1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
   1. Perform !
-     [$ReadableByteStreamControllerClose$](|stream|.[=ReadableStream/[[controller]]=]).
+     [=ReadableByteStreamControllerClose=](|stream|.[=ReadableStream/[[controller]]=]).
   1. If |stream|.[=ReadableStream/[[controller]]=].[=ReadableByteStreamController/[[pendingPullIntos]]=]
      is not [=list/is empty|empty=], perform !
-     [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=], 0).
- 1. Otherwise, perform ! [$ReadableStreamDefaultControllerClose$](|stream|.[=ReadableStream/[[controller]]=]).
+     [=ReadableByteStreamControllerRespond=](|stream|.[=ReadableStream/[[controller]]=], 0).
+ 1. Otherwise, perform ! [=ReadableStreamDefaultControllerClose=](|stream|.[=ReadableStream/[[controller]]=]).
 </div>
 
 <div algorithm>
@@ -7018,9 +7018,9 @@ mark=] is greater than zero.
  value |e|:
 
  1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=] {{ReadableByteStreamController}},
-    then perform ! [$ReadableByteStreamControllerError$](|stream|.[=ReadableStream/[[controller]]=],
+    then perform ! [=ReadableByteStreamControllerError=](|stream|.[=ReadableStream/[[controller]]=],
     |e|).
- 1. Otherwise, perform ! [$ReadableStreamDefaultControllerError$](|stream|.[=ReadableStream/[[controller]]=],
+ 1. Otherwise, perform ! [=ReadableStreamDefaultControllerError=](|stream|.[=ReadableStream/[[controller]]=],
     |e|).
 </div>
 
@@ -7030,7 +7030,7 @@ mark=] is greater than zero.
 
  1. If |stream|.[=ReadableStream/[[controller]]=] [=implements=]
     {{ReadableStreamDefaultController}},
-  1. Perform ! [$ReadableStreamDefaultControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=],
+  1. Perform ! [=ReadableStreamDefaultControllerEnqueue=](|stream|.[=ReadableStream/[[controller]]=],
      |chunk|).
  1. Otherwise,
   1. Assert: |stream|.[=ReadableStream/[[controller]]=] [=implements=]
@@ -7044,10 +7044,10 @@ mark=] is greater than zero.
       <p class="note">These asserts ensure that the caller does not write outside the requested
       range in the [=ReadableStream/current BYOB request view=].
    1. Perform ?
-      [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
+      [=ReadableByteStreamControllerRespond=](|stream|.[=ReadableStream/[[controller]]=],
       |chunk|.\[[ByteLength]]).
   1. Otherwise, perform ?
-     [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=], |chunk|).
+     [=ReadableByteStreamControllerEnqueue=](|stream|.[=ReadableStream/[[controller]]=], |chunk|).
 </div>
 
 <hr>
@@ -7063,7 +7063,7 @@ The following algorithms must only be used on {{ReadableStream}} instances initi
  1. Assert: |stream|.[=ReadableStream/[[controller]]=] [=implements=]
     {{ReadableByteStreamController}}.
  1. Let |byobRequest| be !
-    [$ReadableByteStreamControllerGetBYOBRequest$](|stream|.[=ReadableStream/[[controller]]=]).
+    [=ReadableByteStreamControllerGetBYOBRequest=](|stream|.[=ReadableStream/[[controller]]=]).
  1. If |byobRequest| is null, then return null.
  1. Return |byobRequest|.[=ReadableStreamBYOBRequest/[[view]]=].
 </div>
@@ -7106,12 +7106,12 @@ this algorithm might want to use the number of remaining bytes as a [=backpressu
  1. If |stream|'s [=ReadableStream/current BYOB request view=] is non-null, then:
   1. [=ArrayBufferView/Write=] |pulled| into |stream|'s [=ReadableStream/current BYOB request
      view=].
-  1. Perform ? [$ReadableByteStreamControllerRespond$](|stream|.[=ReadableStream/[[controller]]=],
+  1. Perform ? [=ReadableByteStreamControllerRespond=](|stream|.[=ReadableStream/[[controller]]=],
      |pullSize|).
  1. Otherwise,
   1. Set |view| to the result of [=ArrayBufferView/create|creating=] a {{Uint8Array}} from |pulled|
      in |stream|'s [=relevant Realm=].
-  1. Perform ? [$ReadableByteStreamControllerEnqueue$](|stream|.[=ReadableStream/[[controller]]=],
+  1. Perform ? [=ReadableByteStreamControllerEnqueue=](|stream|.[=ReadableStream/[[controller]]=],
      |view|).
 </div>
 
@@ -7127,7 +7127,7 @@ failures should be handled by the calling specification.
 
 <div algorithm>
  <p>To <dfn export for="ReadableStream" lt="get a reader|getting a reader">get a reader</dfn> for a
- {{ReadableStream}} |stream|, return ? [$AcquireReadableStreamDefaultReader$](|stream|). The result
+ {{ReadableStream}} |stream|, return ? [=AcquireReadableStreamDefaultReader=](|stream|). The result
  will be a {{ReadableStreamDefaultReader}}.
 
  <p class="note">This will throw an exception if |stream| is already [=ReadableStream/locked=].
@@ -7135,7 +7135,7 @@ failures should be handled by the calling specification.
 
 <p algorithm>To <dfn export for="ReadableStreamDefaultReader" lt="read a chunk|reading a chunk">read
 a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read request=]
-|readRequest|, perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
+|readRequest|, perform ! [=ReadableStreamDefaultReaderRead=](|reader|, |readRequest|).
 
 <div algorithm="read all bytes">
  <p>To <dfn export for="ReadableStreamDefaultReader" lt="read all bytes|reading all bytes">read all
@@ -7166,7 +7166,7 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
    : [=read request/error steps=], given |e|
    ::
     1. Call |failureSteps| with |e|.
-  1. Perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
+  1. Perform ! [=ReadableStreamDefaultReaderRead=](|reader|, |readRequest|).
  </div>
 
  <p class="note">Because |reader| grants exclusive access to its corresponding {{ReadableStream}},
@@ -7177,22 +7177,22 @@ a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read re
 
 <p algorithm>To <dfn export for="ReadableStreamDefaultReader">release</dfn> a
 {{ReadableStreamDefaultReader}} |reader|, perform !
-[$ReadableStreamDefaultReaderRelease$](|reader|).
+[=ReadableStreamDefaultReaderRelease=](|reader|).
 
 <p algorithm>To <dfn export for="ReadableStreamDefaultReader">cancel</dfn> a
 {{ReadableStreamDefaultReader}} |reader| with |reason|, perform !
-[$ReadableStreamReaderGenericCancel$](|reader|, |reason|). The return value will be a promise
+[=ReadableStreamReaderGenericCancel=](|reader|, |reason|). The return value will be a promise
 that either fulfills with undefined, or rejects with a failure reason.
 
 <p algorithm>To <dfn export for="ReadableStream">cancel</dfn> a {{ReadableStream}} |stream| with
-|reason|, return ! [$ReadableStreamCancel$](|stream|, |reason|). The return value will be a promise
+|reason|, return ! [=ReadableStreamCancel=](|stream|, |reason|). The return value will be a promise
 that either fulfills with undefined, or rejects with a failure reason.
 
 <div algorithm>
  <p>To <dfn export for="ReadableStream" lt="tee|teeing">tee</dfn> a {{ReadableStream}} |stream|,
- return ? [$ReadableStreamTee$](|stream|, true).
+ return ? [=ReadableStreamTee=](|stream|, true).
 
- <p class="note">Because we pass true as the second argument to [$ReadableStreamTee$], the second
+ <p class="note">Because we pass true as the second argument to [=ReadableStreamTee=], the second
  branch returned will have its [=chunks=] cloned (using HTML's [=serializable objects=] framework)
  from those of the first branch. This prevents consumption of one of the branches from interfering
  with the other.
@@ -7216,7 +7216,7 @@ use the algorithms in [[#other-specs-rs-reading]]. (For example, instead of test
 |stream|.[=ReadableStream/[[state]]=] is "`errored`".
 
 <p algorithm="ReadableStream locked">A {{ReadableStream}} |stream| is <dfn export
-for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) returns true.
+for="ReadableStream">locked</dfn> if ! [=IsReadableStreamLocked=](|stream|) returns true.
 
 <div algorithm>
  <p>A {{ReadableStream}} |stream| is <dfn export for="ReadableStream"
@@ -7259,9 +7259,9 @@ for="ReadableStream">locked</dfn> if ! [$IsReadableStreamLocked$](|stream|) retu
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. If |sizeAlgorithm| was not given, then set it to an algorithm that returns 1.
- 1. Perform ! [$InitializeWritableStream$](|stream|).
+ 1. Perform ! [=InitializeWritableStream=](|stream|).
  1. Let |controller| be a [=new=] {{WritableStreamDefaultController}}.
- 1. Perform ! [$SetUpWritableStreamDefaultController$](|stream|, |controller|, |startAlgorithm|,
+ 1. Perform ! [=SetUpWritableStreamDefaultController=](|stream|, |controller|, |startAlgorithm|,
     |writeAlgorithm|, |closeAlgorithmWrapper|, |abortAlgorithmWrapper|, |highWaterMark|,
     |sizeAlgorithm|).
 
@@ -7292,7 +7292,7 @@ above [=WritableStream/set up=] algorithm:
 
 <p algorithm>To <dfn export for="WritableStream" lt="error|erroring">error</dfn> a
 {{WritableStream}} |stream| given a JavaScript value |e|, perform !
-[$WritableStreamDefaultControllerErrorIfNeeded$](|stream|.[=WritableStream/[[controller]]=], |e|).
+[=WritableStreamDefaultControllerErrorIfNeeded=](|stream|.[=WritableStream/[[controller]]=], |e|).
 
 <p>The <dfn export for="WritableStream">signal</dfn> of a {{WritableStream}} |stream| is
 |stream|.[=WritableStream/[[controller]]=].[=WritableStreamDefaultController/[[abortController]]=]'s
@@ -7315,7 +7315,7 @@ failures should be handled by the calling specification.
 
 <div algorithm>
  <p>To <dfn export for="WritableStream" lt="get a writer|getting a writer">get a writer</dfn> for a
- {{WritableStream}} |stream|, return ? [$AcquireWritableStreamDefaultWriter$](|stream|). The result
+ {{WritableStream}} |stream|, return ? [=AcquireWritableStreamDefaultWriter=](|stream|). The result
  will be a {{WritableStreamDefaultWriter}}.
 
  <p class="note">This will throw an exception if |stream| is already locked.
@@ -7323,18 +7323,18 @@ failures should be handled by the calling specification.
 
 <p algorithm>To <dfn export for="WritableStreamDefaultWriter" lt="write a chunk|writing a
 chunk">write a chunk</dfn> to a {{WritableStreamDefaultWriter}} |writer|, given a value |chunk|,
-return ! [$WritableStreamDefaultWriterWrite$](|writer|, |chunk|).
+return ! [=WritableStreamDefaultWriterWrite=](|writer|, |chunk|).
 
 <p algorithm>To <dfn export for="WritableStreamDefaultWriter">release</dfn> a
 {{WritableStreamDefaultWriter}} |writer|, perform !
-[$WritableStreamDefaultWriterRelease$](|writer|).
+[=WritableStreamDefaultWriterRelease=](|writer|).
 
 <p algorithm>To <dfn export for="WritableStream" lt="close|closing">close</dfn> a {{WritableStream}}
-|stream|, return ! [$WritableStreamClose$](|stream|). The return value will be a promise that either
+|stream|, return ! [=WritableStreamClose=](|stream|). The return value will be a promise that either
 fulfills with undefined, or rejects with a failure reason.
 
 <p algorithm>To <dfn export for="WritableStream" lt="abort|aborting">abort</dfn> a
-{{WritableStream}} |stream| with |reason|, return ! [$WritableStreamAbort$](|stream|, |reason|). The
+{{WritableStream}} |stream| with |reason|, return ! [=WritableStreamAbort=](|stream|, |reason|). The
 return value will be a promise that either fulfills with undefined, or rejects with a failure
 reason.
 
@@ -7371,10 +7371,10 @@ reason.
   1. If |result| is a {{Promise}}, then return |result|.
   1. Return [=a promise resolved with=] undefined.
  1. Let |startPromise| be [=a promise resolved with=] undefined.
- 1. Perform ! [$InitializeTransformStream$](|stream|, |startPromise|, |writableHighWaterMark|,
+ 1. Perform ! [=InitializeTransformStream=](|stream|, |startPromise|, |writableHighWaterMark|,
     |writableSizeAlgorithm|, |readableHighWaterMark|, |readableSizeAlgorithm|).
  1. Let |controller| be a [=new=] {{TransformStreamDefaultController}}.
- 1. Perform ! [$SetUpTransformStreamDefaultController$](|stream|, |controller|,
+ 1. Perform ! [=SetUpTransformStreamDefaultController=](|stream|, |controller|,
     |transformAlgorithmWrapper|, |flushAlgorithmWrapper|, |cancelAlgorithmWrapper|).
 
  Other specifications should be careful when constructing their
@@ -7417,15 +7417,15 @@ above [=TransformStream/set up=] algorithm. Usually they are called as part of
 
 <p algorithm>To <dfn export for="TransformStream">enqueue</dfn> the JavaScript value |chunk| into a
 {{TransformStream}} |stream|, perform !
-[$TransformStreamDefaultControllerEnqueue$](|stream|.[=TransformStream/[[controller]]=], |chunk|).
+[=TransformStreamDefaultControllerEnqueue=](|stream|.[=TransformStream/[[controller]]=], |chunk|).
 
 <p algorithm>To <dfn export for="TransformStream">terminate</dfn> a {{TransformStream}} |stream|,
 perform !
-[$TransformStreamDefaultControllerTerminate$](|stream|.[=TransformStream/[[controller]]=]).
+[=TransformStreamDefaultControllerTerminate=](|stream|.[=TransformStream/[[controller]]=]).
 
 <p algorithm>To <dfn export for="TransformStream">error</dfn> a {{TransformStream}} |stream| given a
 JavaScript value |e|, perform !
-[$TransformStreamDefaultControllerError$](|stream|.[=TransformStream/[[controller]]=], |e|).
+[=TransformStreamDefaultControllerError=](|stream|.[=TransformStream/[[controller]]=], |e|).
 
 <h4 id="other-specs-ts-wrapping">Wrapping into a custom class</h4>
 
@@ -7555,10 +7555,10 @@ sense to pass them to {{ReadableStream/pipeThrough()}}.
  They will return a {{Promise}} that fulfills when the pipe completes, or rejects with an exception
  if it fails.
 
- 1. Assert: ! [$IsReadableStreamLocked$](|readable|) is false.
- 1. Assert: ! [$IsWritableStreamLocked$](|writable|) is false.
+ 1. Assert: ! [=IsReadableStreamLocked=](|readable|) is false.
+ 1. Assert: ! [=IsWritableStreamLocked=](|writable|) is false.
  1. Let |signalArg| be |signal| if |signal| was given, or undefined otherwise.
- 1. Return ! [$ReadableStreamPipeTo$](|readable|, |writable|, |preventClose|, |preventAbort|,
+ 1. Return ! [=ReadableStreamPipeTo=](|readable|, |writable|, |preventClose|, |preventAbort|,
     |preventCancel|, |signalArg|).
 
  <p class="note">If one doesn't care about the promise returned, referencing this concept can be a
@@ -7578,10 +7578,10 @@ sense to pass them to {{ReadableStream/pipeThrough()}}.
  through"><var>signal</var></dfn>, is given by performing the following steps. The result will be
  the [=readable side=] of |transform|.
 
- 1. Assert: ! [$IsReadableStreamLocked$](|readable|) is false.
- 1. Assert: ! [$IsWritableStreamLocked$](|transform|.[=TransformStream/[[writable]]=]) is false.
+ 1. Assert: ! [=IsReadableStreamLocked=](|readable|) is false.
+ 1. Assert: ! [=IsWritableStreamLocked=](|transform|.[=TransformStream/[[writable]]=]) is false.
  1. Let |signalArg| be |signal| if |signal| was given, or undefined otherwise.
- 1. Let |promise| be ! [$ReadableStreamPipeTo$](|readable|,
+ 1. Let |promise| be ! [=ReadableStreamPipeTo=](|readable|,
     |transform|.[=TransformStream/[[writable]]=], |preventClose|, |preventAbort|, |preventCancel|,
     |signalArg|).
  1. Set |promise|.\[[PromiseIsHandled]] to true.


### PR DESCRIPTION
Fixes #1365

One alternative way is to add `no-export` to all abstract-ops, but given web specs don't actively use abstract-op, I think we can just remove it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams-1/1368.html" title="Last updated on Apr 21, 2026, 12:03 PM UTC (4d69cb5)">Preview</a> | <a href="https://whatpr.org/streams/1368/7611362...4d69cb5.html" title="Last updated on Apr 21, 2026, 12:03 PM UTC (4d69cb5)">Diff</a>