### PR TITLE
Meta: roll web platform tests for reference implementation

### DIFF
--- a/reference-implementation/run-web-platform-tests.js
+++ b/reference-implementation/run-web-platform-tests.js
@@ -37,9 +37,9 @@ async function main() {
     // These tests use ArrayBuffers backed by WebAssembly.Memory objects, which *should* be non-transferable.
     // However, our TransferArrayBuffer implementation cannot detect these, and will incorrectly "transfer" them anyway.
     'readable-byte-streams/non-transferable-buffers.any.html',
-    'readable-streams/owning-type-message-port.any.html', // disabled due to MessagePort use.
-    'readable-streams/owning-type-video-frame.any.html', // disabled due to VideoFrame use.
-    'readable-streams/owning-type.any.html', // FIXME: reenable this test once owning type PR lands.
+    'readable-streams/owning-type-message-port.tentative.any.html', // disabled due to MessagePort use.
+    'readable-streams/owning-type-video-frame.tentative.any.html', // disabled due to VideoFrame use.
+    'readable-streams/owning-type.tentative.any.html', // FIXME: reenable this test once owning type PR lands.
     'transferable/transform-stream-members.any.html' // FIXME: reenable if structuredClone is aligned.
   ];
   const anyTestPattern = /\.any\.html$/;


### PR DESCRIPTION
Tests for owning streams have been marked as tentative. This updates the test runner to ignore these (now renamed) test suites.

- [x] At least two implementers are interested (and none opposed):
   * N/A
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/59593
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
