### PR TITLE
Add `noexport` for abstract operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1633,7 +1633,7 @@ The readable stream implementation will polymorphically call to either these, or
 counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-controllers]].
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[CancelSteps]]" for="ReadableStreamDefaultController"
+ <dfn abstract-op noexport lt="[[CancelSteps]]" for="ReadableStreamDefaultController"
  id="rs-default-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
@@ -1645,7 +1645,7 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[PullSteps]]" for="ReadableStreamDefaultController"
+ <dfn abstract-op noexport lt="[[PullSteps]]" for="ReadableStreamDefaultController"
  id="rs-default-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
@@ -1664,7 +1664,7 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[ReleaseSteps]]" for="ReadableStreamDefaultController"
+ <dfn abstract-op noexport lt="[[ReleaseSteps]]" for="ReadableStreamDefaultController"
  >\[[ReleaseSteps]]()</dfn> implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract.
  It performs the following steps:
 
@@ -1901,7 +1901,7 @@ The readable stream implementation will polymorphically call to either these, or
 counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by-controllers]].
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[CancelSteps]]" for="ReadableByteStreamController"
+ <dfn abstract-op noexport lt="[[CancelSteps]]" for="ReadableByteStreamController"
  id="rbs-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
@@ -1914,7 +1914,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[PullSteps]]" for="ReadableByteStreamController"
+ <dfn abstract-op noexport lt="[[PullSteps]]" for="ReadableByteStreamController"
  id="rbs-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
@@ -1967,7 +1967,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[ReleaseSteps]]" for="ReadableByteStreamController"
+ <dfn abstract-op noexport lt="[[ReleaseSteps]]" for="ReadableByteStreamController"
  >\[[ReleaseSteps]]()</dfn> implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract.
  It performs the following steps:
 
