### PR TITLE
Export "set up reader/writer" algorithms for other specs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7133,6 +7133,16 @@ failures should be handled by the calling specification.
  <p class="note">This will throw an exception if |stream| is already [=ReadableStream/locked=].
 </div>
 
+<div algorithm>
+ <p>To <dfn export for="ReadableStreamDefaultReader">set up</dfn> a newly-[=new|created-via-Web IDL=]
+ {{ReadableStreamDefaultReader}} |reader| for a {{ReadableStream}} |stream|,
+ perform ? [$SetUpReadableStreamDefaultReader$](|reader|, |stream|).
+
+ <p class="note">Subclasses of {{ReadableStreamDefaultReader}} will use the
+ [=ReadableStreamDefaultReader/set up=] operation directly on the [=this=] value inside their
+ constructor steps.</p>
+</div>
+
 <p algorithm>To <dfn export for="ReadableStreamDefaultReader" lt="read a chunk|reading a chunk">read
 a chunk</dfn> from a {{ReadableStreamDefaultReader}} |reader|, given a [=read request=]
 |readRequest|, perform ! [$ReadableStreamDefaultReaderRead$](|reader|, |readRequest|).
@@ -7319,6 +7329,16 @@ failures should be handled by the calling specification.
  will be a {{WritableStreamDefaultWriter}}.
 
  <p class="note">This will throw an exception if |stream| is already locked.
+</div>
+
+<div algorithm>
+ <p>To <dfn export for="WritableStreamDefaultWriter">set up</dfn> a newly-[=new|created-via-Web IDL=]
+ {{WritableStreamDefaultWriter}} |writer| for a {{WritableStream}} |stream|,
+ perform ? [$SetUpWritableStreamDefaultWriter$](|writer|, |stream|).
+
+ <p class="note">Subclasses of {{WritableStreamDefaultWriter}} will use the
+ [=WritableStreamDefaultWriter/set up=] operation directly on the [=this=] value inside their
+ constructor steps.</p>
 </div>
 
 <p algorithm>To <dfn export for="WritableStreamDefaultWriter" lt="write a chunk|writing a


### PR DESCRIPTION
These new algorithms allow other specifications to subclass `ReadableStreamDefaultReader` and/or `WritableStreamDefaultWriter`, without depending on the internal `SetUpReadableStreamDefaultReader` and `SetUpWritableStreamDefaultWriter` abstract ops.

Blocks https://github.com/w3c/webtransport/issues/753.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1370.html" title="Last updated on Apr 22, 2026, 9:10 PM UTC (ff88178)">Preview</a> | <a href="https://whatpr.org/streams/1370/7611362...ff88178.html" title="Last updated on Apr 22, 2026, 9:10 PM UTC (ff88178)">Diff</a>