### PR TITLE
Editorial: Remove redundant assertion in "ReadableStream pipe through" and "ReadableStream pipe to"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7582,8 +7582,6 @@ sense to pass them to {{ReadableStream/pipeThrough()}}.
  They will return a {{Promise}} that fulfills when the pipe completes, or rejects with an exception
  if it fails.
 
- 1. Assert: ! [$IsReadableStreamLocked$](|readable|) is false.
- 1. Assert: ! [$IsWritableStreamLocked$](|writable|) is false.
  1. Let |signalArg| be |signal| if |signal| was given, or undefined otherwise.
  1. Return ! [$ReadableStreamPipeTo$](|readable|, |writable|, |preventClose|, |preventAbort|,
     |preventCancel|, |signalArg|).

--- a/index.bs
+++ b/index.bs
@@ -7605,8 +7605,6 @@ sense to pass them to {{ReadableStream/pipeThrough()}}.
  through"><var>signal</var></dfn>, is given by performing the following steps. The result will be
  the [=readable side=] of |transform|.
 
- 1. Assert: ! [$IsReadableStreamLocked$](|readable|) is false.
- 1. Assert: ! [$IsWritableStreamLocked$](|transform|.[=TransformStream/[[writable]]=]) is false.
  1. Let |signalArg| be |signal| if |signal| was given, or undefined otherwise.
  1. Let |promise| be ! [$ReadableStreamPipeTo$](|readable|,
     |transform|.[=TransformStream/[[writable]]=], |preventClose|, |preventAbort|, |preventCancel|,


### PR DESCRIPTION
This is removing redundancy that does not change behaviour.

For https://streams.spec.whatwg.org/#readablestream-pipe-through, the assertion is already done in step 4:
> Let promise be ! [ReadableStreamPipeTo](https://streams.spec.whatwg.org/#readable-stream-pipe-to)(readable, transform.[[[writable]]](https://streams.spec.whatwg.org/#transformstream-writable), preventClose, preventAbort, preventCancel, signalArg).

Similarly, for https://streams.spec.whatwg.org/#readablestream-pipe, the assertion is done in step 4 as well:
> Return ! [ReadableStreamPipeTo](https://streams.spec.whatwg.org/#readable-stream-pipe-to)(readable, writable, preventClose, preventAbort, preventCancel, signalArg).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/streams/1375.html" title="Last updated on Jun 22, 2026, 2:30 PM UTC (83335ed)">Preview</a> | <a href="https://whatpr.org/streams/1375/4c5b332...83335ed.html" title="Last updated on Jun 22, 2026, 2:30 PM UTC (83335ed)">Diff</a>