@@ -2093,7 +2093,7 @@ following table:
 The following abstract operations operate on {{ReadableStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op no-export lt="AcquireReadableStreamBYOBReader"
+ <dfn abstract-op noexport lt="AcquireReadableStreamBYOBReader"
  id="acquire-readable-stream-byob-reader">AcquireReadableStreamBYOBReader(|stream|)</dfn> performs
  the following steps:
 
@@ -2103,7 +2103,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="AcquireReadableStreamDefaultReader"
+ <dfn abstract-op noexport lt="AcquireReadableStreamDefaultReader"
  id="acquire-readable-stream-reader">AcquireReadableStreamDefaultReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2113,7 +2113,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="CreateReadableStream"
+ <dfn abstract-op noexport lt="CreateReadableStream"
  id="create-readable-stream">CreateReadableStream(|startAlgorithm|, |pullAlgorithm|,
  |cancelAlgorithm|[, |highWaterMark|, [, |sizeAlgorithm|]])</dfn> performs the following steps:
 
@@ -2132,7 +2132,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
+ <dfn abstract-op noexport lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
  |pullAlgorithm|, |cancelAlgorithm|)</dfn> performs the following steps:
 
  1. Let |stream| be a [=new=] {{ReadableStream}}.
@@ -2147,7 +2147,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="InitializeReadableStream"
+ <dfn abstract-op noexport lt="InitializeReadableStream"
  id="initialize-readable-stream">InitializeReadableStream(|stream|)</dfn> performs the following
  steps:
 
@@ -2158,7 +2158,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="IsReadableStreamLocked"
+ <dfn abstract-op noexport lt="IsReadableStreamLocked"
  id="is-readable-stream-locked">IsReadableStreamLocked(|stream|)</dfn> performs the following steps:
 
  1. If |stream|.[=ReadableStream/[[reader]]=] is undefined, return false.
@@ -2166,7 +2166,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamFromIterable" id="readable-stream-from-iterable">
+ <dfn abstract-op noexport lt="ReadableStreamFromIterable" id="readable-stream-from-iterable">
  ReadableStreamFromIterable(|asyncIterable|)</dfn> performs the following steps:
 
  1. Let |stream| be undefined.
@@ -2209,7 +2209,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm="ReadableStreamPipeTo">
- <dfn abstract-op no-export lt="ReadableStreamPipeTo"
+ <dfn abstract-op noexport lt="ReadableStreamPipeTo"
  id="readable-stream-pipe-to">ReadableStreamPipeTo(|source|, |dest|, |preventClose|, |preventAbort|,
  |preventCancel|[, |signal|])</dfn> performs the following steps:
 
@@ -2338,7 +2338,7 @@ of the locking, none of these objects can be observed by author code. As such, t
 create them does not matter.
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamTee" id="readable-stream-tee"
+ <dfn abstract-op noexport lt="ReadableStreamTee" id="readable-stream-tee"
  >ReadableStreamTee(|stream|, |cloneForBranch2|)</dfn> will [=tee a readable stream|tee=] a given
  readable stream.
 
@@ -2365,7 +2365,7 @@ create them does not matter.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultTee">ReadableStreamDefaultTee(|stream|,
+ <dfn abstract-op noexport lt="ReadableStreamDefaultTee">ReadableStreamDefaultTee(|stream|,
  |cloneForBranch2|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
@@ -2459,7 +2459,7 @@ create them does not matter.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamTee">ReadableByteStreamTee(|stream|)</dfn>
+ <dfn abstract-op noexport lt="ReadableByteStreamTee">ReadableByteStreamTee(|stream|)</dfn>
  performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
@@ -2661,18 +2661,18 @@ Each controller class defines three internal methods, which are called by the {{
 algorithms:
 
 <dl>
-  <dt><dfn abstract-op no-export lt="[[CancelSteps]]"
+  <dt><dfn abstract-op noexport lt="[[CancelSteps]]"
   for="ReadableStreamController">\[[CancelSteps]](<var ignore>reason</var>)</dfn>
   <dd>The controller's steps that run in reaction to the stream being [=cancel a readable
   stream|canceled=], used to clean up the state stored in the controller and inform the
   [=underlying source=].
 
-  <dt><dfn abstract-op no-export lt="[[PullSteps]]" for="ReadableStreamController"
+  <dt><dfn abstract-op noexport lt="[[PullSteps]]" for="ReadableStreamController"
   >\[[PullSteps]](<var ignore>readRequest</var>)</dfn>
   <dd>The controller's steps that run when a [=default reader=] is read from, used to pull from the
   controller any queued [=chunks=], or pull from the [=underlying source=] to get more chunks.
 
-  <dt><dfn abstract-op no-export lt="[[ReleaseSteps]]" for="ReadableStreamController"
+  <dt><dfn abstract-op noexport lt="[[ReleaseSteps]]" for="ReadableStreamController"
   >\[[ReleaseSteps]]()</dfn>
   <dd>The controller's steps that run when a [=readable stream reader|reader=] is
   [=release a read lock|released=], used to clean up reader-specific resources stored in the controller.
@@ -2688,7 +2688,7 @@ translates internal state changes of the controller into developer-facing result
 the {{ReadableStream}}'s public API.
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamAddReadIntoRequest"
+ <dfn abstract-op noexport lt="ReadableStreamAddReadIntoRequest"
  id="readable-stream-add-read-into-request">ReadableStreamAddReadIntoRequest(|stream|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -2699,7 +2699,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamAddReadRequest"
+ <dfn abstract-op noexport lt="ReadableStreamAddReadRequest"
  id="readable-stream-add-read-request">ReadableStreamAddReadRequest(|stream|, |readRequest|)</dfn>
  performs the following steps:
 
@@ -2710,7 +2710,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamCancel"
+ <dfn abstract-op noexport lt="ReadableStreamCancel"
  id="readable-stream-cancel">ReadableStreamCancel(|stream|, |reason|)</dfn> performs the following
  steps:
 
@@ -2733,7 +2733,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamClose"
+ <dfn abstract-op noexport lt="ReadableStreamClose"
  id="readable-stream-close">ReadableStreamClose(|stream|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
@@ -2749,7 +2749,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamError" id="readable-stream-error"
+ <dfn abstract-op noexport lt="ReadableStreamError" id="readable-stream-error"
  >ReadableStreamError(|stream|, |e|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
@@ -2767,7 +2767,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamFulfillReadIntoRequest"
+ <dfn abstract-op noexport lt="ReadableStreamFulfillReadIntoRequest"
  id="readable-stream-fulfill-read-into-request">ReadableStreamFulfillReadIntoRequest(|stream|,
  |chunk|, |done|)</dfn> performs the following steps:
 
@@ -2783,7 +2783,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamFulfillReadRequest"
+ <dfn abstract-op noexport lt="ReadableStreamFulfillReadRequest"
  id="readable-stream-fulfill-read-request">ReadableStreamFulfillReadRequest(|stream|, |chunk|,
  |done|)</dfn> performs the following steps:
 
@@ -2798,7 +2798,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamGetNumReadIntoRequests"
+ <dfn abstract-op noexport lt="ReadableStreamGetNumReadIntoRequests"
  id="readable-stream-get-num-read-into-requests">ReadableStreamGetNumReadIntoRequests(|stream|)</dfn>
  performs the following steps:
 
@@ -2809,7 +2809,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamGetNumReadRequests"
+ <dfn abstract-op noexport lt="ReadableStreamGetNumReadRequests"
  id="readable-stream-get-num-read-requests">ReadableStreamGetNumReadRequests(|stream|)</dfn>
  performs the following steps:
 
@@ -2819,7 +2819,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamHasBYOBReader"
+ <dfn abstract-op noexport lt="ReadableStreamHasBYOBReader"
  id="readable-stream-has-byob-reader">ReadableStreamHasBYOBReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2830,7 +2830,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamHasDefaultReader"
+ <dfn abstract-op noexport lt="ReadableStreamHasDefaultReader"
  id="readable-stream-has-default-reader">ReadableStreamHasDefaultReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2846,7 +2846,7 @@ The following abstract operations support the implementation and manipulation of
 {{ReadableStreamDefaultReader}} and {{ReadableStreamBYOBReader}} instances.
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamReaderGenericCancel"
+ <dfn abstract-op noexport lt="ReadableStreamReaderGenericCancel"
  id="readable-stream-reader-generic-cancel">ReadableStreamReaderGenericCancel(|reader|,
  |reason|)</dfn> performs the following steps:
 
@@ -2856,7 +2856,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamReaderGenericInitialize"
+ <dfn abstract-op noexport lt="ReadableStreamReaderGenericInitialize"
  id="readable-stream-reader-generic-initialize">ReadableStreamReaderGenericInitialize(|reader|,
  |stream|)</dfn> performs the following steps:
 
@@ -2875,7 +2875,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamReaderGenericRelease"
+ <dfn abstract-op noexport lt="ReadableStreamReaderGenericRelease"
  id="readable-stream-reader-generic-release">ReadableStreamReaderGenericRelease(|reader|)</dfn>
  performs the following steps:
 
@@ -2893,7 +2893,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export
+ <dfn abstract-op noexport
  lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
@@ -2904,7 +2904,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamBYOBReaderRead"
+ <dfn abstract-op noexport lt="ReadableStreamBYOBReaderRead"
  id="readable-stream-byob-reader-read">ReadableStreamBYOBReaderRead(|reader|, |view|, |min|,
  |readIntoRequest|)</dfn> performs the following steps:
 
@@ -2918,7 +2918,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamBYOBReaderRelease"
+ <dfn abstract-op noexport lt="ReadableStreamBYOBReaderRelease"
  >ReadableStreamBYOBReaderRelease(|reader|)</dfn>
  performs the following steps:
 
@@ -2928,7 +2928,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export
+ <dfn abstract-op noexport
  lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
@@ -2939,7 +2939,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultReaderRead"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultReaderRead"
  id="readable-stream-default-reader-read">ReadableStreamDefaultReaderRead(|reader|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -2957,7 +2957,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultReaderRelease"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultReaderRelease"
  >ReadableStreamDefaultReaderRelease(|reader|)</dfn>
  performs the following steps:
 
@@ -2967,7 +2967,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpReadableStreamBYOBReader"
+ <dfn abstract-op noexport lt="SetUpReadableStreamBYOBReader"
  id="set-up-readable-stream-byob-reader">SetUpReadableStreamBYOBReader(|reader|, |stream|)</dfn>
  performs the following steps:
 
@@ -2979,7 +2979,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpReadableStreamDefaultReader"
+ <dfn abstract-op noexport lt="SetUpReadableStreamDefaultReader"
  id="set-up-readable-stream-default-reader">SetUpReadableStreamDefaultReader(|reader|,
  |stream|)</dfn> performs the following steps:
 
@@ -2994,7 +2994,7 @@ The following abstract operations support the implementation of the
 {{ReadableStreamDefaultController}} class.
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerCallPullIfNeeded"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerCallPullIfNeeded"
  id="readable-stream-default-controller-call-pull-if-needed">ReadableStreamDefaultControllerCallPullIfNeeded(|controller|)</dfn>
  performs the following steps:
 
@@ -3017,7 +3017,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerShouldCallPull"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerShouldCallPull"
  id="readable-stream-default-controller-should-call-pull">ReadableStreamDefaultControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
@@ -3033,7 +3033,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerClearAlgorithms"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerClearAlgorithms"
  id="readable-stream-default-controller-clear-algorithms">ReadableStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying source=] object to be garbage
@@ -3052,7 +3052,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerClose"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerClose"
  id="readable-stream-default-controller-close">ReadableStreamDefaultControllerClose(|controller|)</dfn>
  performs the following steps:
 
@@ -3065,7 +3065,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerEnqueue"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerEnqueue"
  id="readable-stream-default-controller-enqueue">ReadableStreamDefaultControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -3090,7 +3090,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerError"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerError"
  id="readable-stream-default-controller-error">ReadableStreamDefaultControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
@@ -3102,7 +3102,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerGetDesiredSize"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerGetDesiredSize"
  id="readable-stream-default-controller-get-desired-size">ReadableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -3115,7 +3115,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerHasBackpressure"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerHasBackpressure"
  id="rs-default-controller-has-backpressure">ReadableStreamDefaultControllerHasBackpressure(|controller|)</dfn>
  is used in the implementation of {{TransformStream}}. It performs the following steps:
 
@@ -3124,7 +3124,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableStreamDefaultControllerCanCloseOrEnqueue"
+ <dfn abstract-op noexport lt="ReadableStreamDefaultControllerCanCloseOrEnqueue"
  id="readable-stream-default-controller-can-close-or-enqueue">ReadableStreamDefaultControllerCanCloseOrEnqueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3143,7 +3143,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpReadableStreamDefaultController"
+ <dfn abstract-op noexport lt="SetUpReadableStreamDefaultController"
  id="set-up-readable-stream-default-controller">SetUpReadableStreamDefaultController(|stream|,
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |sizeAlgorithm|)</dfn> performs the following steps:
@@ -3173,7 +3173,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
+ <dfn abstract-op noexport lt="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
  id="set-up-readable-stream-default-controller-from-underlying-source">SetUpReadableStreamDefaultControllerFromUnderlyingSource(|stream|,
  |underlyingSource|, |underlyingSourceDict|, |highWaterMark|, |sizeAlgorithm|)</dfn>
  performs the following steps:
@@ -3201,7 +3201,7 @@ The following abstract operations support the implementation of the
 <h4 id="rbs-controller-abstract-ops">Byte stream controllers</h4>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerCallPullIfNeeded"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerCallPullIfNeeded"
  id="readable-byte-stream-controller-call-pull-if-needed">ReadableByteStreamControllerCallPullIfNeeded(|controller|)</dfn>
  performs the following steps:
 
@@ -3224,7 +3224,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerClearAlgorithms"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerClearAlgorithms"
  id="readable-byte-stream-controller-clear-algorithms">ReadableByteStreamControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying byte source=] object to be garbage
@@ -3242,7 +3242,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerClearPendingPullIntos"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerClearPendingPullIntos"
  id="readable-byte-stream-controller-clear-pending-pull-intos">ReadableByteStreamControllerClearPendingPullIntos(|controller|)</dfn>
  performs the following steps:
 
@@ -3251,7 +3251,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerClose"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerClose"
  id="readable-byte-stream-controller-close">ReadableByteStreamControllerClose(|controller|)</dfn>
  performs the following steps:
 
@@ -3274,7 +3274,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerCommitPullIntoDescriptor"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerCommitPullIntoDescriptor"
  id="readable-byte-stream-controller-commit-pull-into-descriptor">ReadableByteStreamControllerCommitPullIntoDescriptor(|stream|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3295,7 +3295,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerConvertPullIntoDescriptor"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerConvertPullIntoDescriptor"
  id="readable-byte-stream-controller-convert-pull-into-descriptor">ReadableByteStreamControllerConvertPullIntoDescriptor(|pullIntoDescriptor|)</dfn>
  performs the following steps:
 
@@ -3310,7 +3310,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerEnqueue"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerEnqueue"
  id="readable-byte-stream-controller-enqueue">ReadableByteStreamControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -3367,7 +3367,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerEnqueueChunkToQueue"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerEnqueueChunkToQueue"
  id="readable-byte-stream-controller-enqueue-chunk-to-queue">ReadableByteStreamControllerEnqueueChunkToQueue(|controller|,
  |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
 
@@ -3380,7 +3380,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export
+ <dfn abstract-op noexport
  lt="ReadableByteStreamControllerEnqueueClonedChunkToQueue">ReadableByteStreamControllerEnqueueClonedChunkToQueue(|controller|,
  |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
 
@@ -3393,7 +3393,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export
+ <dfn abstract-op noexport
  lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3406,7 +3406,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerError"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerError"
  id="readable-byte-stream-controller-error">ReadableByteStreamControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
@@ -3419,7 +3419,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerFillHeadPullIntoDescriptor"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerFillHeadPullIntoDescriptor"
  id="readable-byte-stream-controller-fill-head-pull-into-descriptor">ReadableByteStreamControllerFillHeadPullIntoDescriptor(|controller|,
  |size|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3432,7 +3432,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerFillPullIntoDescriptorFromQueue"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerFillPullIntoDescriptorFromQueue"
  id="readable-byte-stream-controller-fill-pull-into-descriptor-from-queue">ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(|controller|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3496,7 +3496,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export
+ <dfn abstract-op noexport
  lt="ReadableByteStreamControllerFillReadRequestFromQueue">ReadableByteStreamControllerFillReadRequestFromQueue(|controller|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -3514,7 +3514,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export
+ <dfn abstract-op noexport
  lt="ReadableByteStreamControllerGetBYOBRequest">ReadableByteStreamControllerGetBYOBRequest(|controller|)</dfn> performs
  the following steps:
 
@@ -3533,7 +3533,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerGetDesiredSize"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerGetDesiredSize"
  id="readable-byte-stream-controller-get-desired-size">ReadableByteStreamControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -3545,7 +3545,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerHandleQueueDrain"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerHandleQueueDrain"
  id="readable-byte-stream-controller-handle-queue-drain">ReadableByteStreamControllerHandleQueueDrain(|controller|)</dfn>
  performs the following steps:
 
@@ -3560,7 +3560,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerInvalidateBYOBRequest"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerInvalidateBYOBRequest"
  id="readable-byte-stream-controller-invalidate-byob-request">ReadableByteStreamControllerInvalidateBYOBRequest(|controller|)</dfn>
  performs the following steps:
 
@@ -3575,7 +3575,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue"
  id="readable-byte-stream-controller-process-pull-into-descriptors-using-queue">ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3594,7 +3594,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export
+ <dfn abstract-op noexport
  lt="ReadableByteStreamControllerProcessReadRequestsUsingQueue">ReadableByteStreamControllerProcessReadRequestsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3608,7 +3608,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerPullInto"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerPullInto"
  id="readable-byte-stream-controller-pull-into">ReadableByteStreamControllerPullInto(|controller|,
  |view|, |min|, |readIntoRequest|)</dfn> performs the following steps:
 
@@ -3689,7 +3689,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerRespond"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerRespond"
  id="readable-byte-stream-controller-respond">ReadableByteStreamControllerRespond(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
@@ -3710,7 +3710,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondInClosedState"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerRespondInClosedState"
  id="readable-byte-stream-controller-respond-in-closed-state">ReadableByteStreamControllerRespondInClosedState(|controller|,
  |firstDescriptor|)</dfn> performs the following steps:
 
@@ -3732,7 +3732,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondInReadableState"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerRespondInReadableState"
  id="readable-byte-stream-controller-respond-in-readable-state">ReadableByteStreamControllerRespondInReadableState(|controller|,
  |bytesWritten|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3778,7 +3778,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondInternal"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerRespondInternal"
  id="readable-byte-stream-controller-respond-internal">ReadableByteStreamControllerRespondInternal(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
@@ -3800,7 +3800,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondWithNewView"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerRespondWithNewView"
  id="readable-byte-stream-controller-respond-with-new-view">ReadableByteStreamControllerRespondWithNewView(|controller|,
  |view|)</dfn> performs the following steps:
 
@@ -3828,7 +3828,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerShiftPendingPullInto"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerShiftPendingPullInto"
  id="readable-byte-stream-controller-shift-pending-pull-into">ReadableByteStreamControllerShiftPendingPullInto(|controller|)</dfn>
  performs the following steps:
 
@@ -3840,7 +3840,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ReadableByteStreamControllerShouldCallPull"
+ <dfn abstract-op noexport lt="ReadableByteStreamControllerShouldCallPull"
  id="readable-byte-stream-controller-should-call-pull">ReadableByteStreamControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
@@ -3859,7 +3859,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpReadableByteStreamController"
+ <dfn abstract-op noexport lt="SetUpReadableByteStreamController"
  id="set-up-readable-byte-stream-controller">SetUpReadableByteStreamController(|stream|,
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |autoAllocateChunkSize|)</dfn> performs the following steps:
@@ -3894,7 +3894,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpReadableByteStreamControllerFromUnderlyingSource"
+ <dfn abstract-op noexport lt="SetUpReadableByteStreamControllerFromUnderlyingSource"
  id="set-up-readable-byte-stream-controller-from-underlying-source">SetUpReadableByteStreamControllerFromUnderlyingSource(|stream|,
  |underlyingSource|, |underlyingSourceDict|, |highWaterMark|)</dfn> performs the following steps:
 
@@ -4714,7 +4714,7 @@ implemented such internal methods. A similar scenario is seen for readable strea
 as such the counterpart internal methods are used polymorphically.
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[AbortSteps]]" for="WritableStreamDefaultController"
+ <dfn abstract-op noexport lt="[[AbortSteps]]" for="WritableStreamDefaultController"
  id="ws-default-controller-private-abort"
  oldids="writable-stream-default-controller-abort">\[[AbortSteps]](|reason|)</dfn> implements the
  [$WritableStreamController/[[AbortSteps]]$] contract. It performs the following steps:
@@ -4726,7 +4726,7 @@ as such the counterpart internal methods are used polymorphically.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="[[ErrorSteps]]" for="WritableStreamDefaultController"
+ <dfn abstract-op noexport lt="[[ErrorSteps]]" for="WritableStreamDefaultController"
  id="ws-default-controller-private-error">\[[ErrorSteps]]()</dfn> implements the
  [$WritableStreamController/[[ErrorSteps]]$] contract. It performs the following steps:
 
@@ -4740,7 +4740,7 @@ as such the counterpart internal methods are used polymorphically.
 The following abstract operations operate on {{WritableStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op no-export lt="AcquireWritableStreamDefaultWriter"
+ <dfn abstract-op noexport lt="AcquireWritableStreamDefaultWriter"
  id="acquire-writable-stream-default-writer">AcquireWritableStreamDefaultWriter(|stream|)</dfn>
  performs the following steps:
 
@@ -4750,7 +4750,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="CreateWritableStream"
+ <dfn abstract-op noexport lt="CreateWritableStream"
  id="create-writable-stream">CreateWritableStream(|startAlgorithm|, |writeAlgorithm|,
  |closeAlgorithm|, |abortAlgorithm|, |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following
  steps:
@@ -4768,7 +4768,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="InitializeWritableStream"
+ <dfn abstract-op noexport lt="InitializeWritableStream"
  id="initialize-writable-stream">InitializeWritableStream(|stream|)</dfn> performs the following
  steps:
 
@@ -4784,7 +4784,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="IsWritableStreamLocked"
+ <dfn abstract-op noexport lt="IsWritableStreamLocked"
  id="is-writable-stream-locked">IsWritableStreamLocked(|stream|)</dfn> performs the following steps:
 
  1. If |stream|.[=WritableStream/[[writer]]=] is undefined, return false.
@@ -4792,7 +4792,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpWritableStreamDefaultWriter"
+ <dfn abstract-op noexport lt="SetUpWritableStreamDefaultWriter"
  id="set-up-writable-stream-default-writer">SetUpWritableStreamDefaultWriter(|writer|,
  |stream|)</dfn> performs the following steps:
 
@@ -4829,7 +4829,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamAbort"
+ <dfn abstract-op noexport lt="WritableStreamAbort"
  id="writable-stream-abort">WritableStreamAbort(|stream|, |reason|)</dfn> performs the following
  steps:
 
@@ -4858,7 +4858,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamClose"
+ <dfn abstract-op noexport lt="WritableStreamClose"
  id="writable-stream-close">WritableStreamClose(|stream|)</dfn> performs the following steps:
 
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
@@ -4886,13 +4886,13 @@ Each controller class defines two internal methods, which are called by the {{Wr
 algorithms:
 
 <dl>
-  <dt><dfn abstract-op no-export lt="[[AbortSteps]]"
+  <dt><dfn abstract-op noexport lt="[[AbortSteps]]"
   for="WritableStreamController">\[[AbortSteps]](<var ignore>reason</var>)</dfn>
   <dd>The controller's steps that run in reaction to the stream being [=abort a writable
   stream|aborted=], used to clean up the state stored in the controller and inform the
   [=underlying sink=].
 
-  <dt><dfn abstract-op no-export lt="[[ErrorSteps]]" for="WritableStreamController"
+  <dt><dfn abstract-op noexport lt="[[ErrorSteps]]" for="WritableStreamController"
   >\[[ErrorSteps]]()</dfn>
   <dd>The controller's steps that run in reaction to the stream being errored, used to clean up the
    state stored in the controller.
@@ -4909,7 +4909,7 @@ translates internal state changes of the controllerinto developer-facing results
 the {{WritableStream}}'s public API.
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamAddWriteRequest"
+ <dfn abstract-op noexport lt="WritableStreamAddWriteRequest"
  id="writable-stream-add-write-request">WritableStreamAddWriteRequest(|stream|)</dfn> performs the
  following steps:
 
@@ -4921,7 +4921,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamCloseQueuedOrInFlight"
+ <dfn abstract-op noexport lt="WritableStreamCloseQueuedOrInFlight"
  id="writable-stream-close-queued-or-in-flight">WritableStreamCloseQueuedOrInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -4931,7 +4931,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDealWithRejection"
+ <dfn abstract-op noexport lt="WritableStreamDealWithRejection"
  id="writable-stream-deal-with-rejection">WritableStreamDealWithRejection(|stream|, |error|)</dfn>
  performs the following steps:
 
@@ -4944,7 +4944,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamFinishErroring"
+ <dfn abstract-op noexport lt="WritableStreamFinishErroring"
  id="writable-stream-finish-erroring">WritableStreamFinishErroring(|stream|)</dfn>
  performs the following steps:
 
@@ -4978,7 +4978,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamFinishInFlightClose"
+ <dfn abstract-op noexport lt="WritableStreamFinishInFlightClose"
  id="writable-stream-finish-in-flight-close">WritableStreamFinishInFlightClose(|stream|)</dfn>
  performs the following steps:
 
@@ -5002,7 +5002,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamFinishInFlightCloseWithError"
+ <dfn abstract-op noexport lt="WritableStreamFinishInFlightCloseWithError"
  id="writable-stream-finish-in-flight-close-with-error">WritableStreamFinishInFlightCloseWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
@@ -5018,7 +5018,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamFinishInFlightWrite"
+ <dfn abstract-op noexport lt="WritableStreamFinishInFlightWrite"
  id="writable-stream-finish-in-flight-write">WritableStreamFinishInFlightWrite(|stream|)</dfn>
  performs the following steps:
 
@@ -5028,7 +5028,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamFinishInFlightWriteWithError"
+ <dfn abstract-op noexport lt="WritableStreamFinishInFlightWriteWithError"
  id="writable-stream-finish-in-flight-write-with-error">WritableStreamFinishInFlightWriteWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
@@ -5040,7 +5040,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamHasOperationMarkedInFlight"
+ <dfn abstract-op noexport lt="WritableStreamHasOperationMarkedInFlight"
  id="writable-stream-has-operation-marked-in-flight">WritableStreamHasOperationMarkedInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5050,7 +5050,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamMarkCloseRequestInFlight"
+ <dfn abstract-op noexport lt="WritableStreamMarkCloseRequestInFlight"
  id="writable-stream-mark-close-request-in-flight">WritableStreamMarkCloseRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5062,7 +5062,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamMarkFirstWriteRequestInFlight"
+ <dfn abstract-op noexport lt="WritableStreamMarkFirstWriteRequestInFlight"
  id="writable-stream-mark-first-write-request-in-flight">WritableStreamMarkFirstWriteRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5074,7 +5074,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamRejectCloseAndClosedPromiseIfNeeded"
+ <dfn abstract-op noexport lt="WritableStreamRejectCloseAndClosedPromiseIfNeeded"
  id="writable-stream-reject-close-and-closed-promise-if-needed">WritableStreamRejectCloseAndClosedPromiseIfNeeded(|stream|)</dfn>
  performs the following steps:
 
@@ -5092,7 +5092,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamStartErroring"
+ <dfn abstract-op noexport lt="WritableStreamStartErroring"
  id="writable-stream-start-erroring">WritableStreamStartErroring(|stream|, |reason|)</dfn>
  performs the following steps:
 
@@ -5111,7 +5111,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamUpdateBackpressure"
+ <dfn abstract-op noexport lt="WritableStreamUpdateBackpressure"
  id="writable-stream-update-backpressure">WritableStreamUpdateBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
@@ -5134,7 +5134,7 @@ The following abstract operations support the implementation and manipulation of
 {{WritableStreamDefaultWriter}} instances.
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterAbort"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterAbort"
  id="writable-stream-default-writer-abort">WritableStreamDefaultWriterAbort(|writer|,
  |reason|)</dfn> performs the following steps:
 
@@ -5144,7 +5144,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterClose"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterClose"
  id="writable-stream-default-writer-close">WritableStreamDefaultWriterClose(|writer|)</dfn> performs
  the following steps:
 
@@ -5154,7 +5154,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterCloseWithErrorPropagation"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterCloseWithErrorPropagation"
  id="writable-stream-default-writer-close-with-error-propagation">WritableStreamDefaultWriterCloseWithErrorPropagation(|writer|)</dfn>
  performs the following steps:
 
@@ -5173,7 +5173,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterEnsureClosedPromiseRejected"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterEnsureClosedPromiseRejected"
  id="writable-stream-default-writer-ensure-closed-promise-rejected">WritableStreamDefaultWriterEnsureClosedPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
@@ -5185,7 +5185,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterEnsureReadyPromiseRejected"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterEnsureReadyPromiseRejected"
  id="writable-stream-default-writer-ensure-ready-promise-rejected">WritableStreamDefaultWriterEnsureReadyPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
@@ -5197,7 +5197,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterGetDesiredSize"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterGetDesiredSize"
  id="writable-stream-default-writer-get-desired-size">WritableStreamDefaultWriterGetDesiredSize(|writer|)</dfn>
  performs the following steps:
 
@@ -5210,7 +5210,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterRelease"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterRelease"
  id="writable-stream-default-writer-release">WritableStreamDefaultWriterRelease(|writer|)</dfn>
  performs the following steps:
 
@@ -5225,7 +5225,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultWriterWrite"
+ <dfn abstract-op noexport lt="WritableStreamDefaultWriterWrite"
  id="writable-stream-default-writer-write">WritableStreamDefaultWriterWrite(|writer|, |chunk|)</dfn>
  performs the following steps:
 
@@ -5256,7 +5256,7 @@ The following abstract operations support the implementation of the
 
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpWritableStreamDefaultController"
+ <dfn abstract-op noexport lt="SetUpWritableStreamDefaultController"
  id="set-up-writable-stream-default-controller">SetUpWritableStreamDefaultController(|stream|,
  |controller|, |startAlgorithm|, |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|,
  |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following steps:
@@ -5290,7 +5290,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpWritableStreamDefaultControllerFromUnderlyingSink"
+ <dfn abstract-op noexport lt="SetUpWritableStreamDefaultControllerFromUnderlyingSink"
  id="set-up-writable-stream-default-controller-from-underlying-sink">SetUpWritableStreamDefaultControllerFromUnderlyingSink(|stream|,
  |underlyingSink|, |underlyingSinkDict|, |highWaterMark|, |sizeAlgorithm|)</dfn> performs the
  following steps:
@@ -5321,7 +5321,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
  id="writable-stream-default-controller-advance-queue-if-needed">WritableStreamDefaultControllerAdvanceQueueIfNeeded(|controller|)</dfn>
  performs the following steps:
 
@@ -5342,7 +5342,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerClearAlgorithms"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerClearAlgorithms"
  id="writable-stream-default-controller-clear-algorithms">WritableStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying sink=] object to be garbage
@@ -5365,7 +5365,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerClose"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerClose"
  id="writable-stream-default-controller-close">WritableStreamDefaultControllerClose(|controller|)</dfn>
  performs the following steps:
 
@@ -5374,7 +5374,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerError"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerError"
  id="writable-stream-default-controller-error">WritableStreamDefaultControllerError(|controller|,
  |error|)</dfn> performs the following steps:
 
@@ -5385,7 +5385,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerErrorIfNeeded"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerErrorIfNeeded"
  id="writable-stream-default-controller-error-if-needed">WritableStreamDefaultControllerErrorIfNeeded(|controller|,
  |error|)</dfn> performs the following steps:
 
@@ -5394,7 +5394,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerGetBackpressure"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerGetBackpressure"
  id="writable-stream-default-controller-get-backpressure">WritableStreamDefaultControllerGetBackpressure(|controller|)</dfn>
  performs the following steps:
 
@@ -5403,7 +5403,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerGetChunkSize"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerGetChunkSize"
  id="writable-stream-default-controller-get-chunk-size">WritableStreamDefaultControllerGetChunkSize(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -5422,7 +5422,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerGetDesiredSize"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerGetDesiredSize"
  id="writable-stream-default-controller-get-desired-size">WritableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -5431,7 +5431,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerProcessClose"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerProcessClose"
  id="writable-stream-default-controller-process-close">WritableStreamDefaultControllerProcessClose(|controller|)</dfn>
  performs the following steps:
 
@@ -5449,7 +5449,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerProcessWrite"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerProcessWrite"
  id="writable-stream-default-controller-process-write">WritableStreamDefaultControllerProcessWrite(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -5473,7 +5473,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="WritableStreamDefaultControllerWrite"
+ <dfn abstract-op noexport lt="WritableStreamDefaultControllerWrite"
  id="writable-stream-default-controller-write">WritableStreamDefaultControllerWrite(|controller|,
  |chunk|, |chunkSize|)</dfn> performs the following steps:
 
@@ -5959,7 +5959,7 @@ the following table:
 The following abstract operations operate on {{TransformStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op no-export lt="InitializeTransformStream"
+ <dfn abstract-op noexport lt="InitializeTransformStream"
  id="initialize-transform-stream">InitializeTransformStream(|stream|, |startPromise|,
  |writableHighWaterMark|, |writableSizeAlgorithm|, |readableHighWaterMark|,
  |readableSizeAlgorithm|)</dfn> performs the following steps:
@@ -5992,7 +5992,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamError"
+ <dfn abstract-op noexport lt="TransformStreamError"
  id="transform-stream-error">TransformStreamError(|stream|, |e|)</dfn> performs the following steps:
 
  1. Perform ! [$ReadableStreamDefaultControllerError$](|stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=], |e|).
@@ -6004,7 +6004,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamErrorWritableAndUnblockWrite"
+ <dfn abstract-op noexport lt="TransformStreamErrorWritableAndUnblockWrite"
  id="transform-stream-error-writable-and-unblock-write">TransformStreamErrorWritableAndUnblockWrite(|stream|,
  |e|)</dfn> performs the following steps:
 
@@ -6015,7 +6015,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamSetBackpressure"
+ <dfn abstract-op noexport lt="TransformStreamSetBackpressure"
  id="transform-stream-set-backpressure">TransformStreamSetBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
@@ -6027,7 +6027,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamUnblockWrite"
+ <dfn abstract-op noexport lt="TransformStreamUnblockWrite"
  id="transform-stream-unblock-write">TransformStreamUnblockWrite(|stream|)</dfn> performs the
  following steps:
 
@@ -6045,7 +6045,7 @@ The following abstract operations support the implementaiton of the
 {{TransformStreamDefaultController}} class.
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpTransformStreamDefaultController"
+ <dfn abstract-op noexport lt="SetUpTransformStreamDefaultController"
  id="set-up-transform-stream-default-controller">SetUpTransformStreamDefaultController(|stream|,
  |controller|, |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|)</dfn> performs the
  following steps:
@@ -6061,7 +6061,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpTransformStreamDefaultControllerFromTransformer"
+ <dfn abstract-op noexport lt="SetUpTransformStreamDefaultControllerFromTransformer"
  id="set-up-transform-stream-default-controller-from-transformer">SetUpTransformStreamDefaultControllerFromTransformer(|stream|,
  |transformer|, |transformerDict|)</dfn> performs the following steps:
 
@@ -6088,7 +6088,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultControllerClearAlgorithms"
+ <dfn abstract-op noexport lt="TransformStreamDefaultControllerClearAlgorithms"
  id="transform-stream-default-controller-clear-algorithms">TransformStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more.
  By removing the algorithm references it permits the [=transformer=] object to be garbage collected
@@ -6107,7 +6107,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultControllerEnqueue"
+ <dfn abstract-op noexport lt="TransformStreamDefaultControllerEnqueue"
  id="transform-stream-default-controller-enqueue">TransformStreamDefaultControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6129,7 +6129,7 @@ The following abstract operations support the implementaiton of the
    1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
 </div>
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultControllerError"
+ <dfn abstract-op noexport lt="TransformStreamDefaultControllerError"
  id="transform-stream-default-controller-error">TransformStreamDefaultControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
@@ -6138,7 +6138,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultControllerPerformTransform"
+ <dfn abstract-op noexport lt="TransformStreamDefaultControllerPerformTransform"
  id="transform-stream-default-controller-perform-transform">TransformStreamDefaultControllerPerformTransform(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6152,7 +6152,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultControllerTerminate"
+ <dfn abstract-op noexport lt="TransformStreamDefaultControllerTerminate"
  id="transform-stream-default-controller-terminate">TransformStreamDefaultControllerTerminate(|controller|)</dfn>
  performs the following steps:
 
@@ -6170,7 +6170,7 @@ The following abstract operations are used to implement the [=underlying sink=] 
 side=] of [=transform streams=].
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultSinkWriteAlgorithm"
+ <dfn abstract-op noexport lt="TransformStreamDefaultSinkWriteAlgorithm"
  id="transform-stream-default-sink-write-algorithm">TransformStreamDefaultSinkWriteAlgorithm(|stream|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6190,7 +6190,7 @@ side=] of [=transform streams=].
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultSinkAbortAlgorithm"
+ <dfn abstract-op noexport lt="TransformStreamDefaultSinkAbortAlgorithm"
  id="transform-stream-default-sink-abort-algorithm">TransformStreamDefaultSinkAbortAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
@@ -6217,7 +6217,7 @@ side=] of [=transform streams=].
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultSinkCloseAlgorithm"
+ <dfn abstract-op noexport lt="TransformStreamDefaultSinkCloseAlgorithm"
  id="transform-stream-default-sink-close-algorithm">TransformStreamDefaultSinkCloseAlgorithm(|stream|)</dfn>
  performs the following steps:
 
@@ -6249,7 +6249,7 @@ The following abstract operation is used to implement the [=underlying source=] 
 side=] of [=transform streams=].
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultSourceCancelAlgorithm"
+ <dfn abstract-op noexport lt="TransformStreamDefaultSourceCancelAlgorithm"
  id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
@@ -6278,7 +6278,7 @@ side=] of [=transform streams=].
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransformStreamDefaultSourcePullAlgorithm"
+ <dfn abstract-op noexport lt="TransformStreamDefaultSourcePullAlgorithm"
  id="transform-stream-default-source-pull">TransformStreamDefaultSourcePullAlgorithm(|stream|)</dfn>
  performs the following steps:
 
@@ -6581,7 +6581,7 @@ The following algorithms are used by the stream constructors to extract the rele
 a {{QueuingStrategy}} dictionary.
 
 <div algorithm>
- <dfn abstract-op no-export lt="ExtractHighWaterMark"
+ <dfn abstract-op noexport lt="ExtractHighWaterMark"
  id="validate-and-normalize-high-water-mark">ExtractHighWaterMark(|strategy|, |defaultHWM|)</dfn>
  performs the following steps:
 
@@ -6595,7 +6595,7 @@ a {{QueuingStrategy}} dictionary.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ExtractSizeAlgorithm"
+ <dfn abstract-op noexport lt="ExtractSizeAlgorithm"
  id="make-size-algorithm-from-size-function">ExtractSizeAlgorithm(|strategy|)</dfn>
  performs the following steps:
 
@@ -6632,7 +6632,7 @@ In what follows, a <dfn>value-with-size</dfn> is a [=struct=] with the two [=str
 for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 
 <div algorithm>
- <dfn abstract-op no-export lt="DequeueValue" id="dequeue-value">DequeueValue(|container|)</dfn>
+ <dfn abstract-op noexport lt="DequeueValue" id="dequeue-value">DequeueValue(|container|)</dfn>
  performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
@@ -6647,7 +6647,7 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="EnqueueValueWithSize"
+ <dfn abstract-op noexport lt="EnqueueValueWithSize"
  id="enqueue-value-with-size">EnqueueValueWithSize(|container|, |value|, |size|)</dfn> performs the
  following steps:
 
@@ -6660,7 +6660,7 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="PeekQueueValue" id="peek-queue-value"
+ <dfn abstract-op noexport lt="PeekQueueValue" id="peek-queue-value"
  >PeekQueueValue(|container|)</dfn> performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
@@ -6670,7 +6670,7 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="ResetQueue" id="reset-queue">ResetQueue(|container|)</dfn>
+ <dfn abstract-op noexport lt="ResetQueue" id="reset-queue">ResetQueue(|container|)</dfn>
  performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
@@ -6685,7 +6685,7 @@ Transferable streams are implemented using a special kind of identity transform 
 abstract operations are used to implement these "cross-realm transforms".
 
 <div algorithm>
- <dfn abstract-op no-export lt="CrossRealmTransformSendError">CrossRealmTransformSendError(|port|,
+ <dfn abstract-op noexport lt="CrossRealmTransformSendError">CrossRealmTransformSendError(|port|,
  |error|)</dfn> performs the following steps:
 
  1. Perform [$PackAndPostMessage$](|port|, "`error`", |error|), discarding the result.
@@ -6695,7 +6695,7 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="PackAndPostMessage"
+ <dfn abstract-op noexport lt="PackAndPostMessage"
  >PackAndPostMessage(|port|, |type|, |value|)</dfn> performs the following steps:
 
  1. Let |message| be [$OrdinaryObjectCreate$](null).
@@ -6711,7 +6711,7 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="PackAndPostMessageHandlingError"
+ <dfn abstract-op noexport lt="PackAndPostMessageHandlingError"
  >PackAndPostMessageHandlingError(|port|, |type|, |value|)</dfn> performs the following steps:
 
  1. Let |result| be [$PackAndPostMessage$](|port|, |type|, |value|).
@@ -6721,7 +6721,7 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpCrossRealmTransformReadable"
+ <dfn abstract-op noexport lt="SetUpCrossRealmTransformReadable"
  >SetUpCrossRealmTransformReadable(|stream|, |port|)</dfn> performs the following steps:
 
  1. Perform ! [$InitializeReadableStream$](|stream|).
@@ -6765,7 +6765,7 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="SetUpCrossRealmTransformWritable">
+ <dfn abstract-op noexport lt="SetUpCrossRealmTransformWritable">
  SetUpCrossRealmTransformWritable(|stream|, |port|)</dfn> performs the following steps:
 
  1. Perform ! [$InitializeWritableStream$](|stream|).
@@ -6827,7 +6827,7 @@ abstract operations are used to implement these "cross-realm transforms".
 The following abstract operations are a grab-bag of utilities.
 
 <div algorithm>
- <dfn abstract-op no-export lt="CanTransferArrayBuffer"
+ <dfn abstract-op noexport lt="CanTransferArrayBuffer"
  id="can-transfer-array-buffer">CanTransferArrayBuffer(|O|)</dfn> performs the following steps:
 
  1. Assert: |O| [=is an Object=].
@@ -6838,7 +6838,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="IsNonNegativeNumber"
+ <dfn abstract-op noexport lt="IsNonNegativeNumber"
  id="is-non-negative-number">IsNonNegativeNumber(|v|)</dfn> performs the following steps:
 
  1. If |v| [=is not a Number=], return false.
@@ -6848,7 +6848,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="TransferArrayBuffer"
+ <dfn abstract-op noexport lt="TransferArrayBuffer"
  id="transfer-array-buffer">TransferArrayBuffer(|O|)</dfn> performs the following steps:
 
  1. Assert: ! [$IsDetachedBuffer$](|O|) is false.
@@ -6864,7 +6864,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="CloneAsUint8Array">CloneAsUint8Array(|O|)</dfn> performs the
+ <dfn abstract-op noexport lt="CloneAsUint8Array">CloneAsUint8Array(|O|)</dfn> performs the
  following steps:
 
  1. Assert: |O| [=is an Object=].
@@ -6877,7 +6877,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="StructuredClone">StructuredClone(|v|)</dfn> performs the following
+ <dfn abstract-op noexport lt="StructuredClone">StructuredClone(|v|)</dfn> performs the following
  steps:
 
  1. Let |serialized| be ? [$StructuredSerialize$](|v|).
@@ -6885,7 +6885,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op no-export lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
+ <dfn abstract-op noexport lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
  |fromBuffer|, |fromIndex|, |count|)</dfn> performs the following steps:
 
  1. Assert: |toBuffer| [=is an Object=].

--- a/index.bs
+++ b/index.bs
@@ -1633,7 +1633,7 @@ The readable stream implementation will polymorphically call to either these, or
 counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-controllers]].
 
 <div algorithm>
- <dfn abstract-op lt="[[CancelSteps]]" for="ReadableStreamDefaultController"
+ <dfn abstract-op no-export lt="[[CancelSteps]]" for="ReadableStreamDefaultController"
  id="rs-default-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
@@ -1645,7 +1645,7 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="[[PullSteps]]" for="ReadableStreamDefaultController"
+ <dfn abstract-op no-export lt="[[PullSteps]]" for="ReadableStreamDefaultController"
  id="rs-default-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
@@ -1664,9 +1664,9 @@ counterparts for BYOB controllers, as discussed in [[#rs-abstract-ops-used-by-co
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="[[ReleaseSteps]]" for="ReadableStreamDefaultController">\[[ReleaseSteps]]()</dfn>
- implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract. It performs the following
- steps:
+ <dfn abstract-op no-export lt="[[ReleaseSteps]]" for="ReadableStreamDefaultController"
+ >\[[ReleaseSteps]]()</dfn> implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract.
+ It performs the following steps:
 
  1. Return.
 </div>
@@ -1901,7 +1901,7 @@ The readable stream implementation will polymorphically call to either these, or
 counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by-controllers]].
 
 <div algorithm>
- <dfn abstract-op lt="[[CancelSteps]]" for="ReadableByteStreamController"
+ <dfn abstract-op no-export lt="[[CancelSteps]]" for="ReadableByteStreamController"
  id="rbs-controller-private-cancel">\[[CancelSteps]](|reason|)</dfn> implements the
  [$ReadableStreamController/[[CancelSteps]]$] contract. It performs the following steps:
 
@@ -1914,7 +1914,7 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="[[PullSteps]]" for="ReadableByteStreamController"
+ <dfn abstract-op no-export lt="[[PullSteps]]" for="ReadableByteStreamController"
  id="rbs-controller-private-pull">\[[PullSteps]](|readRequest|)</dfn> implements the
  [$ReadableStreamController/[[PullSteps]]$] contract. It performs the following steps:
 
@@ -1967,9 +1967,9 @@ counterparts for default controllers, as discussed in [[#rs-abstract-ops-used-by
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="[[ReleaseSteps]]" for="ReadableByteStreamController">\[[ReleaseSteps]]()</dfn>
- implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract. It performs the following
- steps:
+ <dfn abstract-op no-export lt="[[ReleaseSteps]]" for="ReadableByteStreamController"
+ >\[[ReleaseSteps]]()</dfn> implements the [$ReadableStreamController/[[ReleaseSteps]]$] contract.
+ It performs the following steps:
 
  1. If [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=] is not [=list/is empty|empty=],
   1. Let |firstPendingPullInto| be [=this=].[=ReadableByteStreamController/[[pendingPullIntos]]=][0].
@@ -2093,7 +2093,7 @@ following table:
 The following abstract operations operate on {{ReadableStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op lt="AcquireReadableStreamBYOBReader"
+ <dfn abstract-op no-export lt="AcquireReadableStreamBYOBReader"
  id="acquire-readable-stream-byob-reader">AcquireReadableStreamBYOBReader(|stream|)</dfn> performs
  the following steps:
 
@@ -2103,7 +2103,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="AcquireReadableStreamDefaultReader"
+ <dfn abstract-op no-export lt="AcquireReadableStreamDefaultReader"
  id="acquire-readable-stream-reader">AcquireReadableStreamDefaultReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2113,7 +2113,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateReadableStream"
+ <dfn abstract-op no-export lt="CreateReadableStream"
  id="create-readable-stream">CreateReadableStream(|startAlgorithm|, |pullAlgorithm|,
  |cancelAlgorithm|[, |highWaterMark|, [, |sizeAlgorithm|]])</dfn> performs the following steps:
 
@@ -2132,7 +2132,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
+ <dfn abstract-op no-export lt="CreateReadableByteStream">CreateReadableByteStream(|startAlgorithm|,
  |pullAlgorithm|, |cancelAlgorithm|)</dfn> performs the following steps:
 
  1. Let |stream| be a [=new=] {{ReadableStream}}.
@@ -2147,7 +2147,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="InitializeReadableStream"
+ <dfn abstract-op no-export lt="InitializeReadableStream"
  id="initialize-readable-stream">InitializeReadableStream(|stream|)</dfn> performs the following
  steps:
 
@@ -2158,7 +2158,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="IsReadableStreamLocked"
+ <dfn abstract-op no-export lt="IsReadableStreamLocked"
  id="is-readable-stream-locked">IsReadableStreamLocked(|stream|)</dfn> performs the following steps:
 
  1. If |stream|.[=ReadableStream/[[reader]]=] is undefined, return false.
@@ -2166,7 +2166,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamFromIterable" id="readable-stream-from-iterable">
+ <dfn abstract-op no-export lt="ReadableStreamFromIterable" id="readable-stream-from-iterable">
  ReadableStreamFromIterable(|asyncIterable|)</dfn> performs the following steps:
 
  1. Let |stream| be undefined.
@@ -2209,7 +2209,7 @@ The following abstract operations operate on {{ReadableStream}} instances at a h
 </div>
 
 <div algorithm="ReadableStreamPipeTo">
- <dfn abstract-op lt="ReadableStreamPipeTo"
+ <dfn abstract-op no-export lt="ReadableStreamPipeTo"
  id="readable-stream-pipe-to">ReadableStreamPipeTo(|source|, |dest|, |preventClose|, |preventAbort|,
  |preventCancel|[, |signal|])</dfn> performs the following steps:
 
@@ -2338,8 +2338,9 @@ of the locking, none of these objects can be observed by author code. As such, t
 create them does not matter.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamTee" id="readable-stream-tee">ReadableStreamTee(|stream|,
- |cloneForBranch2|)</dfn> will [=tee a readable stream|tee=] a given readable stream.
+ <dfn abstract-op no-export lt="ReadableStreamTee" id="readable-stream-tee"
+ >ReadableStreamTee(|stream|, |cloneForBranch2|)</dfn> will [=tee a readable stream|tee=] a given
+ readable stream.
 
  The second argument, |cloneForBranch2|, governs whether or not the data from the original stream
  will be cloned (using HTML's [=serializable objects=] framework) before appearing in the second of
@@ -2364,7 +2365,7 @@ create them does not matter.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultTee">ReadableStreamDefaultTee(|stream|,
+ <dfn abstract-op no-export lt="ReadableStreamDefaultTee">ReadableStreamDefaultTee(|stream|,
  |cloneForBranch2|)</dfn> performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
@@ -2458,7 +2459,7 @@ create them does not matter.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamTee">ReadableByteStreamTee(|stream|)</dfn>
+ <dfn abstract-op no-export lt="ReadableByteStreamTee">ReadableByteStreamTee(|stream|)</dfn>
  performs the following steps:
 
  1. Assert: |stream| [=implements=] {{ReadableStream}}.
@@ -2660,18 +2661,19 @@ Each controller class defines three internal methods, which are called by the {{
 algorithms:
 
 <dl>
-  <dt><dfn abstract-op lt="[[CancelSteps]]"
+  <dt><dfn abstract-op no-export lt="[[CancelSteps]]"
   for="ReadableStreamController">\[[CancelSteps]](<var ignore>reason</var>)</dfn>
   <dd>The controller's steps that run in reaction to the stream being [=cancel a readable
   stream|canceled=], used to clean up the state stored in the controller and inform the
   [=underlying source=].
 
-  <dt><dfn abstract-op lt="[[PullSteps]]" for="ReadableStreamController">\[[PullSteps]](<var
-  ignore>readRequest</var>)</dfn>
+  <dt><dfn abstract-op no-export lt="[[PullSteps]]" for="ReadableStreamController"
+  >\[[PullSteps]](<var ignore>readRequest</var>)</dfn>
   <dd>The controller's steps that run when a [=default reader=] is read from, used to pull from the
   controller any queued [=chunks=], or pull from the [=underlying source=] to get more chunks.
 
-  <dt><dfn abstract-op lt="[[ReleaseSteps]]" for="ReadableStreamController">\[[ReleaseSteps]]()</dfn>
+  <dt><dfn abstract-op no-export lt="[[ReleaseSteps]]" for="ReadableStreamController"
+  >\[[ReleaseSteps]]()</dfn>
   <dd>The controller's steps that run when a [=readable stream reader|reader=] is
   [=release a read lock|released=], used to clean up reader-specific resources stored in the controller.
 </dl>
@@ -2686,7 +2688,7 @@ translates internal state changes of the controller into developer-facing result
 the {{ReadableStream}}'s public API.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamAddReadIntoRequest"
+ <dfn abstract-op no-export lt="ReadableStreamAddReadIntoRequest"
  id="readable-stream-add-read-into-request">ReadableStreamAddReadIntoRequest(|stream|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -2697,7 +2699,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamAddReadRequest"
+ <dfn abstract-op no-export lt="ReadableStreamAddReadRequest"
  id="readable-stream-add-read-request">ReadableStreamAddReadRequest(|stream|, |readRequest|)</dfn>
  performs the following steps:
 
@@ -2708,7 +2710,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamCancel"
+ <dfn abstract-op no-export lt="ReadableStreamCancel"
  id="readable-stream-cancel">ReadableStreamCancel(|stream|, |reason|)</dfn> performs the following
  steps:
 
@@ -2731,7 +2733,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamClose"
+ <dfn abstract-op no-export lt="ReadableStreamClose"
  id="readable-stream-close">ReadableStreamClose(|stream|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
@@ -2747,8 +2749,8 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamError" id="readable-stream-error">ReadableStreamError(|stream|,
- |e|)</dfn> performs the following steps:
+ <dfn abstract-op no-export lt="ReadableStreamError" id="readable-stream-error"
+ >ReadableStreamError(|stream|, |e|)</dfn> performs the following steps:
 
  1. Assert: |stream|.[=ReadableStream/[[state]]=] is "`readable`".
  1. Set |stream|.[=ReadableStream/[[state]]=] to "`errored`".
@@ -2765,7 +2767,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamFulfillReadIntoRequest"
+ <dfn abstract-op no-export lt="ReadableStreamFulfillReadIntoRequest"
  id="readable-stream-fulfill-read-into-request">ReadableStreamFulfillReadIntoRequest(|stream|,
  |chunk|, |done|)</dfn> performs the following steps:
 
@@ -2781,7 +2783,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamFulfillReadRequest"
+ <dfn abstract-op no-export lt="ReadableStreamFulfillReadRequest"
  id="readable-stream-fulfill-read-request">ReadableStreamFulfillReadRequest(|stream|, |chunk|,
  |done|)</dfn> performs the following steps:
 
@@ -2796,7 +2798,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamGetNumReadIntoRequests"
+ <dfn abstract-op no-export lt="ReadableStreamGetNumReadIntoRequests"
  id="readable-stream-get-num-read-into-requests">ReadableStreamGetNumReadIntoRequests(|stream|)</dfn>
  performs the following steps:
 
@@ -2807,7 +2809,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamGetNumReadRequests"
+ <dfn abstract-op no-export lt="ReadableStreamGetNumReadRequests"
  id="readable-stream-get-num-read-requests">ReadableStreamGetNumReadRequests(|stream|)</dfn>
  performs the following steps:
 
@@ -2817,7 +2819,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamHasBYOBReader"
+ <dfn abstract-op no-export lt="ReadableStreamHasBYOBReader"
  id="readable-stream-has-byob-reader">ReadableStreamHasBYOBReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2828,7 +2830,7 @@ the {{ReadableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamHasDefaultReader"
+ <dfn abstract-op no-export lt="ReadableStreamHasDefaultReader"
  id="readable-stream-has-default-reader">ReadableStreamHasDefaultReader(|stream|)</dfn> performs the
  following steps:
 
@@ -2844,7 +2846,7 @@ The following abstract operations support the implementation and manipulation of
 {{ReadableStreamDefaultReader}} and {{ReadableStreamBYOBReader}} instances.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamReaderGenericCancel"
+ <dfn abstract-op no-export lt="ReadableStreamReaderGenericCancel"
  id="readable-stream-reader-generic-cancel">ReadableStreamReaderGenericCancel(|reader|,
  |reason|)</dfn> performs the following steps:
 
@@ -2854,7 +2856,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamReaderGenericInitialize"
+ <dfn abstract-op no-export lt="ReadableStreamReaderGenericInitialize"
  id="readable-stream-reader-generic-initialize">ReadableStreamReaderGenericInitialize(|reader|,
  |stream|)</dfn> performs the following steps:
 
@@ -2873,7 +2875,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamReaderGenericRelease"
+ <dfn abstract-op no-export lt="ReadableStreamReaderGenericRelease"
  id="readable-stream-reader-generic-release">ReadableStreamReaderGenericRelease(|reader|)</dfn>
  performs the following steps:
 
@@ -2891,7 +2893,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn abstract-op no-export
  lt="ReadableStreamBYOBReaderErrorReadIntoRequests">ReadableStreamBYOBReaderErrorReadIntoRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
@@ -2902,7 +2904,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamBYOBReaderRead"
+ <dfn abstract-op no-export lt="ReadableStreamBYOBReaderRead"
  id="readable-stream-byob-reader-read">ReadableStreamBYOBReaderRead(|reader|, |view|, |min|,
  |readIntoRequest|)</dfn> performs the following steps:
 
@@ -2916,7 +2918,8 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamBYOBReaderRelease">ReadableStreamBYOBReaderRelease(|reader|)</dfn>
+ <dfn abstract-op no-export lt="ReadableStreamBYOBReaderRelease"
+ >ReadableStreamBYOBReaderRelease(|reader|)</dfn>
  performs the following steps:
 
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
@@ -2925,7 +2928,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn abstract-op no-export
  lt="ReadableStreamDefaultReaderErrorReadRequests">ReadableStreamDefaultReaderErrorReadRequests(|reader|, |e|)</dfn>
  performs the following steps:
 
@@ -2936,7 +2939,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultReaderRead"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultReaderRead"
  id="readable-stream-default-reader-read">ReadableStreamDefaultReaderRead(|reader|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -2954,7 +2957,8 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultReaderRelease">ReadableStreamDefaultReaderRelease(|reader|)</dfn>
+ <dfn abstract-op no-export lt="ReadableStreamDefaultReaderRelease"
+ >ReadableStreamDefaultReaderRelease(|reader|)</dfn>
  performs the following steps:
 
  1. Perform ! [$ReadableStreamReaderGenericRelease$](|reader|).
@@ -2963,7 +2967,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamBYOBReader"
+ <dfn abstract-op no-export lt="SetUpReadableStreamBYOBReader"
  id="set-up-readable-stream-byob-reader">SetUpReadableStreamBYOBReader(|reader|, |stream|)</dfn>
  performs the following steps:
 
@@ -2975,7 +2979,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamDefaultReader"
+ <dfn abstract-op no-export lt="SetUpReadableStreamDefaultReader"
  id="set-up-readable-stream-default-reader">SetUpReadableStreamDefaultReader(|reader|,
  |stream|)</dfn> performs the following steps:
 
@@ -2990,7 +2994,7 @@ The following abstract operations support the implementation of the
 {{ReadableStreamDefaultController}} class.
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerCallPullIfNeeded"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerCallPullIfNeeded"
  id="readable-stream-default-controller-call-pull-if-needed">ReadableStreamDefaultControllerCallPullIfNeeded(|controller|)</dfn>
  performs the following steps:
 
@@ -3013,7 +3017,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerShouldCallPull"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerShouldCallPull"
  id="readable-stream-default-controller-should-call-pull">ReadableStreamDefaultControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
@@ -3029,7 +3033,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerClearAlgorithms"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerClearAlgorithms"
  id="readable-stream-default-controller-clear-algorithms">ReadableStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying source=] object to be garbage
@@ -3048,7 +3052,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerClose"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerClose"
  id="readable-stream-default-controller-close">ReadableStreamDefaultControllerClose(|controller|)</dfn>
  performs the following steps:
 
@@ -3061,7 +3065,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerEnqueue"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerEnqueue"
  id="readable-stream-default-controller-enqueue">ReadableStreamDefaultControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -3086,7 +3090,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerError"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerError"
  id="readable-stream-default-controller-error">ReadableStreamDefaultControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
@@ -3098,7 +3102,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerGetDesiredSize"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerGetDesiredSize"
  id="readable-stream-default-controller-get-desired-size">ReadableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -3111,7 +3115,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerHasBackpressure"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerHasBackpressure"
  id="rs-default-controller-has-backpressure">ReadableStreamDefaultControllerHasBackpressure(|controller|)</dfn>
  is used in the implementation of {{TransformStream}}. It performs the following steps:
 
@@ -3120,7 +3124,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableStreamDefaultControllerCanCloseOrEnqueue"
+ <dfn abstract-op no-export lt="ReadableStreamDefaultControllerCanCloseOrEnqueue"
  id="readable-stream-default-controller-can-close-or-enqueue">ReadableStreamDefaultControllerCanCloseOrEnqueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3139,7 +3143,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamDefaultController"
+ <dfn abstract-op no-export lt="SetUpReadableStreamDefaultController"
  id="set-up-readable-stream-default-controller">SetUpReadableStreamDefaultController(|stream|,
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |sizeAlgorithm|)</dfn> performs the following steps:
@@ -3169,7 +3173,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
+ <dfn abstract-op no-export lt="SetUpReadableStreamDefaultControllerFromUnderlyingSource"
  id="set-up-readable-stream-default-controller-from-underlying-source">SetUpReadableStreamDefaultControllerFromUnderlyingSource(|stream|,
  |underlyingSource|, |underlyingSourceDict|, |highWaterMark|, |sizeAlgorithm|)</dfn>
  performs the following steps:
@@ -3197,7 +3201,7 @@ The following abstract operations support the implementation of the
 <h4 id="rbs-controller-abstract-ops">Byte stream controllers</h4>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerCallPullIfNeeded"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerCallPullIfNeeded"
  id="readable-byte-stream-controller-call-pull-if-needed">ReadableByteStreamControllerCallPullIfNeeded(|controller|)</dfn>
  performs the following steps:
 
@@ -3220,7 +3224,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerClearAlgorithms"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerClearAlgorithms"
  id="readable-byte-stream-controller-clear-algorithms">ReadableByteStreamControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying byte source=] object to be garbage
@@ -3238,7 +3242,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerClearPendingPullIntos"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerClearPendingPullIntos"
  id="readable-byte-stream-controller-clear-pending-pull-intos">ReadableByteStreamControllerClearPendingPullIntos(|controller|)</dfn>
  performs the following steps:
 
@@ -3247,7 +3251,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerClose"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerClose"
  id="readable-byte-stream-controller-close">ReadableByteStreamControllerClose(|controller|)</dfn>
  performs the following steps:
 
@@ -3270,7 +3274,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerCommitPullIntoDescriptor"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerCommitPullIntoDescriptor"
  id="readable-byte-stream-controller-commit-pull-into-descriptor">ReadableByteStreamControllerCommitPullIntoDescriptor(|stream|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3291,7 +3295,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerConvertPullIntoDescriptor"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerConvertPullIntoDescriptor"
  id="readable-byte-stream-controller-convert-pull-into-descriptor">ReadableByteStreamControllerConvertPullIntoDescriptor(|pullIntoDescriptor|)</dfn>
  performs the following steps:
 
@@ -3306,7 +3310,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerEnqueue"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerEnqueue"
  id="readable-byte-stream-controller-enqueue">ReadableByteStreamControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -3363,7 +3367,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerEnqueueChunkToQueue"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerEnqueueChunkToQueue"
  id="readable-byte-stream-controller-enqueue-chunk-to-queue">ReadableByteStreamControllerEnqueueChunkToQueue(|controller|,
  |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
 
@@ -3376,7 +3380,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn abstract-op no-export
  lt="ReadableByteStreamControllerEnqueueClonedChunkToQueue">ReadableByteStreamControllerEnqueueClonedChunkToQueue(|controller|,
  |buffer|, |byteOffset|, |byteLength|)</dfn> performs the following steps:
 
@@ -3389,7 +3393,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn abstract-op no-export
  lt="ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue">ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(|controller|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3402,7 +3406,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerError"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerError"
  id="readable-byte-stream-controller-error">ReadableByteStreamControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
@@ -3415,7 +3419,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerFillHeadPullIntoDescriptor"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerFillHeadPullIntoDescriptor"
  id="readable-byte-stream-controller-fill-head-pull-into-descriptor">ReadableByteStreamControllerFillHeadPullIntoDescriptor(|controller|,
  |size|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3428,7 +3432,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerFillPullIntoDescriptorFromQueue"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerFillPullIntoDescriptorFromQueue"
  id="readable-byte-stream-controller-fill-pull-into-descriptor-from-queue">ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(|controller|,
  |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3492,7 +3496,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn abstract-op no-export
  lt="ReadableByteStreamControllerFillReadRequestFromQueue">ReadableByteStreamControllerFillReadRequestFromQueue(|controller|,
  |readRequest|)</dfn> performs the following steps:
 
@@ -3510,7 +3514,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn abstract-op no-export
  lt="ReadableByteStreamControllerGetBYOBRequest">ReadableByteStreamControllerGetBYOBRequest(|controller|)</dfn> performs
  the following steps:
 
@@ -3529,7 +3533,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerGetDesiredSize"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerGetDesiredSize"
  id="readable-byte-stream-controller-get-desired-size">ReadableByteStreamControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -3541,7 +3545,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerHandleQueueDrain"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerHandleQueueDrain"
  id="readable-byte-stream-controller-handle-queue-drain">ReadableByteStreamControllerHandleQueueDrain(|controller|)</dfn>
  performs the following steps:
 
@@ -3556,7 +3560,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerInvalidateBYOBRequest"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerInvalidateBYOBRequest"
  id="readable-byte-stream-controller-invalidate-byob-request">ReadableByteStreamControllerInvalidateBYOBRequest(|controller|)</dfn>
  performs the following steps:
 
@@ -3571,7 +3575,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue"
  id="readable-byte-stream-controller-process-pull-into-descriptors-using-queue">ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3590,7 +3594,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op
+ <dfn abstract-op no-export
  lt="ReadableByteStreamControllerProcessReadRequestsUsingQueue">ReadableByteStreamControllerProcessReadRequestsUsingQueue(|controller|)</dfn>
  performs the following steps:
 
@@ -3604,7 +3608,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerPullInto"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerPullInto"
  id="readable-byte-stream-controller-pull-into">ReadableByteStreamControllerPullInto(|controller|,
  |view|, |min|, |readIntoRequest|)</dfn> performs the following steps:
 
@@ -3685,7 +3689,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespond"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerRespond"
  id="readable-byte-stream-controller-respond">ReadableByteStreamControllerRespond(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
@@ -3706,7 +3710,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondInClosedState"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondInClosedState"
  id="readable-byte-stream-controller-respond-in-closed-state">ReadableByteStreamControllerRespondInClosedState(|controller|,
  |firstDescriptor|)</dfn> performs the following steps:
 
@@ -3728,7 +3732,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondInReadableState"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondInReadableState"
  id="readable-byte-stream-controller-respond-in-readable-state">ReadableByteStreamControllerRespondInReadableState(|controller|,
  |bytesWritten|, |pullIntoDescriptor|)</dfn> performs the following steps:
 
@@ -3774,7 +3778,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondInternal"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondInternal"
  id="readable-byte-stream-controller-respond-internal">ReadableByteStreamControllerRespondInternal(|controller|,
  |bytesWritten|)</dfn> performs the following steps:
 
@@ -3796,7 +3800,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerRespondWithNewView"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerRespondWithNewView"
  id="readable-byte-stream-controller-respond-with-new-view">ReadableByteStreamControllerRespondWithNewView(|controller|,
  |view|)</dfn> performs the following steps:
 
@@ -3824,7 +3828,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerShiftPendingPullInto"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerShiftPendingPullInto"
  id="readable-byte-stream-controller-shift-pending-pull-into">ReadableByteStreamControllerShiftPendingPullInto(|controller|)</dfn>
  performs the following steps:
 
@@ -3836,7 +3840,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ReadableByteStreamControllerShouldCallPull"
+ <dfn abstract-op no-export lt="ReadableByteStreamControllerShouldCallPull"
  id="readable-byte-stream-controller-should-call-pull">ReadableByteStreamControllerShouldCallPull(|controller|)</dfn>
  performs the following steps:
 
@@ -3855,7 +3859,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableByteStreamController"
+ <dfn abstract-op no-export lt="SetUpReadableByteStreamController"
  id="set-up-readable-byte-stream-controller">SetUpReadableByteStreamController(|stream|,
  |controller|, |startAlgorithm|, |pullAlgorithm|, |cancelAlgorithm|, |highWaterMark|,
  |autoAllocateChunkSize|)</dfn> performs the following steps:
@@ -3890,7 +3894,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpReadableByteStreamControllerFromUnderlyingSource"
+ <dfn abstract-op no-export lt="SetUpReadableByteStreamControllerFromUnderlyingSource"
  id="set-up-readable-byte-stream-controller-from-underlying-source">SetUpReadableByteStreamControllerFromUnderlyingSource(|stream|,
  |underlyingSource|, |underlyingSourceDict|, |highWaterMark|)</dfn> performs the following steps:
 
@@ -4710,7 +4714,7 @@ implemented such internal methods. A similar scenario is seen for readable strea
 as such the counterpart internal methods are used polymorphically.
 
 <div algorithm>
- <dfn abstract-op lt="[[AbortSteps]]" for="WritableStreamDefaultController"
+ <dfn abstract-op no-export lt="[[AbortSteps]]" for="WritableStreamDefaultController"
  id="ws-default-controller-private-abort"
  oldids="writable-stream-default-controller-abort">\[[AbortSteps]](|reason|)</dfn> implements the
  [$WritableStreamController/[[AbortSteps]]$] contract. It performs the following steps:
@@ -4722,7 +4726,7 @@ as such the counterpart internal methods are used polymorphically.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="[[ErrorSteps]]" for="WritableStreamDefaultController"
+ <dfn abstract-op no-export lt="[[ErrorSteps]]" for="WritableStreamDefaultController"
  id="ws-default-controller-private-error">\[[ErrorSteps]]()</dfn> implements the
  [$WritableStreamController/[[ErrorSteps]]$] contract. It performs the following steps:
 
@@ -4736,7 +4740,7 @@ as such the counterpart internal methods are used polymorphically.
 The following abstract operations operate on {{WritableStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op lt="AcquireWritableStreamDefaultWriter"
+ <dfn abstract-op no-export lt="AcquireWritableStreamDefaultWriter"
  id="acquire-writable-stream-default-writer">AcquireWritableStreamDefaultWriter(|stream|)</dfn>
  performs the following steps:
 
@@ -4746,7 +4750,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CreateWritableStream"
+ <dfn abstract-op no-export lt="CreateWritableStream"
  id="create-writable-stream">CreateWritableStream(|startAlgorithm|, |writeAlgorithm|,
  |closeAlgorithm|, |abortAlgorithm|, |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following
  steps:
@@ -4764,7 +4768,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="InitializeWritableStream"
+ <dfn abstract-op no-export lt="InitializeWritableStream"
  id="initialize-writable-stream">InitializeWritableStream(|stream|)</dfn> performs the following
  steps:
 
@@ -4780,7 +4784,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="IsWritableStreamLocked"
+ <dfn abstract-op no-export lt="IsWritableStreamLocked"
  id="is-writable-stream-locked">IsWritableStreamLocked(|stream|)</dfn> performs the following steps:
 
  1. If |stream|.[=WritableStream/[[writer]]=] is undefined, return false.
@@ -4788,7 +4792,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpWritableStreamDefaultWriter"
+ <dfn abstract-op no-export lt="SetUpWritableStreamDefaultWriter"
  id="set-up-writable-stream-default-writer">SetUpWritableStreamDefaultWriter(|writer|,
  |stream|)</dfn> performs the following steps:
 
@@ -4825,7 +4829,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamAbort"
+ <dfn abstract-op no-export lt="WritableStreamAbort"
  id="writable-stream-abort">WritableStreamAbort(|stream|, |reason|)</dfn> performs the following
  steps:
 
@@ -4854,7 +4858,7 @@ The following abstract operations operate on {{WritableStream}} instances at a h
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamClose"
+ <dfn abstract-op no-export lt="WritableStreamClose"
  id="writable-stream-close">WritableStreamClose(|stream|)</dfn> performs the following steps:
 
  1. Let |state| be |stream|.[=WritableStream/[[state]]=].
@@ -4882,13 +4886,14 @@ Each controller class defines two internal methods, which are called by the {{Wr
 algorithms:
 
 <dl>
-  <dt><dfn abstract-op lt="[[AbortSteps]]"
+  <dt><dfn abstract-op no-export lt="[[AbortSteps]]"
   for="WritableStreamController">\[[AbortSteps]](<var ignore>reason</var>)</dfn>
   <dd>The controller's steps that run in reaction to the stream being [=abort a writable
   stream|aborted=], used to clean up the state stored in the controller and inform the
   [=underlying sink=].
 
-  <dt><dfn abstract-op lt="[[ErrorSteps]]" for="WritableStreamController">\[[ErrorSteps]]()</dfn>
+  <dt><dfn abstract-op no-export lt="[[ErrorSteps]]" for="WritableStreamController"
+  >\[[ErrorSteps]]()</dfn>
   <dd>The controller's steps that run in reaction to the stream being errored, used to clean up the
    state stored in the controller.
 </dl>
@@ -4904,7 +4909,7 @@ translates internal state changes of the controllerinto developer-facing results
 the {{WritableStream}}'s public API.
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamAddWriteRequest"
+ <dfn abstract-op no-export lt="WritableStreamAddWriteRequest"
  id="writable-stream-add-write-request">WritableStreamAddWriteRequest(|stream|)</dfn> performs the
  following steps:
 
@@ -4916,7 +4921,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamCloseQueuedOrInFlight"
+ <dfn abstract-op no-export lt="WritableStreamCloseQueuedOrInFlight"
  id="writable-stream-close-queued-or-in-flight">WritableStreamCloseQueuedOrInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -4926,7 +4931,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDealWithRejection"
+ <dfn abstract-op no-export lt="WritableStreamDealWithRejection"
  id="writable-stream-deal-with-rejection">WritableStreamDealWithRejection(|stream|, |error|)</dfn>
  performs the following steps:
 
@@ -4939,7 +4944,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishErroring"
+ <dfn abstract-op no-export lt="WritableStreamFinishErroring"
  id="writable-stream-finish-erroring">WritableStreamFinishErroring(|stream|)</dfn>
  performs the following steps:
 
@@ -4973,7 +4978,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightClose"
+ <dfn abstract-op no-export lt="WritableStreamFinishInFlightClose"
  id="writable-stream-finish-in-flight-close">WritableStreamFinishInFlightClose(|stream|)</dfn>
  performs the following steps:
 
@@ -4997,7 +5002,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightCloseWithError"
+ <dfn abstract-op no-export lt="WritableStreamFinishInFlightCloseWithError"
  id="writable-stream-finish-in-flight-close-with-error">WritableStreamFinishInFlightCloseWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
@@ -5013,7 +5018,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightWrite"
+ <dfn abstract-op no-export lt="WritableStreamFinishInFlightWrite"
  id="writable-stream-finish-in-flight-write">WritableStreamFinishInFlightWrite(|stream|)</dfn>
  performs the following steps:
 
@@ -5023,7 +5028,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamFinishInFlightWriteWithError"
+ <dfn abstract-op no-export lt="WritableStreamFinishInFlightWriteWithError"
  id="writable-stream-finish-in-flight-write-with-error">WritableStreamFinishInFlightWriteWithError(|stream|,
  |error|)</dfn> performs the following steps:
 
@@ -5035,7 +5040,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamHasOperationMarkedInFlight"
+ <dfn abstract-op no-export lt="WritableStreamHasOperationMarkedInFlight"
  id="writable-stream-has-operation-marked-in-flight">WritableStreamHasOperationMarkedInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5045,7 +5050,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamMarkCloseRequestInFlight"
+ <dfn abstract-op no-export lt="WritableStreamMarkCloseRequestInFlight"
  id="writable-stream-mark-close-request-in-flight">WritableStreamMarkCloseRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5057,7 +5062,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamMarkFirstWriteRequestInFlight"
+ <dfn abstract-op no-export lt="WritableStreamMarkFirstWriteRequestInFlight"
  id="writable-stream-mark-first-write-request-in-flight">WritableStreamMarkFirstWriteRequestInFlight(|stream|)</dfn>
  performs the following steps:
 
@@ -5069,7 +5074,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamRejectCloseAndClosedPromiseIfNeeded"
+ <dfn abstract-op no-export lt="WritableStreamRejectCloseAndClosedPromiseIfNeeded"
  id="writable-stream-reject-close-and-closed-promise-if-needed">WritableStreamRejectCloseAndClosedPromiseIfNeeded(|stream|)</dfn>
  performs the following steps:
 
@@ -5087,7 +5092,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamStartErroring"
+ <dfn abstract-op no-export lt="WritableStreamStartErroring"
  id="writable-stream-start-erroring">WritableStreamStartErroring(|stream|, |reason|)</dfn>
  performs the following steps:
 
@@ -5106,7 +5111,7 @@ the {{WritableStream}}'s public API.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamUpdateBackpressure"
+ <dfn abstract-op no-export lt="WritableStreamUpdateBackpressure"
  id="writable-stream-update-backpressure">WritableStreamUpdateBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
@@ -5129,7 +5134,7 @@ The following abstract operations support the implementation and manipulation of
 {{WritableStreamDefaultWriter}} instances.
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterAbort"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterAbort"
  id="writable-stream-default-writer-abort">WritableStreamDefaultWriterAbort(|writer|,
  |reason|)</dfn> performs the following steps:
 
@@ -5139,7 +5144,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterClose"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterClose"
  id="writable-stream-default-writer-close">WritableStreamDefaultWriterClose(|writer|)</dfn> performs
  the following steps:
 
@@ -5149,7 +5154,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterCloseWithErrorPropagation"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterCloseWithErrorPropagation"
  id="writable-stream-default-writer-close-with-error-propagation">WritableStreamDefaultWriterCloseWithErrorPropagation(|writer|)</dfn>
  performs the following steps:
 
@@ -5168,7 +5173,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterEnsureClosedPromiseRejected"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterEnsureClosedPromiseRejected"
  id="writable-stream-default-writer-ensure-closed-promise-rejected">WritableStreamDefaultWriterEnsureClosedPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
@@ -5180,7 +5185,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterEnsureReadyPromiseRejected"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterEnsureReadyPromiseRejected"
  id="writable-stream-default-writer-ensure-ready-promise-rejected">WritableStreamDefaultWriterEnsureReadyPromiseRejected(|writer|,
  |error|)</dfn> performs the following steps:
 
@@ -5192,7 +5197,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterGetDesiredSize"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterGetDesiredSize"
  id="writable-stream-default-writer-get-desired-size">WritableStreamDefaultWriterGetDesiredSize(|writer|)</dfn>
  performs the following steps:
 
@@ -5205,7 +5210,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterRelease"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterRelease"
  id="writable-stream-default-writer-release">WritableStreamDefaultWriterRelease(|writer|)</dfn>
  performs the following steps:
 
@@ -5220,7 +5225,7 @@ The following abstract operations support the implementation and manipulation of
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultWriterWrite"
+ <dfn abstract-op no-export lt="WritableStreamDefaultWriterWrite"
  id="writable-stream-default-writer-write">WritableStreamDefaultWriterWrite(|writer|, |chunk|)</dfn>
  performs the following steps:
 
@@ -5251,7 +5256,7 @@ The following abstract operations support the implementation of the
 
 
 <div algorithm>
- <dfn abstract-op lt="SetUpWritableStreamDefaultController"
+ <dfn abstract-op no-export lt="SetUpWritableStreamDefaultController"
  id="set-up-writable-stream-default-controller">SetUpWritableStreamDefaultController(|stream|,
  |controller|, |startAlgorithm|, |writeAlgorithm|, |closeAlgorithm|, |abortAlgorithm|,
  |highWaterMark|, |sizeAlgorithm|)</dfn> performs the following steps:
@@ -5285,7 +5290,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpWritableStreamDefaultControllerFromUnderlyingSink"
+ <dfn abstract-op no-export lt="SetUpWritableStreamDefaultControllerFromUnderlyingSink"
  id="set-up-writable-stream-default-controller-from-underlying-sink">SetUpWritableStreamDefaultControllerFromUnderlyingSink(|stream|,
  |underlyingSink|, |underlyingSinkDict|, |highWaterMark|, |sizeAlgorithm|)</dfn> performs the
  following steps:
@@ -5316,7 +5321,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerAdvanceQueueIfNeeded"
  id="writable-stream-default-controller-advance-queue-if-needed">WritableStreamDefaultControllerAdvanceQueueIfNeeded(|controller|)</dfn>
  performs the following steps:
 
@@ -5337,7 +5342,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerClearAlgorithms"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerClearAlgorithms"
  id="writable-stream-default-controller-clear-algorithms">WritableStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more. By
  removing the algorithm references it permits the [=underlying sink=] object to be garbage
@@ -5360,7 +5365,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerClose"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerClose"
  id="writable-stream-default-controller-close">WritableStreamDefaultControllerClose(|controller|)</dfn>
  performs the following steps:
 
@@ -5369,7 +5374,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerError"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerError"
  id="writable-stream-default-controller-error">WritableStreamDefaultControllerError(|controller|,
  |error|)</dfn> performs the following steps:
 
@@ -5380,7 +5385,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerErrorIfNeeded"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerErrorIfNeeded"
  id="writable-stream-default-controller-error-if-needed">WritableStreamDefaultControllerErrorIfNeeded(|controller|,
  |error|)</dfn> performs the following steps:
 
@@ -5389,7 +5394,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerGetBackpressure"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerGetBackpressure"
  id="writable-stream-default-controller-get-backpressure">WritableStreamDefaultControllerGetBackpressure(|controller|)</dfn>
  performs the following steps:
 
@@ -5398,7 +5403,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerGetChunkSize"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerGetChunkSize"
  id="writable-stream-default-controller-get-chunk-size">WritableStreamDefaultControllerGetChunkSize(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -5417,7 +5422,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerGetDesiredSize"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerGetDesiredSize"
  id="writable-stream-default-controller-get-desired-size">WritableStreamDefaultControllerGetDesiredSize(|controller|)</dfn>
  performs the following steps:
 
@@ -5426,7 +5431,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerProcessClose"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerProcessClose"
  id="writable-stream-default-controller-process-close">WritableStreamDefaultControllerProcessClose(|controller|)</dfn>
  performs the following steps:
 
@@ -5444,7 +5449,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerProcessWrite"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerProcessWrite"
  id="writable-stream-default-controller-process-write">WritableStreamDefaultControllerProcessWrite(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -5468,7 +5473,7 @@ The following abstract operations support the implementation of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="WritableStreamDefaultControllerWrite"
+ <dfn abstract-op no-export lt="WritableStreamDefaultControllerWrite"
  id="writable-stream-default-controller-write">WritableStreamDefaultControllerWrite(|controller|,
  |chunk|, |chunkSize|)</dfn> performs the following steps:
 
@@ -5954,7 +5959,7 @@ the following table:
 The following abstract operations operate on {{TransformStream}} instances at a higher level.
 
 <div algorithm>
- <dfn abstract-op lt="InitializeTransformStream"
+ <dfn abstract-op no-export lt="InitializeTransformStream"
  id="initialize-transform-stream">InitializeTransformStream(|stream|, |startPromise|,
  |writableHighWaterMark|, |writableSizeAlgorithm|, |readableHighWaterMark|,
  |readableSizeAlgorithm|)</dfn> performs the following steps:
@@ -5987,7 +5992,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamError"
+ <dfn abstract-op no-export lt="TransformStreamError"
  id="transform-stream-error">TransformStreamError(|stream|, |e|)</dfn> performs the following steps:
 
  1. Perform ! [$ReadableStreamDefaultControllerError$](|stream|.[=TransformStream/[[readable]]=].[=ReadableStream/[[controller]]=], |e|).
@@ -5999,7 +6004,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamErrorWritableAndUnblockWrite"
+ <dfn abstract-op no-export lt="TransformStreamErrorWritableAndUnblockWrite"
  id="transform-stream-error-writable-and-unblock-write">TransformStreamErrorWritableAndUnblockWrite(|stream|,
  |e|)</dfn> performs the following steps:
 
@@ -6010,7 +6015,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamSetBackpressure"
+ <dfn abstract-op no-export lt="TransformStreamSetBackpressure"
  id="transform-stream-set-backpressure">TransformStreamSetBackpressure(|stream|,
  |backpressure|)</dfn> performs the following steps:
 
@@ -6022,7 +6027,7 @@ The following abstract operations operate on {{TransformStream}} instances at a 
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamUnblockWrite"
+ <dfn abstract-op no-export lt="TransformStreamUnblockWrite"
  id="transform-stream-unblock-write">TransformStreamUnblockWrite(|stream|)</dfn> performs the
  following steps:
 
@@ -6040,7 +6045,7 @@ The following abstract operations support the implementaiton of the
 {{TransformStreamDefaultController}} class.
 
 <div algorithm>
- <dfn abstract-op lt="SetUpTransformStreamDefaultController"
+ <dfn abstract-op no-export lt="SetUpTransformStreamDefaultController"
  id="set-up-transform-stream-default-controller">SetUpTransformStreamDefaultController(|stream|,
  |controller|, |transformAlgorithm|, |flushAlgorithm|, |cancelAlgorithm|)</dfn> performs the
  following steps:
@@ -6056,7 +6061,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpTransformStreamDefaultControllerFromTransformer"
+ <dfn abstract-op no-export lt="SetUpTransformStreamDefaultControllerFromTransformer"
  id="set-up-transform-stream-default-controller-from-transformer">SetUpTransformStreamDefaultControllerFromTransformer(|stream|,
  |transformer|, |transformerDict|)</dfn> performs the following steps:
 
@@ -6083,7 +6088,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerClearAlgorithms"
+ <dfn abstract-op no-export lt="TransformStreamDefaultControllerClearAlgorithms"
  id="transform-stream-default-controller-clear-algorithms">TransformStreamDefaultControllerClearAlgorithms(|controller|)</dfn>
  is called once the stream is closed or errored and the algorithms will not be executed any more.
  By removing the algorithm references it permits the [=transformer=] object to be garbage collected
@@ -6102,7 +6107,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerEnqueue"
+ <dfn abstract-op no-export lt="TransformStreamDefaultControllerEnqueue"
  id="transform-stream-default-controller-enqueue">TransformStreamDefaultControllerEnqueue(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6124,7 +6129,7 @@ The following abstract operations support the implementaiton of the
    1. Perform ! [$TransformStreamSetBackpressure$](|stream|, true).
 </div>
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerError"
+ <dfn abstract-op no-export lt="TransformStreamDefaultControllerError"
  id="transform-stream-default-controller-error">TransformStreamDefaultControllerError(|controller|,
  |e|)</dfn> performs the following steps:
 
@@ -6133,7 +6138,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerPerformTransform"
+ <dfn abstract-op no-export lt="TransformStreamDefaultControllerPerformTransform"
  id="transform-stream-default-controller-perform-transform">TransformStreamDefaultControllerPerformTransform(|controller|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6147,7 +6152,7 @@ The following abstract operations support the implementaiton of the
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultControllerTerminate"
+ <dfn abstract-op no-export lt="TransformStreamDefaultControllerTerminate"
  id="transform-stream-default-controller-terminate">TransformStreamDefaultControllerTerminate(|controller|)</dfn>
  performs the following steps:
 
@@ -6165,7 +6170,7 @@ The following abstract operations are used to implement the [=underlying sink=] 
 side=] of [=transform streams=].
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSinkWriteAlgorithm"
+ <dfn abstract-op no-export lt="TransformStreamDefaultSinkWriteAlgorithm"
  id="transform-stream-default-sink-write-algorithm">TransformStreamDefaultSinkWriteAlgorithm(|stream|,
  |chunk|)</dfn> performs the following steps:
 
@@ -6185,7 +6190,7 @@ side=] of [=transform streams=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSinkAbortAlgorithm"
+ <dfn abstract-op no-export lt="TransformStreamDefaultSinkAbortAlgorithm"
  id="transform-stream-default-sink-abort-algorithm">TransformStreamDefaultSinkAbortAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
@@ -6212,7 +6217,7 @@ side=] of [=transform streams=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSinkCloseAlgorithm"
+ <dfn abstract-op no-export lt="TransformStreamDefaultSinkCloseAlgorithm"
  id="transform-stream-default-sink-close-algorithm">TransformStreamDefaultSinkCloseAlgorithm(|stream|)</dfn>
  performs the following steps:
 
@@ -6244,7 +6249,7 @@ The following abstract operation is used to implement the [=underlying source=] 
 side=] of [=transform streams=].
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSourceCancelAlgorithm"
+ <dfn abstract-op no-export lt="TransformStreamDefaultSourceCancelAlgorithm"
  id="transform-stream-default-source-cancel">TransformStreamDefaultSourceCancelAlgorithm(|stream|,
  |reason|)</dfn> performs the following steps:
 
@@ -6273,7 +6278,7 @@ side=] of [=transform streams=].
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransformStreamDefaultSourcePullAlgorithm"
+ <dfn abstract-op no-export lt="TransformStreamDefaultSourcePullAlgorithm"
  id="transform-stream-default-source-pull">TransformStreamDefaultSourcePullAlgorithm(|stream|)</dfn>
  performs the following steps:
 
@@ -6576,7 +6581,7 @@ The following algorithms are used by the stream constructors to extract the rele
 a {{QueuingStrategy}} dictionary.
 
 <div algorithm>
- <dfn abstract-op lt="ExtractHighWaterMark"
+ <dfn abstract-op no-export lt="ExtractHighWaterMark"
  id="validate-and-normalize-high-water-mark">ExtractHighWaterMark(|strategy|, |defaultHWM|)</dfn>
  performs the following steps:
 
@@ -6590,7 +6595,7 @@ a {{QueuingStrategy}} dictionary.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ExtractSizeAlgorithm"
+ <dfn abstract-op no-export lt="ExtractSizeAlgorithm"
  id="make-size-algorithm-from-size-function">ExtractSizeAlgorithm(|strategy|)</dfn>
  performs the following steps:
 
@@ -6627,8 +6632,8 @@ In what follows, a <dfn>value-with-size</dfn> is a [=struct=] with the two [=str
 for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 
 <div algorithm>
- <dfn abstract-op lt="DequeueValue" id="dequeue-value">DequeueValue(|container|)</dfn> performs the
- following steps:
+ <dfn abstract-op no-export lt="DequeueValue" id="dequeue-value">DequeueValue(|container|)</dfn>
+ performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
  1. Assert: |container|.\[[queue]] is not [=list/is empty|empty=].
@@ -6642,7 +6647,7 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="EnqueueValueWithSize"
+ <dfn abstract-op no-export lt="EnqueueValueWithSize"
  id="enqueue-value-with-size">EnqueueValueWithSize(|container|, |value|, |size|)</dfn> performs the
  following steps:
 
@@ -6655,8 +6660,8 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="PeekQueueValue" id="peek-queue-value">PeekQueueValue(|container|)</dfn>
- performs the following steps:
+ <dfn abstract-op no-export lt="PeekQueueValue" id="peek-queue-value"
+ >PeekQueueValue(|container|)</dfn> performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
  1. Assert: |container|.\[[queue]] is not [=list/is empty|empty=].
@@ -6665,7 +6670,7 @@ for="value-with-size">value</dfn> and <dfn for="value-with-size">size</dfn>.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="ResetQueue" id="reset-queue">ResetQueue(|container|)</dfn>
+ <dfn abstract-op no-export lt="ResetQueue" id="reset-queue">ResetQueue(|container|)</dfn>
  performs the following steps:
 
  1. Assert: |container| has \[[queue]] and \[[queueTotalSize]] internal slots.
@@ -6680,7 +6685,7 @@ Transferable streams are implemented using a special kind of identity transform 
 abstract operations are used to implement these "cross-realm transforms".
 
 <div algorithm>
- <dfn abstract-op lt="CrossRealmTransformSendError">CrossRealmTransformSendError(|port|,
+ <dfn abstract-op no-export lt="CrossRealmTransformSendError">CrossRealmTransformSendError(|port|,
  |error|)</dfn> performs the following steps:
 
  1. Perform [$PackAndPostMessage$](|port|, "`error`", |error|), discarding the result.
@@ -6690,8 +6695,8 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="PackAndPostMessage">PackAndPostMessage(|port|, |type|, |value|)</dfn> performs
- the following steps:
+ <dfn abstract-op no-export lt="PackAndPostMessage"
+ >PackAndPostMessage(|port|, |type|, |value|)</dfn> performs the following steps:
 
  1. Let |message| be [$OrdinaryObjectCreate$](null).
  1. Perform ! [$CreateDataProperty$](|message|, "`type`", |type|).
@@ -6706,8 +6711,8 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="PackAndPostMessageHandlingError">PackAndPostMessageHandlingError(|port|,
- |type|, |value|)</dfn> performs the following steps:
+ <dfn abstract-op no-export lt="PackAndPostMessageHandlingError"
+ >PackAndPostMessageHandlingError(|port|, |type|, |value|)</dfn> performs the following steps:
 
  1. Let |result| be [$PackAndPostMessage$](|port|, |type|, |value|).
  1. If |result| is an abrupt completion,
@@ -6716,8 +6721,8 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpCrossRealmTransformReadable">SetUpCrossRealmTransformReadable(|stream|,
- |port|)</dfn> performs the following steps:
+ <dfn abstract-op no-export lt="SetUpCrossRealmTransformReadable"
+ >SetUpCrossRealmTransformReadable(|stream|, |port|)</dfn> performs the following steps:
 
  1. Perform ! [$InitializeReadableStream$](|stream|).
  1. Let |controller| be a [=new=] {{ReadableStreamDefaultController}}.
@@ -6760,8 +6765,8 @@ abstract operations are used to implement these "cross-realm transforms".
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="SetUpCrossRealmTransformWritable">SetUpCrossRealmTransformWritable(|stream|,
- |port|)</dfn> performs the following steps:
+ <dfn abstract-op no-export lt="SetUpCrossRealmTransformWritable">
+ SetUpCrossRealmTransformWritable(|stream|, |port|)</dfn> performs the following steps:
 
  1. Perform ! [$InitializeWritableStream$](|stream|).
  1. Let |controller| be a [=new=] {{WritableStreamDefaultController}}.
@@ -6822,7 +6827,7 @@ abstract operations are used to implement these "cross-realm transforms".
 The following abstract operations are a grab-bag of utilities.
 
 <div algorithm>
- <dfn abstract-op lt="CanTransferArrayBuffer"
+ <dfn abstract-op no-export lt="CanTransferArrayBuffer"
  id="can-transfer-array-buffer">CanTransferArrayBuffer(|O|)</dfn> performs the following steps:
 
  1. Assert: |O| [=is an Object=].
@@ -6833,7 +6838,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="IsNonNegativeNumber"
+ <dfn abstract-op no-export lt="IsNonNegativeNumber"
  id="is-non-negative-number">IsNonNegativeNumber(|v|)</dfn> performs the following steps:
 
  1. If |v| [=is not a Number=], return false.
@@ -6843,7 +6848,7 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="TransferArrayBuffer"
+ <dfn abstract-op no-export lt="TransferArrayBuffer"
  id="transfer-array-buffer">TransferArrayBuffer(|O|)</dfn> performs the following steps:
 
  1. Assert: ! [$IsDetachedBuffer$](|O|) is false.
@@ -6859,7 +6864,8 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CloneAsUint8Array">CloneAsUint8Array(|O|)</dfn> performs the following steps:
+ <dfn abstract-op no-export lt="CloneAsUint8Array">CloneAsUint8Array(|O|)</dfn> performs the
+ following steps:
 
  1. Assert: |O| [=is an Object=].
  1. Assert: |O| has an \[[ViewedArrayBuffer]] internal slot.
@@ -6871,14 +6877,15 @@ The following abstract operations are a grab-bag of utilities.
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="StructuredClone">StructuredClone(|v|)</dfn> performs the following steps:
+ <dfn abstract-op no-export lt="StructuredClone">StructuredClone(|v|)</dfn> performs the following
+ steps:
 
  1. Let |serialized| be ? [$StructuredSerialize$](|v|).
  1. Return ? [$StructuredDeserialize$](|serialized|, [=the current Realm=]).
 </div>
 
 <div algorithm>
- <dfn abstract-op lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
+ <dfn abstract-op no-export lt="CanCopyDataBlockBytes">CanCopyDataBlockBytes(|toBuffer|, |toIndex|,
  |fromBuffer|, |fromIndex|, |count|)</dfn> performs the following steps:
 
  1. Assert: |toBuffer| [=is an Object=].


### PR DESCRIPTION
<!--
Thank you for contributing to the Streams Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

Fixes #1365


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams-1/1369.html" title="Last updated on Apr 21, 2026, 3:21 PM UTC (8ed9962)">Preview</a> | <a href="https://whatpr.org/streams/1369/7611362...8ed9962.html" title="Last updated on Apr 21, 2026, 3:21 PM UTC (8ed9962)">Diff</a>