### PR TITLE
Meta: roll web platform tests for reference implementation

### DIFF
--- a/reference-implementation/package.json
+++ b/reference-implementation/package.json
@@ -18,7 +18,7 @@
     "eslint": "^6.8.0",
     "minimatch": "^10.0.1",
     "opener": "^1.5.2",
-    "webidl2js": "^18.0.0",
-    "wpt-runner": "^6.0.0"
+    "webidl2js": "^20.0.0",
+    "wpt-runner": "^7.0.0"
   }
 }


### PR DESCRIPTION
This updates our testing setup to work with the latest version of WPT.

See release notes:
* https://github.com/domenic/wpt-runner/releases/tag/v7.0.0
* https://github.com/jsdom/webidl2js/releases/tag/v19.0.0
* https://github.com/jsdom/webidl2js/releases/tag/v19.1.0
* https://github.com/jsdom/webidl2js/releases/tag/v20.0.0